### PR TITLE
cited updated by Qiang's recent submissions (emnlp17, kbcom18, naacl18)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,11 @@ Step 2 open the program: java -jar jabref.jar
 
        say yes, you want to overwrite the keys
 
-       save! done
+       save! 
+
+       Manually delete the header:
+       % This file was created with JabRef 2.10.
+       % Encoding: UTF-8
 
 Step 3 merge yourfile.bib into cited.bib
 

--- a/ccg-compact.bib
+++ b/ccg-compact.bib
@@ -89,4259 +89,4512 @@
 @string{Benjamin = {Benjamin/Cummings Publishing Company, Inc.}}
 @string{MIT = {MIT Press}}
 
-%%%%%%%%%%%%%%
-%%%  2017  %%%
-%%%%%%%%%%%%%%
-@workshop{NGDIDNDHPR17,
-  author = {Anjali Narayan-Chen  and Colin Graber  and Mayukh Das  and Md Rakibul Islam  and Soham Dan  and Sriraam Natarajan  and Janardhan Rao Doppa  and Julia Hockenmaier  and Martha Palmer and Dan Roth},
-  title = {Towards Problem Solving Agents that Communicate and Learn},
-  year = {2017},
-url-omit = "http://cogcomp.org/papers/ngdidndhpr17.pdf",
-}
-
-@inproceedings{NingFeRo17,
-  author = {Qiang Ning and Zhili Feng and Dan Roth},
-  title = {A Structured Learning Approach to Temporal Relation Extraction},
-  booktitle = {Proc. of the Conference on Empirical Methods in Natural Language Processing (EMNLP)},
-pages-omit = {1038--1048},
-month-omit = {9},
-  year = {2017},
-address-omit = {Copenhagen, Denmark},
-publisher-omit = {Association for Computational Linguistics},
-url-omit = "http://cogcomp.org/papers/NingFeRo17.pdf",
-  funding = {AI2, IBM-ILLINOIS C3SR, DARPA, ARL},
-}
-
-@inproceedings{ChaturvediPeRo17,
-  author = {Snigdha Chaturvedi and Haoruo Peng and Dan Roth},
-  title = {Story Comprehension for Predicting What Happens Next},
-  booktitle = {In proceedings of the Conference on Empirical Methods in Natural Language Processing},
-  year = {2017},
-url-omit = "http://cogcomp.org/papers/ChaturvediPeRo17.pdf",
-  funding = { IBM-ILLINOIS Center for Cognitive Computing Systems Research (C3SR), US Defense Advanced Research Projects Agency (DARPA) under contract FA8750-13-2-0008, Army Research Laboratory (ARL) under agreement W911NF-09-2-0053},
-}
-
-@thesis{Roy17,
-  author = {Subhro Roy},
-  title = {Reasoning about Quantities in Natural Language},
-  booktitle = {UIUC PhD Thesis},
-  year = {2017},
-url-omit = "http://cogcomp.org/papers/ROY-DISSERTATION-2017.pdf",
-}
-
-@inproceedings{KSKCSSR17,
-  author = {Parisa Kordjamshidi and Sameer Singh and Daniel Khashabi and Christos Christodoulopoulos and Mark Summons and Saurabh Sinha and Dan Roth },
-  title = {Relational Learning and Feature Extraction by Querying over Heterogeneous Information Networks},
-  booktitle = {Seventh International Workshop on Statistical Relational AI (StarAI)},
-  year = {2017},
-url-omit = "http://cogcomp.org/papers/2017_saul_relational_learning_starai.pdf",
-}
-
-@inproceedings{MayhewTsRo17,
-  author = {Stephen Mayhew and Chen-Tse Tsai and Dan Roth},
-  title = {Cheap Translation for Cross-Lingual Named Entity Recognition},
-  booktitle = {Proc. of the Conference on Empirical Methods in Natural Language Processing (EMNLP)},
-  year = {2017},
-url-omit = "http://cogcomp.org/papers/MayhewTsRo17.pdf",
-  funding = {LORELEI, DEFT},
-}
-
-@inproceedings{GuptaSiRo17,
-  author = {Nitish Gupta and Sameer Singh and Dan Roth},
-  title = {Entity Linking via Joint Encoding of Types, Descriptions, and Context},
-  booktitle = {Proc. of the Conference on Empirical Methods in Natural Language Processing (EMNLP)},
-  year = {2017},
-url-omit = "http://cogcomp.org/papers/GuptaSiRo17.pdf",
-}
-
-@article{RozovskayaRoSa17,
-  author = {Alla Rozovskaya and Dan Roth and Mark Sammons},
-  title = {Adapting to Learner Errors with Minimal Supervision},
-  year = {2017},
-  journal = {Computational Linguistics},
-url-omit = "http://cogcomp.org/papers/CL-adaptation.pdf",
-}
-
-@thesis{Tsai17,
-  author = {Chen-Tse Tsai},
-  title = {Concept and Entity Grounding Using Indirect Supervision},
-  booktitle = {UIUC PhD Thesis},
-  year = {2017},
-url-omit = "http://cogcomp.org/papers/Tsai17.pdf",
-}
-
-@inproceedings{PengChRo17,
-  author = {Haoruo Peng and Snigdha Chaturvedi and Dan Roth},
-  title = {A Joint Model for Semantic Sequences: Frames, Entities, Sentiments},
-  booktitle = {Proc. of the Conference on Computational Natural Language Learning (CoNLL)},
-  year = {2017},
-  institution = {University of Illinois, Urbana-Champaign},
-url-omit = "http://cogcomp.org/papers/PengChRo17.pdf",
-}
-
-@inproceedings{KhTuSaRo17,
-  author = {Daniel Khashabi and Tushar Khot and Ashish Sabharwal and Dan Roth },
-  title = {Learning What is Essential in Questions},
-  booktitle = {The Conference on Computational Natural Language Learning (Proc. of the Conference on Computational Natural Language Learning (CoNLL))},
-  year = {2017},
-url-omit = "http://cogcomp.org/papers/2017_conll_essential_terms.pdf",
-}
-
-@inproceedings{WSSASURMEGD17,
-  author = {Rachel Wities and Vered Shwartz and Gabriel Stanovsky and Meni Adler and Ori Shapira and Shyam Upadhyay and Dan Roth and Eugenio Martinez Camara and Iryna Gurevych and Ido Dagan},
-  title = {A Consolidated Open Knowledge Representation for Multiple Texts},
-  booktitle = {Proceedings of the 2nd LSDSem Workshop, in EACL},
-  year = {2017},
-url-omit = "http://cogcomp.org/papers/paper.pdf",
-}
-
-@inproceedings{Roth17,
-  author = {Dan Roth},
-  title = {Incidental Supervision: Moving beyond Supervised Learning},
-  booktitle = {Proc. of the Conference on Artificial Intelligence (AAAI)},
-month-omit = {2},
-  year = {2017},
-url-omit = "http://cogcomp.org/papers/Roth-AAAI17-incidental-supervision.pdf",
-}
-
-@inproceedings{RoyRo17,
-  author = {Subhro Roy and Dan Roth},
-  title = {Unit Dependency Graph and its Application to Arithmetic Word Problem Solving},
-  booktitle = {Proc. of the Conference on Artificial Intelligence (AAAI)},
-  year = {2017},
-url-omit = "http://cogcomp.org/papers/14764-64645-1-SM.pdf",
-}
-
-%%%%%%%%%%%%%%
-%%%  2016  %%%
-%%%%%%%%%%%%%%
-@workshop{TMPSMRR16,
-  author = {Chen-Tse Tsai and Stephen Mayhew and Haoruo Peng and Mark Sammons and Bhargav Mangipundi and Pavankumar Reddy and Dan Roth},
-  title = {Illinois CCG Entity Discovery and Linking, Event Nugget Detection and Co-reference, and Slot Filler Validation Systems for TAC 2016},
-  booktitle = {Text Analysis Conference (Proc. of the Text Analysis Conference (TAC) 2016)},
-  year = {2016},
-  institution = {National Institute of Standards and Technology},
-url-omit = {},
-}
-
-@inproceedings{GuptaSaRo16,
-  author = {Narender Gupta and Aman Sawhney and Dan Roth},
-  title = {Will I Get in? - Modeling the Graduate Admission  Process for American Universities},
-  booktitle = {2016 IEEE 16th International Conference on Data Mining Workshops (ICDMW)},
-pages-omit = {631--638},
-  year = {2016},
-url-omit = "http://cogcomp.org/papers/Will_I_Get_In.pdf",
-}
-
-@inproceedings{TsaiRo16c,
-  author = {Chen-Tse Tsai and Dan Roth},
-  title = {Illinois Cross-Lingual Wikifier: Grounding Entities in Many Languages to the English Wikipedia},
-  booktitle = {Proc. of the International Conference on Computational Linguistics (COLING) Demonstrations},
-month-omit = {12},
-  year = {2016},
-url-omit = "http://cogcomp.org/papers/TsaiRo16c.pdf",
-}
-
-@article{WSRZH16,
-  author = {Chenguang Wang and Yangqiu Song and Dan Roth and Ming Zhang and Jiawei Han},
-  title = {World Knowledge as Indirect Supervision for Document Clustering},
-  booktitle = {ACM TKDD},
-  year = {2016},
-url-omit = "http://cogcomp.org/papers/WSRZH16.pdf",
-}
-
-@incollection{SongMaRo16,
-  author = {Yangqiu Song and Stephen Mayhew and Dan Roth},
-  title = {Cross-lingual Dataless Classification for Languages with Small Wikipedia Presence},
-  booktitle = {arXiv},
-pages-omit = {17},
-month-omit = {11},
-  year = {2016},
-number-omit = {arXiv:1611.04122},
-url-omit = "http://cogcomp.org/papers/SongMR16.pdf",
-}
-
-@inproceedings{CYSMD16,
-  author = {Chen-Tse Tsai and Yangqiu Song and Stephen Mayhew and Mark Sammons and Dan Roth},
-  title = {Illinois CCG LoReHLT 2016 Named Entity Recognition and Situation Frame Systems},
-  booktitle = {Low Resource Human Language Technologies (LoReHLT)},
-  year = {2016},
-url-omit = "http://cogcomp.org/papers/CYSMD16.pdf",
-}
-
-@inproceedings{KKCMSR16,
-  author = {Parisa Kordjamshidi and Daniel Khashabi and Christos Christodoulopoulos and Bhargav Mangipudi and Sameer Singh and Dan Roth },
-  title = {Better call Saul: Flexible Programming for Learning and Inference in NLP},
-  booktitle = {Proc. of the International Conference on Computational Linguistics (COLING)},
-  year = {2016},
-url-omit = "http://cogcomp.org/papers/KKCMSR16.pdf",
-}
-
-@inproceedings{RoyRo16,
-  author = {Subhro Roy and Dan Roth},
-  title = {ILLINOIS MATH SOLVER: Math Reasoning on the Web},
-  booktitle = {Proc. of the Annual Conference of the North American Chapter of the Association for Computational Linguistics (NAACL) Demonstrations},
-  year = {2016},
-url-omit = "http://cogcomp.org/papers/IMS.pdf",
-}
-
-@inproceedings{UGCR16,
-  author = {Shyam Upadhyay and Nitish Gupta and Christos Christodoulopoulos and Dan Roth},
-  title = {Revisiting the Evaluation for Cross Document Event Coreference},
-  booktitle = {Proc. of the International Conference on Computational Linguistics (COLING)},
-  year = {2016},
-url-omit = "http://cogcomp.org/papers/revisiting-evaluation-cross.pdf",
-}
-
-@inproceedings{RoyUpRo16,
-  author = {Subhro Roy and Shyam Upadhyay and Dan Roth},
-  title = {EQUATION PARSING : Mapping Sentences to Grounded Equations},
-  booktitle = {Proc. of the Conference on Empirical Methods in Natural Language Processing (EMNLP)},
-  year = {2016},
-url-omit = "http://cogcomp.org/papers/1609.08824v1.pdf",
-}
-
-@inproceedings{PengSoRo16,
-  author = {Haoruo Peng and Yangqiu Song and Dan Roth},
-  title = {Event Detection and Co-reference with Minimal Supervision},
-  booktitle = {Proc. of the Conference on Empirical Methods in Natural Language Processing (EMNLP)},
-  year = {2016},
-url-omit = "http://cogcomp.org/papers/PengSoRo16.pdf",
-}
-
-@workshop{UpChRo16,
-  author = {Shyam Upadhyay and Christos Christodoulopoulos and Dan Roth},
-  title = {Making the News - Identifying Noteworthy Events in News Articles},
-  booktitle = {The 4th Workshop on EVENTS, Proc. of the Annual Conference of the North American Chapter of the Association for Computational Linguistics (NAACL)},
-  year = {2016},
-url-omit = "http://cogcomp.org/papers/W16-1001.pdf",
-}
-
-@workshop{ChristodoulopoulosRoFi16,
-  author = { Christos Christodoulopoulos and Dan Roth and Cynthia Fisher},
-  title = {An incremental model of syntactic bootstrapping},
-  booktitle = {7th Workshop on Cognitive Aspects of Computational Language Learning, Proc. of the Annual Meeting of the Association for Computational Linguistics (ACL)},
-month-omit = {8},
-  year = {2016},
-url-omit = "http://cogcomp.org/papers/christodoulopoulos_16_incremental.pdf",
-}
-
-@inproceedings{TsaiMaRo16,
-  author = {Chen-Tse Tsai and Stephen Mayhew and Dan Roth},
-  title = {Cross-Lingual Named Entity Recognition via Wikification},
-  booktitle = {Proc. of the Conference on Computational Natural Language Learning (CoNLL)},
-  year = {2016},
-url-omit = "http://cogcomp.org/papers/TsaiMaRo16.pdf",
-}
-
-@inproceedings{PengRo16,
-  author = {Haoruo Peng and Dan Roth},
-  title = {Two Discourse Driven Language Models for Semantics},
-  booktitle = {Proc. of the Annual Meeting of the Association for Computational Linguistics (ACL)},
-  year = {2016},
-url-omit = "http://cogcomp.org/papers/PengRo16.pdf",
-}
-
-@inproceedings{UFDR16,
-  author = {Shyam Upadhyay and Manaal Faruqui and Chris Dyer and Dan Roth},
-  title = {Cross-lingual Models of Word Embeddings: An Empirical Comparison},
-  booktitle = {Proc. of the Annual Meeting of the Association for Computational Linguistics (ACL)},
-  year = {2016},
-url-omit = "http://cogcomp.org/papers/acl2016.pdf",
-}
-
-@inproceedings{RozovskayaRo16,
-  author = {Alla Rozovskaya and Dan Roth},
-  title = {Grammatical Error Correction: Machine Translation and Classifiers},
-  booktitle = {Proc. of the Annual Meeting of the Association for Computational Linguistics (ACL)},
-  year = {2016},
-publisher-omit = {ACL},
-url-omit = "http://cogcomp.org/papers/RozovskayaRo16.pdf",
-}
-
-@inproceedings{SCKKSVBWR16,
-  author = {Mark Sammons and Christos Christodoulopoulos and Parisa Kordjamshidi and Daniel Khashabi and Vivek Srikumar and Paul Vijayakumar and Mazin Bokhari and Xinbo Wu and Dan Roth},
-  title = {EDISON: Feature Extraction for NLP, Simplified},
-  booktitle = {Proc. of the International Conference on Language Resources and Evaluation (LREC) },
-  year = {2016},
-publisher-omit = {European Language Resources Association (ELRA)},
-  editor = {Nicoletta Calzolari (Conference Chair) and Khalid Choukri and Thierry Declerck and Marko Grobelnik and Bente Maegaard and Joseph Mariani and Asuncion Moreno and Jan Odijk and Stelios Piperidis},
-url-omit = "http://cogcomp.org/papers/SCKKSVBWR16.pdf",
-}
-
-@inproceedings{LingSoRo16,
-  author = {Shaoshi Ling and Yangqiu Song and Dan Roth},
-  title = {Word Embeddings with Limited Memory},
-  booktitle = {Proc. of the Annual Meeting of the Association for Computational Linguistics (ACL)},
-  year = {2016},
-url-omit = "http://cogcomp.org/papers/LingSoRo16.pdf",
-}
-
-@techreport{RedmanSaRo17,
-  author = {Tom Redman and Mark Sammons and Dan Roth},
-  title = {Illinois Named Entity Recognizer: Addendum to Ratinov and Roth '09 reporting improved results},
-  booktitle = {Tech Reports},
-  year = {2016},
-url-omit = "http://cogcomp.org/papers/ner-addendum.pdf",
-}
-
-@inproceedings{SUPR16,
-  author = {Yangqiu Song and Shyam Upadhyay and Haoruo Peng and Dan Roth},
-  title = {Cross-lingual Dataless Classification for Many Languages},
-  booktitle = {Proc. of the International Joint Conference on Artificial Intelligence (IJCAI)},
-  year = {2016},
-url-omit = "http://cogcomp.org/papers/SUPR16.pdf",
-}
-
-@inproceedings{KKSCER16,
-  author = {Daniel Khashabi and Tushar Khot and Ashish Sabharwal and Peter Clark and Oren Etzioni and Dan Roth },
-  title = {Question Answering via Integer Programming over Semi-Structured Knowledge},
-  booktitle = {Proc. of the International Joint Conference on Artificial Intelligence (IJCAI)},
-  year = {2016},
-url-omit = "http://cogcomp.org/papers/KKSCER16.pdf",
-}
-
-@inproceedings{TsaiRo16b,
-  author = {Chen-Tse Tsai and Dan Roth},
-  title = {Cross-lingual Wikification Using Multilingual Embeddings},
-  booktitle = {Proc. of the Annual Conference of the North American Chapter of the Association for Computational Linguistics (NAACL)},
-month-omit = {6},
-  year = {2016},
-url-omit = "http://cogcomp.org/papers/TsaiRo16b.pdf",
-}
-
-@incollection{RizzoloRo16,
-  author = {N. Rizzolo and D. Roth},
-  title = {Integer Linear Programming for Co-reference Resolution},
-  booktitle = {Anaphora Resolution: Algorithms, Resources, and Applications},
-  year = {2016},
-publisher-omit = {Springer-Verlag},
-  editor = {Massimo Poesio, Roland Stuckardt and Yannick Versley},
-url-omit = {},
-  invisible = {true},
-}
-
-@article{TsaiRo16,
-  author = {Chen-Tse Tsai and Dan Roth},
-  title = {Concept Grounding to Multiple Knowledge Bases via Indirect Supervision},
-  booktitle = {TACL},
-month-omit = {2},
-  year = {2016},
-url-omit = "http://cogcomp.org/papers/TsaiRo16.pdf",
-}
-
-@inproceedings{ArivazhaganChRo16,
-  author = {Naveen Arivazhagan and Christos Christodoulopoulos and Dan Roth},
-  title = {Labeling the Semantic Roles of Commas},
-  booktitle = {Proc. of the Conference on Artificial Intelligence (AAAI)},
-month-omit = {2},
-  year = {2016},
-url-omit = "http://cogcomp.org/papers/ArivazhaganChRo16.pdf",
-  projects = {DEFT},
-}
-
-%%%%%%%%%%%%%%
-%%%  2015  %%%
-%%%%%%%%%%%%%%
-@workshop{SPSUTRRR15,
-  author = {Mark Sammons and Haoruo Peng and Yangqiu Song and Shyam Upadhyay and Chen-Tse Tsai and Pavankumar Reddy and Subhro Roy and Dan Roth},
-  title = {Illinois CCG TAC 2015 Event Nugget, Entity Discovery and Linking, and Slot Filler Validation Systems},
-  booktitle = {Text Analysis Conference},
-  year = {2015},
-  institution = {National Institute of Standards and Technology},
-url-omit = "http://cogcomp.org/papers/SPSUTRRR15.pdf",
-}
-
-@inproceedings{SPSUTRRR15,
-  author = {Mark Sammons and Haoruo Peng and Yangqiu Song and Shyam Upadhyay and Chen-Tse Tsai and Pavankumar Reddy and Subhro Roy and Dan Roth},
-  title = {Illinois CCG TAC 2015 Event Nugget, Entity Discovery and Linking, and Slot Filler Validation Systems},
-  booktitle = {Proc. of the Text Analysis Conference (TAC)},
-  year = {2015},
-url-omit = "http://cogcomp.org/papers/TAC15.pdf",
-}
-
-@workshop{LCUR15,
-  author = {Ching-pei Lee and Kai-Wei Chang and Shyam Upadhyay and Dan Roth},
-  title = {Distributed Training of Structured SVM},
-  booktitle = {OPT Workshop, Proc. of the Conference on Neural Information Processing Systems (NIPS)},
-  year = {2015},
-url-omit = "http://cogcomp.org/papers/OPT2015_paper_1.pdf",
-}
-
-@workshop{PKMLDY15,
-  author = {James Pustejovsky and Parisa Kordjamshidi and Marie-Francine Moens and Aaron Levine and Seth Dworman and Zachary Yocum},
-  title = {SemEval-2015 Task 8: SpaceEval},
-  booktitle = {Proc. of the Annual Meeting of the Association for Computational Linguistics (ACL)},
-pages-omit = {884-894},
-  year = {2015},
-publisher-omit = {ACL},
-url-omit = "http://cogcomp.org/papers/PustejovskyetalSemEval2015.pdf",
-}
-
-@inproceedings{MKPM15,
-  author = {Wouter Massa and Parisa Kordjamshidi and Thomas Provoost and Marie-Francine Moens},
-  title = {Machine Reading of Biological Texts: Bacteria-Biotope Extraction},
-  booktitle = {Proc. of the International Conference on Bioinformatics Models, Methods and Algorithms},
-pages-omit = {55-64},
-  year = {2015},
-publisher-omit = {SCITEPRESS},
-url-omit = "http://cogcomp.org/papers/MassaetalBIOSTEC2015.pdf",
-}
-
-@article{WBGLR15,
-  author = {John Wieting and Mohit Bansal and Kevin Gimpel and Karen Livescu and Dan Roth},
-  title = {From Paraphrase Database to Compositional Paraphrase Model and Back},
-  booktitle = {TACL},
-  year = {2015},
-url-omit = "http://cogcomp.org/papers/WietingBaGiLiRo15.pdf",
-}
-
-@inproceedings{SPKSR15,
-  author = {Yangqiu Song and Haoruo Peng and Parisa Kordjamshidi and Mark Sammons and Dan Roth},
-  title = {Improving a Pipeline Architecture for Shallow Discourse Parsing},
-  booktitle = {Proc. of the Conference on Computational Natural Language Learning (CoNLL)},
-  year = {2015},
-url-omit = "http://cogcomp.org/papers/SPKSR15.pdf",
-}
-
-@inproceedings{RoyRo15,
-  author = {Subhro Roy and Dan Roth},
-  title = {Solving General Arithmetic Word Problems},
-  booktitle = {Proc. of the Conference on Empirical Methods in Natural Language Processing (EMNLP)},
-  year = {2015},
-url-omit = "http://cogcomp.org/papers/arithmetic.pdf",
-}
-
-@inproceedings{PengChRo15,
-  author = {Haoruo Peng and Kai-Wei Chang and Dan Roth},
-  title = {A Joint Framework for Coreference Resolution and Mention Head Detection},
-  booktitle = {Proc. of the Conference on Computational Natural Language Learning (CoNLL)},
-pages-omit = {10},
-month-omit = {7},
-  year = {2015},
-address-omit = {University of Illinois, Urbana-Champaign, Urbana, IL, 61801},
-publisher-omit = {ACL},
-  institution = {University of Illinois at Urbana-Champaign},
-url-omit = "http://cogcomp.org/papers/MentionDetection.pdf",
-}
-
-@workshop{FKPWR15,
-  author = {Zhiye Fei and Daniel Khashabi and Haoruo Peng and Hao Wu and Dan Roth},
-  title = {ILLINOIS-PROFILER: Knowledge Schemas at Scale},
-  booktitle = {Workshop on Cognitive Knowledge Acquisition and Applications, Proc. of the International Joint Conference on Artificial Intelligence (IJCAI)},
-  year = {2015},
-url-omit = "http://cogcomp.org/papers/profiler_ijcai.pdf",
-}
-
-@inproceedings{LeeRo15,
-  author = {Ching-pei Lee and Dan Roth},
-  title = {Distributed Box-Constrained Quadratic Optimization for Dual Linear SVM},
-  booktitle = {Proc. of the International Conference on Machine Learning (ICML)},
-month-omit = {7},
-  year = {2015},
-  acceptance = {26\%},
-url-omit = "http://cogcomp.org/papers/distcd.pdf",
-  funding = {DEFT},
-}
-
-@article{KordjamshidiRoMo15,
-  author = {Parisa Kordjamshidi and Dan Roth and Marie-Francine Moens},
-  title = {Structured Learning for Spatial Information Extraction from Biomedical Text: Bacteria Biotopes},
-  booktitle = {BMC Proc. of the International Conference on Bioinformatics Models, Methods and Algorithms},
-month-omit = {4},
-  year = {2015},
-volume-omit = {16},
-number-omit = {126},
-url-omit = "http://cogcomp.org/papers/BMC_Bacteria_Biotope.pdf",
-}
-
-@inproceedings{KordjamshidiRoWu15,
-  author = {Parisa Kordjamshidi and Hao Wu and Dan Roth},
-  title = {Saul: Towards Declarative Learning Based Programming},
-  booktitle = {Proc. of the International Joint Conference on Artificial Intelligence (IJCAI)},
-month-omit = {7},
-  year = {2015},
-url-omit = "http://cogcomp.org/papers/KordjamshidiRoWu15.pdf",
-}
-
-@inproceedings{WSERZH15,
-  author = {Chenguang Wang and Yangqiu Song and Ahmed El-Kishky and Dan Roth and Ming Zhang and Jiawei Han},
-  title = {Incorporating World Knowledge to Document Clustering via Heterogeneous Information Networks},
-  booktitle = {Proc. of the ACM SIGKDD Conference on Knowledge Discovery and Data Mining (KDD)},
-  year = {2015},
-url-omit = "http://cogcomp.org/papers/WSERZH15.pdf",
-}
-
-@inproceedings{WSRWHJZ15,
-  author = {Chenguang Wang and Yangqiu Song and Dan Roth and Chi Wang and Jiawei Han and Heng Ji and Ming Zhang},
-  title = {Constrained Information-Theoretic Tripartite Graph Clustering to Identify Semantically Similar Relations},
-  booktitle = {Proc. of the International Joint Conference on Artificial Intelligence (IJCAI)},
-  year = {2015},
-url-omit = "http://cogcomp.org/papers/WSRWHJZ15.pdf",
-}
-
-@thesis{Chang15,
-  author = {Kai-Wei Chang},
-  title = {Selective Algorithms for Large-Scale Classification and Structured Learning},
-  booktitle = {UIUC PhD Thesis},
-  year = {2015},
-url-omit = "http://cogcomp.org/papers/Chang15.pdf",
-}
-
-@inproceedings{SongRo15,
-  author = {Yangqiu Song and Dan Roth},
-  title = {Unsupervised Sparse Vector Densification for Short Text Similarity},
-  booktitle = {Proc. of the Annual Conference of the North American Chapter of the Association for Computational Linguistics (NAACL)},
-month-omit = {5},
-  year = {2015},
-url-omit = "http://cogcomp.org/papers/SongRo15.pdf",
-}
-
-@inproceedings{PengKhRo15,
-  author = {Haoruo Peng and Daniel Khashabi and Dan Roth},
-  title = {Solving Hard Coreference Problems},
-  booktitle = {Proc. of the Annual Conference of the North American Chapter of the Association for Computational Linguistics (NAACL)},
-month-omit = {5},
-  year = {2015},
-url-omit = "http://cogcomp.org/papers/PengKhRo15.pdf",
-}
-
-@article{RoyViRo15,
-  author = {Subhro Roy and Tim Vieira and Dan Roth},
-  title = {Reasoning about Quantities in Natural Language},
-  booktitle = {TACL},
-  year = {2015},
-  journal = {Transactions of the Association for Computational Linguistics (TACL)},
-volume-omit = {3},
-url-omit = "http://cogcomp.org/papers/RoyViRo15.pdf",
-}
-
-@inproceedings{CUKR15,
-  author = {Kai-Wei Chang and Shyam Upadhyay and Gourab Kundu and Dan Roth},
-  title = {Structural Learning with Amortized Inference},
-  booktitle = {Proc. of the Conference on Artificial Intelligence (AAAI)},
-  year = {2015},
-url-omit = "http://cogcomp.org/papers/CUKR15.pdf",
-  funding = {ONR,ARL,DEFT},
-}
-
-%%%%%%%%%%%%%%
-%%%  2014  %%%
-%%%%%%%%%%%%%%
-@incollection{PasternackRo14,
-  author = {Jeff Pasternack and Dan Roth},
-  title = {Judging the Veracity of Claims and Reliability of Sources With Fact-Finders},
-  booktitle = {Computational Trust Models and Machine Learning},
-pages-omit = {39-72},
-  year = {2014},
-publisher-omit = {Chapman and Hall/CRC},
-  editor = {Xin Liu, Anwitaman Datta, and Ee-Peng Lim},
-url-omit = "http://cogcomp.org/papers/fact_finder_chapter_clean.pdf",
-}
-
-@inproceedings{JindalGuRo14,
-  author = {Prateek Jindal and Carl A. Gunter and Dan Roth},
-  title = {Detecting Privacy-Sensitive Events in Medical Text},
-  booktitle = {Proc. of the ACM Conference on Proc. of the International Conference on Bioinformatics Models, Methods and Algorithms, Computational Biology, and Health Informatics},
-month-omit = {9},
-  year = {2014},
-url-omit = "http://cogcomp.org/papers/JindalGR14.pdf",
-}
-
-@inproceedings{JindalRoGu14,
-  author = {Prateek Jindal and Dan Roth and  Carl A. Gunter},
-  title = {Joint Inference for End-to-End Coreference Resolution for Clinical Notes},
-  booktitle = {Proc. of the ACM Conference on Proc. of the International Conference on Bioinformatics Models, Methods and Algorithms, Computational Biology, and Health Informatics},
-month-omit = {9},
-  year = {2014},
-url-omit = "http://cogcomp.org/papers/p192-jindal.pdf",
-}
-
-@inproceedings{SSWKTUMRA14,
-  author = {Mark Sammons and Yangqiu Song and Ruichen Wang and Gourab Kundu and Chen-Tse Tsai and Shyam Upadhyay and Siddarth Ancha and Stephen Mayhew},
-  title = {Overview of UI-CCG Systems for Event Argument Extraction, Entity Discovery and Linking, and Slot Filler Validation},
-  booktitle = {Proc. of the Text Analysis Conference (TAC)},
-  year = {2014},
-  institution = {NIST},
-url-omit = "http://cogcomp.org/papers/SSWKTUMRA14.pdf",
-}
-
-@article{RozovskayaRo14,
-  author = {Alla Rozovskaya and Dan Roth},
-  title = {Building a State-of-the-Art Grammatical Error Correction System},
-  booktitle = {TACL},
-  year = {2014},
-url-omit = "http://cogcomp.org/papers/RozovskayaRo14.pdf",
-}
-
-@inproceedings{SongRo14,
-  author = {Yangqiu Song and Dan Roth},
-  title = {On Dataless Hierarchical Text Classification},
-  booktitle = {Proc. of the Conference on Artificial Intelligence (AAAI)},
-month-omit = {7},
-  year = {2014},
-url-omit = "http://cogcomp.org/papers/SongRo14.pdf",
-}
-
-@inproceedings{RCSRH14,
-  author = {Alla Rozovskaya and Kai-Wei Chang and Mark Sammons and Dan Roth and Nizar Habash},
-  title = {The Illinois-Columbia System in the CoNLL-2014 Shared Task},
-  booktitle = {Proc. of the Conference on Computational Natural Language Learning (CoNLL)},
-  year = {2014},
-url-omit = "http://cogcomp.org/papers/RCSRH14.pdf",
-}
-
-@inproceedings{WFDMSR14,
-  author = {Hao Wu and Zhiye Fei and Aaron Dai and Stephen Mayhew and Mark Sammons and Dan Roth},
-  title = {IllinoisCloudNLP: Text Analytics Services in the Cloud},
-  booktitle = {Proc. of the International Conference on Language Resources and Evaluation (LREC)},
-month-omit = {5},
-  year = {2014},
-url-omit = "http://cogcomp.org/papers/WFDMSR14.pdf",
-  funding = {MIAS, ARL, DARPA, NSF},
-}
-
-@article{VZRP14,
-  author = {V.G.Vinod Vydiswaran and Chengxiang Zhai and Dan Roth and Peter Pirolli},
-  title = {Overcoming bias to learn about controversial topics},
-  year = {2014},
-publisher-omit = {Wiley},
-  journal = {Journal of the American Society for Information Science and Technology (JASIST)},
-url-omit = "http://cogcomp.org/papers/VZRP14.pdf",
-  projects = {Trustworthiness},
-}
-
-@inproceedings{RozovskayaRoSr14,
-  author = {Alla Rozovskaya and Dan Roth and Vivek Srikumar},
-  title = {Correcting Grammatical Verb Errors},
-  booktitle = {EACL},
-month-omit = {4},
-  year = {2014},
-url-omit = "http://cogcomp.org/papers/RozovskayaRoSr14.pdf",
-}
-
-@article{GoldwasserRo14,
-  author = {Dan Goldwasser and Dan Roth},
-  title = {Learning from Natural Instructions},
-pages-omit = {205-232},
-month-omit = {2},
-  year = {2014},
-publisher-omit = {Springer},
-  journal = {Machine Learning},
-volume-omit = {94},
-number-omit = {2},
-url-omit = "http://cogcomp.org/papers/GoldwasserRo14.pdf",
-}
-
-@article{BBCRWZ14,
-  author = {Antoine Bordes and L�on Bottou and Ronan Collobert and Dan Roth and Jason Weston and Luke Zettlemoyer},
-  title = {Introduction to the special issue on learning semantics},
-pages-omit = {127-131},
-month-omit = {2},
-  year = {2014},
-publisher-omit = {Springer},
-  journal = {Machine Learning},
-volume-omit = {94},
-number-omit = {2},
-url-omit = "http://cogcomp.org/papers/BBCRWZ14.pdf",
-}
-
-@inproceedings{SamdaniChRo14,
-  author = {Rajhans Samdani and Kai-Wei Chang and Dan Roth},
-  title = {A Discriminative Latent Variable Model for Online Clustering},
-  booktitle = {Proc. of the International Conference on Machine Learning (ICML)},
-  year = {2014},
-  acceptance = {14.7\%},
-url-omit = "http://cogcomp.org/papers/l3m.icml.pdf",
-}
-
-%%%%%%%%%%%%%%
-%%%  2013  %%%
-%%%%%%%%%%%%%%
-@inproceedings{CCSCFSWRWR13,
-  author = {Xiao Cheng and Bingling Chen and Rajhans Samdani and Kai-Wei Chang and Zhiye Fei and Mark Sammons and John Wieting and Subhro Roy and Chizheng Wang and Dan Roth},
-  title = {Illinois Cognitive Computation Group UI-CCG TAC 2013 Entity Linking and Slot Filler Validation Systems},
-  booktitle = {Proc. of the Text Analysis Conference (TAC)},
-  year = {2013},
-url-omit = "http://cogcomp.org/papers/UI_CCG.TAC2013.proceedings.pdf",
-}
-
-@thesis{Srikumar13,
-  author = {Vivek Srikumar},
-  title = {The Semantics of Role Labeling},
-  booktitle = {UIUC PhD Thesis},
-  year = {2013},
-url-omit = "http://cogcomp.org/papers/Srikumar13.pdf",
-}
-
-@thesis{Vydiswaran13,
-  author = {V.G.Vinod Vydiswaran},
-  title = {Modeling and Predicting Trustworthiness of Online Textual Information},
-  booktitle = {UIUC PhD Thesis},
-  year = {2013},
-url-omit = "http://cogcomp.org/papers/Vydiswaran13.pdf",
-}
-
-@thesis{Samdani13,
-  author = {Rajhans Samdani},
-  title = {Algorithms for Structural Learning with Decompositions},
-  booktitle = {UIUC PhD Thesis},
-  year = {2013},
-url-omit = "http://cogcomp.org/papers/Samdani13.pdf",
-}
-
-@thesis{Jindal13,
-  author = {Prateek Jindal},
-  title = {Information Extraction for Clinical Narratives},
-  booktitle = {UIUC PhD Thesis},
-  year = {2013},
-url-omit = "http://cogcomp.org/papers/Jindal13.pdf",
-}
-
-@thesis{Rozovskaya13,
-  author = {Alla Rozovskaya},
-  title = {Automated Methods for Text Correction},
-  booktitle = {UIUC PhD Thesis},
-  year = {2013},
-url-omit = "http://cogcomp.org/papers/Rozovskaya13.pdf",
-}
-
-@inproceedings{TsaiKuRo13,
-  author = {Chen-Tse Tsai and Gourab Kundu and Dan Roth},
-  title = {Concept-Based Analysis of Scientific Literature},
-  booktitle = {Proc. of the ACM Conference on Information and Knowledge Management (CIKM)},
-  year = {2013},
-url-omit = "http://cogcomp.org/papers/TsaiKuRo13.pdf",
-}
-
-@inproceedings{ChengRo13,
-  author = {Xiao Cheng and Dan Roth},
-  title = {Relational Inference for Wikification},
-  booktitle = {Proc. of the Conference on Empirical Methods in Natural Language Processing (EMNLP)},
-  year = {2013},
-url-omit = "http://cogcomp.org/papers/ChengRo13.pdf",
-  funding = {DEFT,ARL,MIAS},
-}
-
-@inproceedings{RozovskayaRo13,
-  author = {Alla Rozovskaya and Dan Roth},
-  title = {Joint Learning and Inference for Grammatical Error Correction},
-  booktitle = {Proc. of the Conference on Empirical Methods in Natural Language Processing (EMNLP)},
-month-omit = {10},
-  year = {2013},
-url-omit = "http://cogcomp.org/papers/RozovskayaRo13.pdf",
-}
-
-@article{JindalRo13d,
-  author = {P. Jindal and D. Roth},
-  title = {Extraction of Events and Temporal Expressions from Clinical Narratives},
-month-omit = {10},
-  year = {2013},
-  editor = {E.H. Shortliffe},
-  journal = {Journal of Biomedical Informatics (JBI)},
-url-omit = "http://cogcomp.org/papers/JindalRo13d.pdf",
-}
-
-@inproceedings{JindalRo13c,
-  author = {Prateek Jindal and Dan Roth},
-  title = {Using Soft Constraints in Joint Inference for Clinical Concept Recognition},
-  booktitle = {Proc. of the Conference on Empirical Methods in Natural Language Processing (EMNLP)},
-month-omit = {10},
-  year = {2013},
-url-omit = "http://cogcomp.org/papers/JindalRo13c.pdf",
-}
-
-@inproceedings{ChangSaRo13,
-  author = {Kai-Wei Chang and Rajhans Samdani and Dan Roth},
-  title = {A Constrained Latent Variable Model for Coreference Resolution},
-  booktitle = {Proc. of the Conference on Empirical Methods in Natural Language Processing (EMNLP)},
-  year = {2013},
-url-omit = "http://cogcomp.org/papers/ChangSaRo13.pdf",
-}
-
-@inproceedings{RCSR13,
-  author = {Alla Rozovskaya and Kai-Wei Chang and Mark Sammons and Dan Roth},
-  title = {The University of Illinois System in the CoNLL-2013 Shared Task},
-  booktitle = {Proc. of the Conference on Computational Natural Language Learning (CoNLL)},
-  year = {2013},
-url-omit = "http://cogcomp.org/papers/RCSR13.pdf",
-  funding = {MR, DEFT},
-}
-
-@unpublished{DRSZ13,
-  author = {Ido Dagan and Dan Roth and Mark Sammons and Fabio Massimo Zanzoto},
-  title = {Recognizing Textual Entailment: Models and Applications},
-  booktitle = {Recognizing Textual Entailment: Models and Applications},
-month-omit = {7},
-  year = {2013},
-publisher-omit = {Morgan and Claypool},
-url-omit = {},
-}
-
-@inproceedings{KunduSrRo13,
-  author = {Gourab Kundu and Vivek Srikumar and Dan Roth},
-  title = {Margin-based Decomposed Amortized Inference},
-  booktitle = {Proc. of the Annual Meeting of the Association for Computational Linguistics (ACL)},
-month-omit = {8},
-  year = {2013},
-url-omit = "http://cogcomp.org/papers/KunduSrRo13.pdf",
-}
-
-@inproceedings{ChangSrRo13,
-  author = {K.-W. Chang and V. Srikumar and D. Roth},
-  title = {Multi-core Structural SVM Training},
-  booktitle = {Proc. of the European Conference on Machine Learning and Principles and Practice of Knowledge Discovery in Databases (ECML PKDD)},
-  year = {2013},
-  acceptance = {25\%},
-url-omit = "http://cogcomp.org/papers/ChangSrRo13.pdf",
-  funding = {ONR, DEFT},
-}
-
-@article{SrikumarRo13,
-  author = {Vivek Srikumar and Dan Roth},
-  title = {Modeling Semantic Relations Expressed by Prepositions},
-  booktitle = {TACL},
-pages-omit = {231-242},
-  year = {2013},
-volume-omit = {1},
-url-omit = "http://cogcomp.org/papers/SrikumarRo13.pdf",
-}
-
-@inproceedings{GoldwasserRoth13,
-  author = {Dan Goldwasser and Dan Roth},
-  title = {Leveraging Domain-Independent Information in Semantic Parsing},
-  booktitle = {Proc. of the Annual Meeting of the Association for Computational Linguistics (ACL)},
-  year = {2013},
-url-omit = "http://cogcomp.org/papers/GoldwasserRoth13.pdf",
-}
-
-@inproceedings{JindalRo13b,
-  author = {Prateek Jindal and Dan Roth},
-  title = {End-to-End Coreference Resolution for Clinical Narratives},
-  booktitle = {Proc. of the International Joint Conference on Artificial Intelligence (IJCAI)},
-pages-omit = {2106-2112},
-month-omit = {8},
-  year = {2013},
-  acceptance = {19\%},
-url-omit = "http://cogcomp.org/papers/JindalRo13.pdf",
-  funding = {HHS 90TR003/01},
-}
-
-@inproceedings{PasternackRo13,
-  author = {Jeff Pasternack and Dan Roth},
-  title = {Latent Credibility Analysis},
-  booktitle = {Proc. of the International World Wide Web Conference (WWW)},
-  year = {2013},
-url-omit = "http://cogcomp.org/papers/PasternackRo13.pdf",
-}
-
-@article{JindalRo13,
-  author = {Prateek Jindal and Dan Roth},
-  title = {Using Domain Knowledge and Domain-Inspired Discourse Model for Coreference Resolution for Clinical Narratives},
-  booktitle = {Journal of the American Medical Informatics Association (JAMIA)},
-pages-omit = {356-362},
-month-omit = {3},
-  year = {2013},
-publisher-omit = {BMJ Publishing Group Ltd},
-  editor = {Professor Lucila Ohno-Machado},
-volume-omit = {20},
-number-omit = {2},
-  acceptance = {19\%},
-url-omit = "http://cogcomp.org/papers/JindalRo12.pdf",
-}
-
-%%%%%%%%%%%%%%
-%%%  2012  %%%
-%%%%%%%%%%%%%%
-@thesis{Goldwasser12,
-  author = {Dan Goldwasser },
-  title = {Learning from Natural Instructions},
-  booktitle = {UIUC PhD Thesis},
-  year = {2012},
-url-omit = "http://cogcomp.org/papers/Goldwasser12.pdf",
-}
-
-@inproceedings{JindalRo12,
-  author = {Prateek Jindal and Dan Roth},
-  title = {Using Knowledge and Constraints to Find the Best Antecedent},
-  booktitle = {Proc. of the International Conference on Computational Linguistics (COLING)},
-pages-omit = {1327-1342},
-month-omit = {12},
-  year = {2012},
-  acceptance = {20\%},
-url-omit = "http://cogcomp.org/papers/JindalRo12b.pdf",
-  funding = {Grant HHS 90TR0003/01},
-}
-
-@incollection{ConnorFiRo12,
-  author = {Michael Connor and Cynthia Fisher and Dan Roth},
-  title = {Starting from Scratch in Semantic Role Labeling: Early Indirect Supervision},
-month-omit = {11},
-  year = {2012},
-publisher-omit = {Springer},
-  editor = {A. Alishahi and T. Poibeau and A. Korhonen},
-  journal = {Cognitive Aspects of Computational Language Acquisition},
-url-omit = "http://cogcomp.org/papers/ConnorFiRo12.pdf",
-}
-
-@inproceedings{LWZR12,
-  author = {Yue Lu and Hongning Wang and ChengXiang Zhai and Dan Roth},
-  title = {Unsupervised Discovery of Opposing Opinion Networks From Forum Discussions},
-  booktitle = {Proc. of the ACM Conference on Information and Knowledge Management (CIKM)},
-month-omit = {10},
-  year = {2012},
-url-omit = "http://cogcomp.org/papers/LWZR12.pdf",
-}
-
-@inproceedings{CDHR12,
-  author = {Kai-Wei Chang and Biplab Deka and Wen-Mei W. Hwu and Dan Roth},
-  title = {Efficient Pattern-Based Time Series Classification on GPU },
-  booktitle = {Proc. of the IEEE International Conference on Data Mining (ICDM)},
-  year = {2012},
-  acceptance = {10.7\%},
-url-omit = "http://cogcomp.org/papers/undefined.pdf",
-  funding = {MR, BL},
-}
-
-@thesis{Tu12,
-  author = {Yuancheng Tu},
-  title = {English Complex Verb Constructions: Identification and Inference},
-  booktitle = {UIUC PhD Thesis},
-  year = {2012},
-url-omit = "http://cogcomp.org/papers/Tu12.pdf",
-}
-
-@thesis{Ratinov12,
-  author = {Lev Ratinov},
-  title = {Exploiting Knowledge in NLP},
-  booktitle = {UIUC PhD Thesis},
-  year = {2012},
-url-omit = "http://cogcomp.org/papers/Ratinov12.pdf",
-}
-
-@thesis{Do12,
-  author = {Quang Do},
-  title = {Background Knowledge in Learning-Based Relation Extraction},
-  booktitle = {UIUC PhD Thesis},
-  year = {2012},
-url-omit = "http://cogcomp.org/papers/Do12.pdf",
-}
-
-@inproceedings{SondhiVyZh12,
-  author = {Parikshit Sondhi and V.G. Vinod Vydiswaran and ChengXiang Zhai},
-  title = {Reliability Prediction of Webpages in the Medical Domain},
-  booktitle = {Proc. of the European Conference on Information Retrieval},
-pages-omit = {219--231},
-month-omit = {4},
-  year = {2012},
-volume-omit = {7224},
-url-omit = "http://cogcomp.org/papers/SondhiVyZh12.pdf",
-}
-
-@inproceedings{VZRP12b,
-  author = {V.G.Vinod Vydiswaran and ChengXiang Zhai and Dan Roth and Peter Pirolli},
-  title = {BiasTrust: Teaching biased users about controversial topics},
-  booktitle = {Proc. of the ACM Conference on Information and Knowledge Management (CIKM)},
-pages-omit = {1205--1209},
-month-omit = {10},
-  year = {2012},
-url-omit = "http://cogcomp.org/papers/VZRP12b.pdf",
-  funding = {MIAS, ITI, ARL},
-  projects = {Trustworthiness},
-}
-
-@inproceedings{VZRP12,
-  author = {V.G.Vinod Vydiswaran  and ChengXiang Zhai and Dan Roth and Peter Pirolli},
-  title = {Unbiased Learning of Controversial Topics},
-  booktitle = {Proc. of the Annual Meeting of the American Society for Information Science and Technology},
-month-omit = {10},
-  year = {2012},
-url-omit = "http://cogcomp.org/papers/VZRP12.pdf",
-  funding = {MIAS, ITI, ARL},
-  projects = {Trustworthiness},
-}
-
-@inproceedings{ClarkeSrSaRo2012,
-  author = {James Clarke and Vivek Srikumar and Mark Sammons and Dan Roth},
-  title = {An NLP Curator (or: How I Learned to Stop Worrying and Love NLP Pipelines)},
-  booktitle = {Proc. of the International Conference on Language Resources and Evaluation (LREC)},
-month-omit = {5},
-  year = {2012},
-url-omit = "http://cogcomp.org/papers/ClarkeSrSaRo2012.pdf",
-}
-
-@workshop{RozovskayaSaRo12,
-  author = {Alla Rozovskaya and Mark Sammons and Dan Roth},
-  title = {The UI System in the HOO 2012 Shared Task on Error Correction},
-  booktitle = {Proc. of the Annual Conference of the North American Chapter of the Association for Computational Linguistics (NAACL)},
-month-omit = {6},
-  year = {2012},
-publisher-omit = {Association for Computational Linguistics},
-url-omit = "http://cogcomp.org/papers/RozovskayaSaRo12.pdf",
-}
-
-@inproceedings{CSRSR12,
-  author = {Kai-Wei Chang and Rajhans Samdani and Alla Rozovskaya and Mark Sammons and Dan Roth},
-  title = {Illinois-Coref: The UI System in the CoNLL-2012 Shared Task},
-  booktitle = {Proc. of the Conference on Computational Natural Language Learning (CoNLL)},
-  year = {2012},
-url-omit = "http://cogcomp.org/papers/CSRSR12.pdf",
-  funding = {Machine Reading, ARL},
-  projects = {Coreference Within and Across Documents},
-}
-
-@workshop{SamdaniChRo12b,
-  author = {Rajhans Samdani and Ming-Wei Chang and Dan Roth},
-  title = {A Framework for Tuning Posterior Entropy in Unsupervised Learning},
-  booktitle = {Proc. of the International Conference on Machine Learning (ICML)},
-month-omit = {6},
-  year = {2012},
-url-omit = "http://cogcomp.org/papers/SamdaniChRo12b.pdf",
-  funding = {ONR, ARL, AFRL},
-}
-
-@inproceedings{SamdaniRo12,
-  author = {Rajhans Samdani and Dan Roth},
-  title = {Efficient Decomposed Learning for Structured Prediction},
-  booktitle = {Proc. of the International Conference on Machine Learning (ICML)},
-month-omit = {6},
-  year = {2012},
-  acceptance = {27\%},
-url-omit = "http://cogcomp.org/papers/SamdaniRo12.pdf",
-  funding = {ONR, AFRL, ARL},
-}
-
-@article{ChangRaRo12,
-  author = {Ming-Wei Chang and Lev Ratinov and Dan Roth},
-  title = {Structured Learning with Constrained Conditional Models},
-pages-omit = {399-431},
-month-omit = {6},
-  year = {2012},
-publisher-omit = {Springer},
-  editor = {Hal Daume III},
-  journal = {Machine Learning},
-volume-omit = {88},
-number-omit = {3},
-url-omit = "http://cogcomp.org/papers/ChangRaRo12.pdf",
-}
-
-@inproceedings{LuRo12,
-  author = {Wei Lu and Dan Roth},
-  title = {Automatic Event Extraction with Structured Preference Modeling},
-  booktitle = {Proc. of the Annual Meeting of the Association for Computational Linguistics (ACL)},
-pages-omit = {10},
-month-omit = {7},
-  year = {2012},
-  acceptance = {19\%},
-url-omit = "http://cogcomp.org/papers/LuRo12.pdf",
-  funding = {Machine Reading},
-  projects = {Machine Reading},
-}
-
-@inproceedings{RatinovRo12,
-  author = {Lev Ratinov and Dan Roth},
-  title = {Learning-based Multi-Sieve Co-Reference Resolution with Knowledge},
-  booktitle = {Proc. of the Conference on Empirical Methods in Natural Language Processing (EMNLP)},
-  year = {2012},
-url-omit = "http://cogcomp.org/papers/RatinovRo12.pdf",
-}
-
-@inproceedings{SrikumarKuRo12,
-  author = {Vivek Srikumar and Gourab Kundu and Dan Roth},
-  title = {On Amortizing Inference Cost for Structured Prediction},
-  booktitle = {Proc. of the Conference on Empirical Methods in Natural Language Processing (EMNLP)},
-month-omit = {7},
-  year = {2012},
-url-omit = "http://cogcomp.org/papers/SrikumarKuRo12.pdf",
-}
-
-@inproceedings{SamdaniChRo12,
-  author = {Rajhans Samdani and Ming-Wei Chang and Dan Roth},
-  title = {Unified Expectation Maximization},
-  booktitle = {Proc. of the Annual Conference of the North American Chapter of the Association for Computational Linguistics (NAACL)},
-month-omit = {6},
-  year = {2012},
-url-omit = "http://cogcomp.org/papers/SamdaniChRo12.pdf",
-}
-
-@inproceedings{DoLuRo12,
-  author = {Quang Do and Wei Lu and Dan Roth},
-  title = {Joint Inference for Event Timeline Construction},
-  booktitle = {Proc. of the Conference on Empirical Methods in Natural Language Processing (EMNLP)},
-  year = {2012},
-url-omit = "http://cogcomp.org/papers/DoLuRo12.pdf",
-}
-
-@inproceedings{ZhaoDoRo12,
-  author = {Ran Zhao and Quang Do and Dan Roth},
-  title = {A Robust Shallow Temporal Reasoning System},
-  booktitle = {Proc. of the Annual Conference of the North American Chapter of the Association for Computational Linguistics (NAACL)},
-month-omit = {6},
-  year = {2012},
-url-omit = "http://cogcomp.org/papers/ZhaoDoRo12.pdf",
-}
-
-@article{DoRo12,
-  author = {Quang Do and Dan Roth},
-  title = {Exploiting the Wikipedia Structure in Local and Global Classification of Taxonomic Relations},
-pages-omit = {235-262},
-month-omit = {4},
-  year = {2012},
-publisher-omit = {Cambridge University Press},
-  journal = {Journal of Natural Language Engineering (JNLE)},
-volume-omit = {18},
-number-omit = {2},
-url-omit = "http://cogcomp.org/papers/DoRo12.pdf",
-  comment = {http://journals.cambridge.org/action/displayAbstract?fromPage=online&aid=8511905&fulltextType=RA&fileId=S1351324912000046},
-}
-
-@inproceedings{TuRo12,
-  author = {Yuancheng Tu and Dan Roth},
-  title = {Sorting out the Most Confusing English Phrasal Verbs},
-  booktitle = {Proc. of the Joint Conference on Lexical and Computational Sematics},
-  year = {2012},
-address-omit = {Montreal, Canada},
-publisher-omit = {Association for Computational Linguistics},
-url-omit = "http://cogcomp.org/papers/TuRoth12.pdf",
-  funding = {DHS},
-  projects = {LS},
-}
-
-@incollection{SammonsVyRo12,
-  author = {Mark Sammons and V.G.Vinod Vydiswaran and Dan Roth},
-  title = {Recognizing Textual Entailment },
-  booktitle = {Multilingual Natural Language Applications: From Theory to Practice},
-pages-omit = {209-258},
-month-omit = {5},
-  year = {2012},
-publisher-omit = {Prentice Hall},
-  editor = {Daniel M. Bikel and Imed Zitouni},
-url-omit = {},
-}
-
-%%%%%%%%%%%%%%
-%%%  2011  %%%
-%%%%%%%%%%%%%%
-@thesis{Connor11,
-  author = {M. Connor},
-  title = {Minimal Supervision for Language Learning: Bootstrapping Global Patterns from Local Knowledge},
-  booktitle = {UIUC PhD Thesis},
-  year = {2011},
-url-omit = "http://cogcomp.org/papers/Connor11.pdf",
-}
-
-@thesis{Rizzolo11,
-  author = {N. Rizzolo},
-  title = {Learning Based Programming},
-  booktitle = {UIUC PhD Thesis},
-  year = {2011},
-url-omit = "http://cogcomp.org/papers/Rizzolo11.pdf",
-}
-
-@thesis{Pasternack11,
-  author = {J. Pasternack},
-  title = {Knowing Who to Trust and What to Believe in the Presence of Conflicting Information},
-  booktitle = {UIUC PhD Thesis},
-  year = {2011},
-url-omit = "http://cogcomp.org/papers/Pasternack11.pdf",
-  invisible = {true},
-}
-
-@thesis{Chang11,
-  author = {M. Chang},
-  title = {Structured Prediction with Indirect Supervision},
-  booktitle = {UIUC PhD Thesis},
-  year = {2011},
-url-omit = "http://cogcomp.org/papers/Chang11.pdf",
-}
-
-@inproceedings{BurgardRo11,
-  author = {W. Burgard and D. Roth Program Chairs},
-  title = {Proceedings of the 25th AAAI Conference on Artificial Intelligence},
-  booktitle = {Proc. of the Conference on Artificial Intelligence (AAAI)},
-  year = {2011},
-  editor = {W. Burgard and D. Roth},
-url-omit = {},
-}
-
-@article{MengshoelRoWi11,
-  author = {O. J. Mengshoel and D. Roth and D. C. Wilkins},
-  title = {Portfolios in Stochastic Local Search: Efficiently Computing Most Probable Explanations in Bayesian Networks},
-pages-omit = {103-160},
-  year = {2011},
-  journal = {Journal of Automated Reasoning},
-volume-omit = {46},
-number-omit = {2},
-url-omit = "http://cogcomp.org/papers/MengshoelRoWi11.pdf",
-}
-
-@article{MengshoelWiRo11,
-  author = {O. J. Mengshoel and D. C. Wilkins and D. Roth},
-  title = {Initialization and Restart in Stochastic Local Search: Computing a Most Probable Explanation in Bayesian Networks},
-pages-omit = {235-247},
-  year = {2011},
-  journal = {IEEE Transactions on Knowledge and Data Engineering},
-volume-omit = {23},
-number-omit = {2},
-url-omit = "http://cogcomp.org/papers/MengshoelWiRo11.pdf",
-}
-
-@inproceedings{JindalRo11,
-  author = {P. Jindal and D. Roth},
-  title = {Learning from Negative Examples in Set-Expansion},
-  booktitle = {Proc. of the IEEE International Conference on Data Mining (ICDM)},
-pages-omit = {1110-1115},
-month-omit = {12},
-  year = {2011},
-  acceptance = {18\%},
-url-omit = "http://cogcomp.org/papers/JindalRo11.pdf",
-}
-
-@inproceedings{ConnorFiRo11b,
-  author = {M. Connor and C. Fisher and D. Roth},
-  title = {The Origin of Syntactic Bootstrapping: A computational Model},
-  booktitle = {Proc. of the Boston University Conference on Language Development},
-  year = {2011},
-url-omit = {},
-}
-
-@workshop{RatinovRo11,
-  author = {L. Ratinov and D. Roth},
-  title = {GLOW TAC-KBP 2011 Entity Linking System},
-  booktitle = {Proc. of the Text Analysis Conference (TAC)},
-month-omit = {11},
-  year = {2011},
-publisher-omit = {Text Analysis Conference},
-url-omit = "http://cogcomp.org/papers/RatinovRo11.pdf",
-  funding = {MR, ARL },
-}
-
-@workshop{VydiswaranZhRo11b,
-  author = {V. Vydiswaran and C. Zhai and D. Roth},
-  title = {Gauging the Internet Doctor: Ranking Medical Claims based on Community Knowledge},
-  booktitle = {Proc. of the ACM SIGKDD Conference on Knowledge Discovery and Data Mining (KDD) Workshop on Data Mining for Medicine and HealthCare},
-month-omit = {8},
-  year = {2011},
-url-omit = "http://cogcomp.org/papers/VydiswaranZhRo11b.pdf",
-  funding = {MIAS, CCICADA, ARL},
-  projects = {Trustworthiness},
-}
-
-@workshop{RSGR11,
-  author = {A. Rozovskaya and M. Sammons and J. Gioja and D. Roth},
-  title = {University of Illinois System in HOO Text Correction Shared Task},
-  booktitle = {Proc. of the European Workshop on Natural Language Generation (ENLG)},
-  year = {2011},
-url-omit = "http://cogcomp.org/papers/RSGR11.pdf",
-  funding = {EDU,MR},
-}
-
-@workshop{KunduChRo11,
-  author = {G. Kundu and M. Chang and D. Roth},
-  title = {Prior Knowledge Driven Domain Adaptation},
-  booktitle = {Proc. of the International Conference on Machine Learning (ICML)},
-month-omit = {7},
-  year = {2011},
-url-omit = "http://cogcomp.org/papers/KunduChRo11(3).pdf",
-  funding = {ARL and DARPA Machine Reading},
-}
-
-@workshop{KunduRoSa11,
-  author = {G. Kundu and D. Roth and R. Samdani},
-  title = {Constrained Conditional Models For Information Fusion},
-  booktitle = {Proc. of the International Conference on Information Fusion},
-  year = {2011},
-url-omit = "http://cogcomp.org/papers/SamdaniRothKunduFusion2011.pdf",
-}
-
-@inproceedings{CSRRSR11,
-  author = {K.-W. Chang and R. Samdani and A. Rozovskaya and N. Rizzolo and M. Sammons and D. Roth},
-  title = {Inference Protocols for Coreference Resolution},
-  booktitle = {Proc. of the Conference on Computational Natural Language Learning (CoNLL)},
-pages-omit = {40--44},
-  year = {2011},
-address-omit = {Portland, Oregon, USA},
-publisher-omit = {Association for Computational Linguistics},
-url-omit = "http://cogcomp.org/papers/CSRRSR11.pdf",
-  funding = {MR},
-}
-
-@workshop{WAAPRGHFLA11,
-  author = {D. Wang and T. Abdelzaher and H. Ahmadi and J. Pasternack and D. Roth and M. Gupta and J. Han and O. Fatemieh and H. Le and C. Aggarwal},
-  title = {On Bayesian Interpretation of Fact-finding in Information Networks},
-  booktitle = {Proc. of the International Conference on Information Fusion},
-  year = {2011},
-url-omit = "http://cogcomp.org/papers/WAAPRGHFLA11.pdf",
-}
-
-@workshop{KPAGSAHRSA11,
-  author = {H. Khac Le and J. Pasternack and H. Ahmadi and M. Gupta and Y. Sun and T. Abdelzaher and J. Han and D. Roth and B. Szymanski and S. Adali},
-  title = {Apollo: Towards Factfinding in Participatory Sensing},
-  booktitle = {Proc. of the International Conference on Information Processing in Sensor Networks (IPSN)},
-  year = {2011},
-url-omit = "http://cogcomp.org/papers/LePa11.pdf",
-}
-
-@inproceedings{SrikumarRo11,
-  author = {V. Srikumar and D. Roth},
-  title = {A Joint Model for Extended Semantic Role Labeling},
-  booktitle = {Proc. of the Conference on Empirical Methods in Natural Language Processing (EMNLP)},
-  year = {2011},
-address-omit = {Edinburgh, Scotland},
-url-omit = "http://cogcomp.org/papers/SrikumarRo11.pdf",
-}
-
-@inproceedings{DoChRo11,
-  author = {Q. Do and Y. Chan and D. Roth},
-  title = {Minimally Supervised Event Causality Identification},
-  booktitle = {Proc. of the Conference on Empirical Methods in Natural Language Processing (EMNLP)},
-month-omit = {7},
-  year = {2011},
-address-omit = {Edinburgh, Scotland},
-url-omit = "http://cogcomp.org/papers/DoChaRo11.pdf",
-  funding = {MR},
-}
-
-@workshop{TuRo11,
-  author = {Y. Tu and D. Roth},
-  title = {Learning English Light Verb Constructions: Contextual or Statistical},
-  booktitle = {Proc. of the Annual Meeting of the Association for Computational Linguistics (ACL)},
-  year = {2011},
-url-omit = "http://cogcomp.org/papers/TuRo11.pdf",
-  funding = {MIAS},
-  projects = {LS},
-}
-
-@inproceedings{KunduRo11,
-  author = {G. Kundu and D. Roth},
-  title = {Adapting Text Instead of the Model: An Open Domain Approach},
-  booktitle = {Proc. of the Conference on Computational Natural Language Learning (CoNLL)},
-month-omit = {6},
-  year = {2011},
-url-omit = "http://cogcomp.org/papers/KunduRo11.pdf",
-  funding = {Darpa MR and ARL},
-}
-
-@inproceedings{ChangRo11,
-  author = {K.-W. Chang and D. Roth},
-  title = {Selective Block Minimization for Faster Convergence of Limited Memory Large-scale Linear Models},
-  booktitle = {Proc. of the ACM SIGKDD Conference on Knowledge Discovery and Data Mining (KDD)},
-  year = {2011},
-  acceptance = {17.5\%},
-url-omit = "http://cogcomp.org/papers/ChangRo11(4).pdf",
-  funding = {BL, MR},
-}
-
-@inproceedings{VydiswaranZhRo11,
-  author = {V. Vydiswaran and C. Zhai and D. Roth},
-  title = {Content-driven Trust Propagation Framework},
-  booktitle = {Proc. of the ACM SIGKDD Conference on Knowledge Discovery and Data Mining (KDD)},
-pages-omit = {974--982},
-month-omit = {8},
-  year = {2011},
-  acceptance = {17.5\%},
-url-omit = "http://cogcomp.org/papers/VydiswaranZhRo11.pdf",
-  funding = {MIAS, CCICADA, ARL},
-  projects = {Trustworthiness},
-}
-
-@inproceedings{PasternackRo11b,
-  author = {J. Pasternack and D. Roth},
-  title = {Making Better Informed Trust Decisions with Generalized Fact-Finding},
-  booktitle = {Proc. of the International Joint Conference on Artificial Intelligence (IJCAI)},
-  year = {2011},
-url-omit = "http://cogcomp.org/papers/PasternackRo11b.pdf",
-  funding = {ARL, DHS},
-}
-
-@inproceedings{GoldwasserRo11,
-  author = {D. Goldwasser and D. Roth},
-  title = {Learning from Natural Instructions},
-  booktitle = {Proc. of the International Joint Conference on Artificial Intelligence (IJCAI)},
-  year = {2011},
-url-omit = "http://cogcomp.org/papers/GoldwasserRo11(2).pdf",
-}
-
-@inproceedings{ConnorFiRo11,
-  author = {M. Connor and C. Fisher and D. Roth},
-  title = {Online Latent Structure Training for Language Acquisition},
-  booktitle = {Proc. of the International Joint Conference on Artificial Intelligence (IJCAI)},
-month-omit = {7},
-  year = {2011},
-url-omit = "http://cogcomp.org/papers/ConnorFiRo11.pdf",
-  funding = {Psych},
-  projects = {PSYCHO},
-  comment = {Indirect supervision; language acquisition; BabySRL; psycholinguistically plausible features; },
-}
-
-@inproceedings{PasternackRo11,
-  author = {J. Pasternack and D. Roth},
-  title = {Generalized Fact-Finding},
-  booktitle = {Proc. of the International World Wide Web Conference (WWW)},
-  year = {2011},
-url-omit = "http://cogcomp.org/papers/PasternackRo11.pdf",
-}
-
-@inproceedings{RRDA11,
-  author = {L. Ratinov and D. Roth and D. Downey and M. Anderson},
-  title = {Local and Global Algorithms for Disambiguation to Wikipedia},
-  booktitle = {Proc. of the Annual Meeting of the Association for Computational Linguistics (ACL)},
-  year = {2011},
-url-omit = "http://cogcomp.org/papers/RRDA11.pdf",
-}
-
-@inproceedings{ChanRo11,
-  author = {Y. Chan and D. Roth},
-  title = {Exploiting Syntactico-Semantic Structures for Relation Extraction},
-  booktitle = {Proc. of the Annual Meeting of the Association for Computational Linguistics (ACL)},
-  year = {2011},
-address-omit = {Portland, Oregon},
-url-omit = "http://cogcomp.org/papers/ChanRo11.pdf",
-  funding = {MR},
-  projects = {NLP, IE},
-}
-
-@inproceedings{GRCR11,
-  author = {D. Goldwasser and R. Reichart and J. Clarke and D. Roth },
-  title = {Confidence Driven Unsupervised Semantic Parsing },
-  booktitle = {Proc. of the Annual Meeting of the Association for Computational Linguistics (ACL)},
-  year = {2011},
-url-omit = "http://cogcomp.org/papers/main(2).pdf",
-}
-
-@inproceedings{RozovskayaRo11,
-  author = {A. Rozovskaya and D. Roth},
-  title = {Algorithm Selection and Model Adaptation for ESL Correction Tasks},
-  booktitle = {Proc. of the Annual Meeting of the Association for Computational Linguistics (ACL)},
-month-omit = {6},
-  year = {2011},
-address-omit = {Portland, Oregon},
-publisher-omit = {Association for Computational Linguistics},
-url-omit = "http://cogcomp.org/papers/RozovskayaRo11(1).pdf",
-  funding = {EDU},
-}
-
-%%%%%%%%%%%%%%
-%%%  2010  %%%
-%%%%%%%%%%%%%%
-@article{SmallRo10,
-  author = {K. Small and D. Roth},
-  title = {Margin-based Active Learning for Structured Predictions},
-  booktitle = {IJMLC},
-pages-omit = {3-25},
-  year = {2010},
-volume-omit = {1},
-url-omit = "http://cogcomp.org/papers/SmallRo10.pdf",
-}
-
-@inproceedings{TurianRaBe2010,
-  author = {J. Turian and L. Ratinov and Y. Bengio},
-  title = {Word representations: A simple and general method for semi-supervised learning},
-  booktitle = {Proc. of the Annual Meeting of the Association for Computational Linguistics (ACL)},
-  year = {2010},
-url-omit = "http://cogcomp.org/papers/TurianRaBe2010.pdf",
-}
-
-@inproceedings{PasternackRo10b,
-  author = {J. Pasternack and D. Roth},
-  title = {Comprehensive Trust Metrics for Information Networks},
-  booktitle = {Proc. of the Army Science Conference (ASC)},
-month-omit = {12},
-  year = {2010},
-address-omit = {Orlando, Florida},
-url-omit = "http://cogcomp.org/papers/PasternackRo10b.pdf",
-}
-
-@inproceedings{ChangCoRo10,
-  author = {M. Chang and M. Connor and D. Roth},
-  title = {The Necessity of Combining Adaptation Methods},
-  booktitle = {Proc. of the Conference on Empirical Methods in Natural Language Processing (EMNLP)},
-month-omit = {10},
-  year = {2010},
-address-omit = {Massachusetts, USA},
-url-omit = "http://cogcomp.org/papers/ChangCoRo10.pdf",
-  funding = {DARPA},
-  projects = {Adaptation},
-}
-
-@inproceedings{DoRo10,
-  author = {Q. Do and D. Roth},
-  title = {Relational Constraints based Taxonomic Relation Classification},
-  booktitle = {Proc. of the Conference on Empirical Methods in Natural Language Processing (EMNLP)},
-pages-omit = {1099-1109},
-month-omit = {10},
-  year = {2010},
-address-omit = {Massachusetts, USA},
-url-omit = "http://cogcomp.org/papers/DoRo10.pdf",
-  funding = {DARPA},
-  projects = {Machine Reading},
-}
-
-@inproceedings{LDWSVR10,
-  author = {G. Levine and G. DeJong and L. Wang and R. Samdani and S. Vembu and D. Roth},
-  title = {Automatic Model Adaptation for Complex Structured Domains},
-  booktitle = {Proc. of the European Conference on Machine Learning and Principles and Practice of Knowledge Discovery in Databases (ECML PKDD)},
-  year = {2010},
-url-omit = {},
-}
-
-@inproceedings{RozovskayaRo10b,
-  author = {A. Rozovskaya and D. Roth},
-  title = {Generating Confusion Sets for Context-Sensitive Error Correction},
-  booktitle = {Proc. of the Conference on Empirical Methods in Natural Language Processing (EMNLP)},
-  year = {2010},
-url-omit = "http://cogcomp.org/papers/RozovskayaRo10b.pdf",
-  funding = {EDU},
-}
-
-@inproceedings{PasternackRo10,
-  author = {J. Pasternack and D. Roth},
-  title = {Knowing What to Believe (when you already know something)},
-  booktitle = {Proc. of the International Conference on Computational Linguistics (COLING)},
-month-omit = {8},
-  year = {2010},
-address-omit = {Beijing, China},
-url-omit = "http://cogcomp.org/papers/PasternackRo10.pdf",
-  funding = {ARL},
-  projects = {TRUST, IE, USS},
-  comment = {Trustworthiness. Truth Finders. Using prior knowledge to both improve the accuracy of trust and belief decisions  and permit such decisions to be made subjectively relative to the user},
-}
-
-@inproceedings{TJRH10,
-  author = {Y. Tu and N. Johri and D. Roth and J. Hockenmaier},
-  title = {Citation Author Topic Model in Expert Search},
-  booktitle = {Proc. of the International Conference on Computational Linguistics (COLING)},
-  year = {2010},
-url-omit = "http://cogcomp.org/papers/TJRH10(2).pdf",
-  funding = {MIAS},
-  projects = {search},
-  comment = {author topic model, expert search,  semantic search, information retrieval},
-}
-
-@inproceedings{ChanRo10,
-  author = {Y. Chan and D. Roth},
-  title = {Exploiting Background Knowledge for Relation Extraction},
-  booktitle = {Proc. of the International Conference on Computational Linguistics (COLING)},
-month-omit = {8},
-  year = {2010},
-address-omit = {Beijing, China},
-url-omit = "http://cogcomp.org/papers/ChanRo10.pdf",
-  funding = {MR},
-  projects = {NLP, IE},
-  comment = {Relation extraction, background knowledge, constraints, information extraction},
-}
-
-@inproceedings{CGFR10,
-  author = {M. Connor and Y. Gertner and C. Fisher and D. Roth},
-  title = {Starting from Scratch in Semantic Role Labeling},
-  booktitle = {Proc. of the Annual Meeting of the Association for Computational Linguistics (ACL)},
-month-omit = {7},
-  year = {2010},
-address-omit = {Uppsala, Sweden},
-publisher-omit = {Association for Computational Linguistics},
-url-omit = "http://cogcomp.org/papers/CGFR10.pdf",
-  funding = {Psych},
-  projects = {PSYCHO},
-  comment = {Minimal supervision; language acquisition; BabySRL; psycholinguistically plausible features; unsupervised HMM; background knowledge and linguistic constraints},
-}
-
-@inproceedings{SammonsVyRo10,
-  author = {M. Sammons and V. Vydiswaran and D. Roth},
-  title = {Ask not what Textual Entailment can do for You...},
-  booktitle = {Proc. of the Annual Meeting of the Association for Computational Linguistics (ACL)},
-month-omit = {7},
-  year = {2010},
-address-omit = {Uppsala, Sweden},
-publisher-omit = {Association for Computational Linguistics},
-url-omit = "http://cogcomp.org/papers/SammonsVyRo10.pdf",
-  funding = {DARPA,Boeing, DHS},
-  projects = {TE},
-  comment = {Annotation, explanation, Recognizing Textual Entailment, evaluating textual entailment, data ablation},
-}
-
-@inproceedings{CGCR10,
-  author = {J. Clarke and D. Goldwasser and M. Chang and D. Roth},
-  title = {Driving Semantic Parsing from the World's Response},
-  booktitle = {Proc. of the Conference on Computational Natural Language Learning (CoNLL)},
-month-omit = {7},
-  year = {2010},
-url-omit = "http://cogcomp.org/papers/CGCR10.pdf",
-  funding = {BL,MR},
-  projects = {NLP, SP, COMP, USS},
-  comment = {Learning semantic parsers without complex logical form annotations. Supervision provided in the form of a binary feedback signal recieved from an external world.},
-}
-
-@inproceedings{CSGR10,
-  author = {M. Chang and V. Srikumar and D. Goldwasser and D. Roth},
-  title = {Structured Output Learning with Indirect Supervision},
-  booktitle = {Proc. of the International Conference on Machine Learning (ICML)},
-  year = {2010},
-url-omit = "http://cogcomp.org/papers/CSGR10.pdf",
-  funding = {DARPA,SoD,MIAS,MR},
-  projects = {CCM,TL},
-  comment = {indirect supervision, structured learning, joint learning of binary and structured learning tasks},
-}
-
-@inproceedings{CGRS10,
-  author = {M. Chang and D. Goldwasser and D. Roth and V. Srikumar},
-  title = {Discriminative Learning over Constrained Latent Representations},
-  booktitle = {Proc. of the Annual Conference of the North American Chapter of the Association for Computational Linguistics (NAACL)},
-month-omit = {6},
-  year = {2010},
-url-omit = "http://cogcomp.org/papers/CGRS10.pdf",
-  funding = {DARPA,SoD,MIAS,MR},
-  projects = {CCM,TL},
-  comment = {learning over latent representation, learning feature representation, intermediate representation, generalized alignment for various NLP tasks},
-}
-
-@inproceedings{RozovskayaRo10,
-  author = {A. Rozovskaya and D. Roth},
-  title = {Training Paradigms for Correcting Errors in Grammar and Usage},
-  booktitle = {Proc. of the Annual Conference of the North American Chapter of the Association for Computational Linguistics (NAACL)},
-month-omit = {6},
-  year = {2010},
-url-omit = "http://cogcomp.org/papers/RozovskayaRo10.pdf",
-  funding = {EDU},
-  projects = {CSTC},
-  comment = {Text correction; Error Detection and Correction; ESL Error Detection; ESL Proofing Tools;     Errors in Article Usage; training classifiers for detecting and correcting mistakes by selectively introducing mistakes into the training data},
-}
-
-@workshop{RozovskayaRo10a,
-  author = {A. Rozovskaya and D. Roth},
-  title = {Annotating ESL Errors: Challenges and Rewards},
-  booktitle = {Proc. of the Annual Conference of the North American Chapter of the Association for Computational Linguistics (NAACL)},
-month-omit = {6},
-  year = {2010},
-url-omit = "http://cogcomp.org/papers/RozovskayaRo10a.pdf",
-  funding = {EDU},
-  projects = {CSTC},
-  comment = {Text correction; Error Detection and Correction; ESL Error Detection; Annotation of ESL Errors; Annotation Tool;     Annotation of Article and Preposition Errors; Learner Corpus; Inter-annotator Agreement; ESL Error Statistics},
-}
-
-@workshop{PRSCR10,
-  author = {K. Pham and N. Rizzolo and K. Small and K. Chang and D. Roth},
-  title = {Object Search: Supporting Structured Queries in Web Search Engines},
-  booktitle = {Proc. of the Annual Conference of the North American Chapter of the Association for Computational Linguistics (NAACL) Workshop on Semantic Search},
-month-omit = {6},
-  year = {2010},
-url-omit = "http://cogcomp.org/papers/PRSCR10.pdf",
-  funding = {MIAS, NSF-SoD},
-  projects = {LBP},
-  comment = {Searching on the web for objects by their properties without first building a database; uses LBP/LBJ.},
-}
-
-@workshop{JohriRoTu10,
-  author = {N. Johri and D. Roth and Y. Tu},
-  title = {Experts' Retrieval with Multiword-Enhanced Author Topic Model},
-  booktitle = {Proc. of the Annual Conference of the North American Chapter of the Association for Computational Linguistics (NAACL)},
-  year = {2010},
-url-omit = "http://cogcomp.org/papers/JohriRoTu10(1).pdf",
-  funding = {MIAS},
-  projects = {SEARCH},
-  comment = {author topic model; multiword expression;  expert search; information retrieval},
-}
-
-@inproceedings{TKSR10,
-  author = {I. Titov and A. Klementiev and K. Small and D. Roth},
-  title = {Unsupervised Aggregation for Classification Problems with Large Numbers of Categories},
-  booktitle = {Proc. of the International Workshop on Artificial Intelligence and Statistics (AISTATS)},
-month-omit = {5},
-  year = {2010},
-url-omit = "http://cogcomp.org/papers/TKSR10.pdf",
-  funding = {BL, DHS},
-  comment = {Structured prediction; Unsupervised Learning; Aggregation},
-}
-
-@inproceedings{RizzoloRo10,
-  author = {N. Rizzolo and D. Roth},
-  title = {Learning Based Java for Rapid Development of NLP Systems},
-  booktitle = {Proc. of the International Conference on Language Resources and Evaluation (LREC)},
-month-omit = {5},
-  year = {2010},
-address-omit = {Valletta, Malta},
-url-omit = "http://cogcomp.org/papers/RizzoloRo10.pdf",
-  funding = {NSF-SoD},
-  projects = {LBP, CCM},
-  comment = {Learning Based Java: a Modeling language that facilitates development of systems with learning and inference componenets.},
-}
-
-%%%%%%%%%%%%%%
-%%%  2009  %%%
-%%%%%%%%%%%%%%
-@thesis{Small09,
-  author = {K. Small},
-  title = {Interactive Learning Protocols for Natural Language Applications},
-  booktitle = {UIUC PhD Thesis},
-  year = {2009},
-url-omit = "http://cogcomp.org/papers/Small09.pdf",
-}
-
-@thesis{Klementiev09,
-  author = {A. Klementiev},
-  title = {Learning with Incidental Supervision},
-  booktitle = {UIUC PhD Thesis },
-  year = {2009},
-url-omit = "http://cogcomp.org/papers/Klementiev09.pdf",
-}
-
-@techreport{DRSTV09,
-  author = {Q. Do and D. Roth and M. Sammons and Y. Tu and V. Vydiswaran},
-  title = {Robust, Light-weight Approaches to compute Lexical Similarity},
-  booktitle = {Computer Science Research and Technical Reports, University of Illinois},
-  year = {2009},
-url-omit = "http://cogcomp.org/papers/DRSTV09.pdf",
-}
-
-@inproceedings{RothTu09,
-  author = {D. Roth and Y. Tu},
-  title = {Aspect Guided Text Categorization with Unobserved Labels},
-  booktitle = {Proc. of the IEEE International Conference on Data Mining (ICDM)},
-  year = {2009},
-url-omit = "http://cogcomp.org/papers/RothTu09.pdf",
-  funding = {Honda,MIAS},
-  projects = {CCM,Honda},
-  comment = {multiclass classification; Text classification, short text snippet, structure learning, Constrained optimization; constrained conditional models},
-}
-
-@article{RothSa09,
-  author = {D. Roth and R. Samdani},
-  title = {Learning Multi-Linear Representations},
-pages-omit = {195--209},
-  year = {2009},
-  journal = {Machine Learning},
-volume-omit = {76},
-number-omit = {2},
-url-omit = "http://cogcomp.org/papers/RothSa09.pdf",
-  funding = {ONR},
-  projects = {CCG},
-}
-
-@inproceedings{PasternackRo09a,
-  author = {J. Pasternack and D. Roth},
-  title = {Learning Better Transliterations},
-  booktitle = {Proc. of the ACM Conference on Information and Knowledge Management (CIKM)},
-month-omit = {11},
-  year = {2009},
-url-omit = "http://cogcomp.org/papers/PasternackRo09a.pdf",
-  funding = {MIAS},
-  projects = {TL},
-  comment = {State-of-the-art transliteration with unbounded substring-to-substring productions and capable of both discovery and generation.},
-}
-
-@inproceedings{RothSaVy09,
-  author = {D. Roth and M. Sammons and V. Vydiswaran},
-  title = {A Framework for Entailed Relation Recognition},
-  booktitle = {Proc. of the Annual Meeting of the Association for Computational Linguistics (ACL)},
-month-omit = {8},
-  year = {2009},
-address-omit = {Singapore},
-publisher-omit = {Association for Computational Linguistics},
-url-omit = "http://cogcomp.org/papers/RothSaVy09.pdf",
-  funding = {Boeing, MIAS},
-  projects = {TE,SEARCH},
-  comment = {semantic retrieval, scalable textual entailment, structured query, similarity metrics, exhaustive search, relation recognition, relation extraction},
-}
-
-@inproceedings{ECGR09,
-  author = {J. Eisenstein and J. Clarke and D. Goldwasser and D. Roth},
-  title = {Reading to Learn: Constructing Features from Semantic Abstracts},
-  booktitle = {Proc. of the Conference on Empirical Methods in Natural Language Processing (EMNLP)},
-  year = {2009},
-address-omit = {Singapore},
-url-omit = "http://cogcomp.org/papers/ECGR09.pdf",
-  funding = {SoD, BL},
-  projects = {COMP, USS},
-  comment = {Proposes a novel form of semantic analysis where the goal is to obtain a high-level semantic abstract of documents in a representation that facilitates learning. The abstract is obtained through a generative model that requires no labeled data. The semantic abstract is converted into a transformed feature space for relational learning.},
-}
-
-@inproceedings{KRST09,
-  author = {A. Klementiev and D. Roth and K. Small and I. Titov},
-  title = {Unsupervised Rank Aggregation with Domain-Specific Expertise},
-  booktitle = {Proc. of the International Joint Conference on Artificial Intelligence (IJCAI)},
-month-omit = {7},
-  year = {2009},
-  acceptance = {331/1290 (25.7 \%)},
-url-omit = "http://cogcomp.org/papers/KRST09.pdf",
-  funding = {ITR-EDU, BL, MIAS},
-  projects = {USS, RANK},
-  comment = {Proposes a framework for learning to aggregate votes of rankers with domain specific expertise without supervision. Applies the learning framework to the settings of aggregating full rankings and aggregating top-k lists, demonstrating significant improvements over a domain-agnostic baseline in both cases.},
-}
-
-@inproceedings{CGFR09,
-  author = {M. Connor and Y. Gertner and C. Fisher and D. Roth},
-  title = {Minimally Supervised Model of Early Language Acquisition},
-  booktitle = {Proc. of the Conference on Computational Natural Language Learning (CoNLL)},
-month-omit = {6},
-  year = {2009},
-url-omit = "http://cogcomp.org/papers/CGFR09.pdf",
-  funding = {Psych},
-  projects = {PSYCHO},
-  comment = {Minimal supervision; language acquisition; BabySRL; a semantic role labeling system with simple, psycholinguistically plausible features; trained using background knowledge plus linguistic constraints},
-}
-
-@inproceedings{RothSm09,
-  author = {D. Roth and K. Small},
-  title = {Interactive Feature Space Construction using Semantic Information},
-  booktitle = {Proc. of the Conference on Computational Natural Language Learning (CoNLL)},
-month-omit = {6},
-  year = {2009},
-url-omit = "http://cogcomp.org/papers/RothSm09.pdf",
-  funding = {DARPA},
-  projects = {AL,NER},
-}
-
-@inproceedings{RatinovRo09,
-  author = {L. Ratinov and D. Roth},
-  title = {Design Challenges and Misconceptions in Named Entity Recognition},
-  booktitle = {Proc. of the Conference on Computational Natural Language Learning (CoNLL)},
-month-omit = {6},
-  year = {2009},
-url-omit = "http://cogcomp.org/papers/RatinovRo09.pdf",
-  funding = {MIAS, SoD, Library},
-  projects = {IE},
-  comment = {Named entity recognition; information extraction; knowledge resources; word class models; gazetteers; non-local features; global features; inference methods; BIO vs. BIOLU; text chunk representation},
-}
-
-@inproceedings{CGRT09,
-  author = {M. Chang and D. Goldwasser and D. Roth and Y. Tu},
-  title = {Unsupervised Constraint Driven Learning For Transliteration Discovery},
-  booktitle = {Proc. of the Annual Conference of the North American Chapter of the Association for Computational Linguistics (NAACL)},
-month-omit = {5},
-  year = {2009},
-url-omit = "http://cogcomp.org/papers/CGRT09.pdf",
-  funding = {DARPA,SoD,MIAS},
-  projects = {CCM,TL},
-  comment = {Transliteration; Constrained optimization; constrained conditional models, unsupervised learning; named entity discovery; multilingual corpora; bootstrapping, romanization table, feature selection for transliteration; Discriminative training of Objective function; Dynamic Programming},
-}
-
-@inproceedings{PasternackRo09,
-  author = {J. Pasternack and D. Roth},
-  title = {Extracting Article Text from the Web with Maximum Subsequence Segmentation},
-  booktitle = {Proc. of the International World Wide Web Conference (WWW)},
-month-omit = {4},
-  year = {2009},
-url-omit = "http://cogcomp.org/papers/PasternackRo09.pdf",
-  projects = {IE},
-  comment = {A new global optimization technique, maximum subsequence, is used to accurately identify and extract article text from HTML documents in linear time},
-}
-
-@inproceedings{RothSmTi09,
-  author = {D. Roth and K. Small and I. Titov},
-  title = {Sequential Learning of Classifiers for Structured Prediction Problems},
-  booktitle = {Proc. of the International Workshop on Artificial Intelligence and Statistics (AISTATS)},
-pages-omit = {440--447},
-month-omit = {4},
-  year = {2009},
-  acceptance = {84/210 (40.0 \%)},
-url-omit = "http://cogcomp.org/papers/RothSmTi09.pdf",
-  funding = {BL, SoD},
-  comment = {Structured prediction; Learning algorithm; Pipelines; An alternative both to joint and to independent learning of classifiers},
-}
-
-@inproceedings{RiedelCl09,
-  author = {S. Riedel and J. Clarke},
-  title = {Revisiting Optimal Decoding for Machine Translation IBM Model 4},
-  booktitle = {Proc. of the Annual Conference of the North American Chapter of the Association for Computational Linguistics (NAACL)},
-  year = {2009},
-address-omit = {Boulder, Colorado},
-url-omit = "http://cogcomp.org/papers/RiedelCl09.pdf",
-}
-
-@inproceedings{GCTR09,
-  author = {D. Goldwasser and M. Chang and Y. Tu and D. Roth},
-  title = {Constraint Driven Transliteration Discovery},
-  booktitle = {Proc. of the Conference on Recent Advances in Natural Language Processing},
-  year = {2009},
-publisher-omit = {John Benjamins},
-  editor = {Nicolas Nicolov},
-url-omit = "http://cogcomp.org/papers/GCTR09.pdf",
-  funding = {BL,SoD},
-  projects = {CCG,TL},
-  comment = {Extending Constrained Conditional Model based transliteration; Combines EMNLP'08 and NAACL'09},
-}
-
-@article{DDMR09,
-  author = {I.  Dagan and B. Dolan and B. Magnini and D. Roth},
-  title = {Guest Editors Introduction: Recognizing Textual Entailment: Rational, Evaluation and Approaches},
-pages-omit = {459--476},
-  year = {2009},
-publisher-omit = {Cambridge University Press},
-  journal = {Journal of Natural Language Engineering},
-volume-omit = {15},
-url-omit = {},
-  projects = {TE},
-}
-
-@inproceedings{SVVJCGSKTSRDR09,
-  author = {M. Sammons and V. Vydiswaran and T. Vieira and N. Johri and M. Chang and D. Goldwasser and V. Srikumar and G. Kundu and Y. Tu and K. Small and J. Rule and Q. Do and D. Roth},
-  title = {Relation Alignment for Textual Entailment Recognition},
-  booktitle = {Proc. of the Text Analysis Conference (TAC)},
-  year = {2009},
-url-omit = "http://cogcomp.org/papers/SVVJCGSKTSRDR09(1).pdf",
-  funding = {DARPA,Boeing},
-  projects = {TE,KRNLP},
-  comment = {Recognizing Textual Entailment, textual entailment system, alignment, multi-view representation},
-}
-
-@article{GHJKRRC09,
-  author = {C. Godby and P. Hswe and L. Jackson and J. Klavans and L. Ratinov and D. Roth and H. Cho},
-  title = {Who's Who in Your Digital Collection: Developing a Tool for Name Disambiguation and Identity Resolution},
-  booktitle = {Journal of the Chicago Colloquium on Digital Humanities and Computer Science (Proc. of the Chicago Colloquium on Digital Humanities and Computer Science (DHCS))},
-  year = {2009},
-url-omit = "http://cogcomp.org/papers/GHJKRRC09.pdf",
-  funding = {DARPA,LIBRARY},
-  projects = {IR,LBJ},
-  comment = {Named Entity Recognition (NER) and Wikification; Applications to Digital Libraries},
-}
-
-%%%%%%%%%%%%%%
-%%%  2008  %%%
-%%%%%%%%%%%%%%
-@thesis{Alm08,
-  author = {C. Alm},
-  title = {Affect in Text and Speech},
-  booktitle = {UIUC PhD Thesis},
-  year = {2008},
-url-omit = "http://cogcomp.org/papers/Alm thesis(1).pdf",
-}
-
-@techreport{PasternackRo08,
-  author = {J. Pasternack and D. Roth},
-  title = {The Wikipedia Corpus},
-  year = {2008},
-  journal = {University of Illinois Technical Report},
-url-omit = "http://cogcomp.org/papers/PasternackRo08.pdf",
-}
-
-@incollection{KlementievRo08,
-  author = {A. Klementiev and D. Roth},
-  title = {Named Entity Transliteration and Discovery in Multilingual Corpora},
-  booktitle = {Learning Machine Translation},
-  year = {2008},
-publisher-omit = {MIT Press},
-  editor = {Cyril Goutte and Nicola Cancedda and Marc Dymetman and George Foster},
-url-omit = "http://cogcomp.org/papers/KlementievRo08.pdf",
-  funding = {KINDLE,REFLEX},
-  projects = {REFLEX,USS,TL,ADAPT},
-}
-
-@inproceedings{GoldwasserRo08a,
-  author = {D. Goldwasser and D. Roth},
-  title = {Transliteration as Constrained Optimization},
-  booktitle = {Proc. of the Conference on Empirical Methods in Natural Language Processing (EMNLP)},
-month-omit = {10},
-  year = {2008},
-url-omit = "http://cogcomp.org/papers/GoldwasserRo08a.pdf",
-  funding = {DARPA,SoD},
-  projects = {CCM,TL},
-  comment = {Transliteration; Constrained optimization; Named entity discovery; bilingual corpora; feature selection for transliteration; Discriminative training of Objective function; Integer Linear Programming;ILP; Hebrew transliteration},
-}
-
-@inproceedings{BengtsonRo08,
-  author = {E. Bengtson and D. Roth},
-  title = {Understanding the Value of Features for Coreference Resolution},
-  booktitle = {Proc. of the Conference on Empirical Methods in Natural Language Processing (EMNLP)},
-month-omit = {10},
-  year = {2008},
-url-omit = "http://cogcomp.org/papers/BengtsonRo08.pdf",
-  funding = {Boeing,SoD},
-  projects = {COREF,TE},
-  comment = {The importance of good features for coreference resolution},
-}
-
-@workshop{KlementievRoSm08a,
-  author = {A. Klementiev and D. Roth and K. Small},
-  title = {A Framework for Unsupervised Rank Aggregation},
-  booktitle = {Proc. of the ACM SIGIR Conference (SIGIR)},
-pages-omit = {32-39},
-month-omit = {7},
-  year = {2008},
-url-omit = "http://cogcomp.org/papers/KlementievRoSm08a.pdf",
-  funding = {ITR-EDU, BL, MIAS},
-  projects = {USS,RANK},
-}
-
-@workshop{ChangRaRo08,
-  author = {M. Chang and L. Ratinov and D. Roth},
-  title = {Constraints as Prior Knowledge},
-  booktitle = {Proc. of the International Conference on Machine Learning (ICML)},
-pages-omit = {32-39},
-month-omit = {7},
-  year = {2008},
-url-omit = "http://cogcomp.org/papers/ChangRaRo08.pdf",
-  funding = {SoD, LIBRARY, MIAS},
-  projects = {USS,IE,CCM},
-}
-
-@techreport{RothSa08,
-  author = {D. Roth and M. Sammons},
-  title = {A Unified Representation and Inference Paradigm for Natural Language Processing},
-  year = {2008},
-  institution = {UIUC Computer Science Department},
-number-omit = {UIUCDCS-R-2008-2969},
-url-omit = "http://cogcomp.org/papers/RothSa08.pdf",
-  funding = {Boeing},
-  projects = {TE},
-}
-
-@inproceedings{CGFR08,
-  author = {M. Connor and Y. Gertner and C. Fisher and D. Roth},
-  title = {Baby SRL: Modeling Early Language Acquisition},
-  booktitle = {Proc. of the Conference on Computational Natural Language Learning (CoNLL)},
-month-omit = {8},
-  year = {2008},
-url-omit = "http://cogcomp.org/papers/CGFR08.pdf",
-  funding = {Psych},
-  projects = {PSYCHO},
-  comment = {Evaluating the psycholinguistics structure-mapping assumption; a semantic role labeling system with simple, psycholinguistically plausible features; language acquisition},
-}
-
-@article{PunyakanokRoYi08,
-  author = {V. Punyakanok and D. Roth and W. Yih},
-  title = {The Importance of Syntactic Parsing and Inference in Semantic Role Labeling},
-  year = {2008},
-  journal = {Computational Linguistics},
-volume-omit = {34},
-number-omit = {2},
-url-omit = "http://cogcomp.org/papers/PunyakanokRoYi07.pdf",
-  funding = {KINDLE,REFLEX,MURI,XPRESSMP},
-  projects = {IE,LINL,SP,ILP,SRL},
-}
-
-@article{DayaRoWi08,
-  author = {E. Daya and D. Roth and S. Wintner},
-  title = {Learning Hebrew Roots: Machine Learning with Linguistic Constraints},
-  year = {2008},
-  journal = {Computational Linguistics},
-volume-omit = {34},
-number-omit = {3},
-url-omit = "http://cogcomp.org/papers/DayaRoWi08.pdf",
-  funding = {CAREER,MURI, REFLEX},
-  projects = {LnI,SI,NLP},
-}
-
-@inproceedings{SRSRR08,
-  author = {V. Srikumar and R. Reichart and M. Sammons and A. Rappoport and D. Roth},
-  title = {Extraction of Entailed Semantic Relations Through Syntax-based Comma Resolution},
-  booktitle = {Proc. of the Annual Meeting of the Association for Computational Linguistics (ACL)},
-month-omit = {6},
-  year = {2008},
-address-omit = {Columbus, OH, USA},
-publisher-omit = {Association for Computational Linguistics},
-url-omit = "http://cogcomp.org/papers/SRSRR08.pdf",
-  funding = {SoD,Boeing},
-  projects = {TE},
-}
-
-@inproceedings{GoldwasserRo08,
-  author = {D. Goldwasser and D. Roth},
-  title = {Active Sample Selection for Named Entity Transliteration},
-  booktitle = {Proc. of the Annual Conference of the North American Chapter of the Association for Computational Linguistics (NAACL)},
-month-omit = {6},
-  year = {2008},
-address-omit = {Columbus, OH, USA},
-publisher-omit = {Association for Computational Linguistics},
-url-omit = "http://cogcomp.org/papers/GoldwasserRo08.pdf",
-  funding = {Darpa},
-  projects = {AL,TL},
-  comment = {Named entity discovery; bilingual corpora; active sampling; data selection; domain adaptation; Russian transliteration; Hebrew transliteration},
-}
-
-@inproceedings{LRSS08,
-  author = {B. Liebald and D. Roth and N. Shah and V. Srikumar},
-  title = {Proactive Intrusion Detection},
-  booktitle = {Proc. of the Conference on Artificial Intelligence (AAAI)},
-month-omit = {7},
-  year = {2008},
-url-omit = "http://cogcomp.org/papers/LRSS08.pdf",
-  funding = {DARPA,Boeing},
-}
-
-@inproceedings{CRRS08,
-  author = {M. Chang and L. Ratinov and D. Roth and V. Srikumar},
-  title = {Importance of Semantic Representation: Dataless Classification},
-  booktitle = {Proc. of the Conference on Artificial Intelligence (AAAI)},
-month-omit = {7},
-  year = {2008},
-url-omit = "http://cogcomp.org/papers/CRRS08.pdf",
-  funding = {SoD,MIAS,Library,Boeing},
-  projects = {DC},
-}
-
-@inproceedings{RothSm08,
-  author = {D. Roth and K. Small},
-  title = {Active Learning for Pipeline Models},
-  booktitle = {Proc. of the Conference on Artificial Intelligence (AAAI)},
-month-omit = {7},
-  year = {2008},
-url-omit = "http://cogcomp.org/papers/RothSm08.pdf",
-  funding = {Darpa, DHS},
-  projects = {AL,PL,NER},
-}
-
-@inproceedings{CRRR08,
-  author = {M. Chang and L. Ratinov and N. Rizzolo and D. Roth},
-  title = {Learning and Inference with Constraints},
-  booktitle = {Proc. of the Conference on Artificial Intelligence (AAAI)},
-month-omit = {7},
-  year = {2008},
-url-omit = "http://cogcomp.org/papers/CRRR08.pdf",
-  funding = {SoD,MIAS,Library,Boeing},
-  projects = {CCM,LBP},
-}
-
-@inproceedings{KlementievRoSm08,
-  author = {A. Klementiev and D. Roth and K. Small},
-  title = {Unsupervised Rank Aggregation with Distance-Based Models},
-  booktitle = {Proc. of the International Conference on Machine Learning (ICML)},
-month-omit = {7},
-  year = {2008},
-  acceptance = {158/583 (27\%) (regular papers)},
-url-omit = "http://cogcomp.org/papers/KlementievRoSm08.pdf",
-  funding = {ITR-EDU, BL, MIAS},
-  projects = {USS,RANK},
-  comment = {We propose a mathematical and algorithmic framework for learning to aggregate (partial) rankings without supervision. We instantiate the framework for the cases of combining permutations and combining top-k lists, and propose a novel metric for the latter.},
-}
-
-@inproceedings{RahurkarRoHu08,
-  author = {M. Rahurkar and D. Roth and T. Huang},
-  title = {Which Apple are you talking about},
-  booktitle = {Proc. of the International World Wide Web Conference (WWW)},
-pages-omit = {1197-1198},
-  year = {2008},
-url-omit = "http://cogcomp.org/papers/RahurkarRoHu08.pdf",
-  projects = {SEARCH},
-}
-
-@incollection{BrazAmRo08,
-  author = {R. de Salvo Braz and E. Amir and D. Roth},
-  title = {A Survey of First-Order Probabilistic Models},
-  booktitle = {Innovations in Bayesian Networks},
-pages-omit = {289--317},
-  year = {2008},
-publisher-omit = {Springer-Verlag},
-  editor = {D.E. Holmes and L.C. Jain},
-url-omit = "http://cogcomp.org/papers/BrazAmRo08.pdf",
-  funding = {ARDA, ITR-BI, SoD},
-  projects = {FOPI},
-  comment = {Lifted Probabilistic Inference},
-}
-
-%%%%%%%%%%%%%%
-%%%  2007  %%%
-%%%%%%%%%%%%%%
-@thesis{Braz07,
-  author = {R. de Salvo Braz},
-  title = {Lifted First-Order Probabilistic Inference},
-  booktitle = {UIUC PhD Thesis},
-  year = {2007},
-url-omit = "http://cogcomp.org/papers/Braz07.pdf",
-}
-
-@workshop{RothSa07,
-  author = {D. Roth and M. Sammons},
-  title = {Semantic and Logical Inference Model for Textual Entailment},
-  booktitle = {Proc. of the Annual Meeting of the Association for Computational Linguistics (ACL)},
-pages-omit = {107--112},
-month-omit = {6},
-  year = {2007},
-address-omit = {Prague, Czech Republic},
-publisher-omit = {Association for Computational Linguistics},
-url-omit = "http://cogcomp.org/papers/RothSa07.pdf",
-  funding = {Boeing, ARDA, ACQUAINT, Google},
-  projects = {TE},
-  comment = {Textual Entailment; Compositional semantics; Search-based inference; Modular framework},
-}
-
-@inproceedings{ChangRaRo07,
-  author = {M. Chang and L. Ratinov and D. Roth},
-  title = {Guiding Semi-Supervision with Constraint-Driven Learning},
-  booktitle = {Proc. of the Annual Meeting of the Association for Computational Linguistics (ACL)},
-pages-omit = {280--287},
-month-omit = {6},
-  year = {2007},
-address-omit = {Prague, Czech Republic},
-publisher-omit = {Association for Computational Linguistics},
-url-omit = "http://cogcomp.org/papers/ChangRaRo07.pdf",
-  funding = {SoD,Boeing},
-  projects = {USS,CCM,IE},
-  comment = {Semi-supervised learning with very little supervision; Constraints; Constraints Driven Learning; Information Extraction},
-}
-
-@inproceedings{RizzoloRo07,
-  author = {N. Rizzolo and D. Roth},
-  title = {Modeling Discriminative Global Inference},
-  booktitle = {Proc. of the IEEE International Conference on Semantic Computing (ICSC)},
-pages-omit = {597-604},
-month-omit = {9},
-  year = {2007},
-address-omit = {Irvine, California},
-publisher-omit = {IEEE},
-url-omit = "http://cogcomp.org/papers/RizzoloRo07.pdf",
-  funding = {NSF-SoD, LBP},
-  projects = {LBP,CCM},
-  comment = {Learning Based Java: a Modeling language that facilitates developing of systems with learning and inference componenets.},
-}
-
-@inproceedings{ConnorRo07,
-  author = {M. Connor and D. Roth},
-  title = {Context Sensitive Paraphrasing with a Single Unsupervised Classifier},
-  booktitle = {Proc. of the European Conference on Machine Learning (ECML)},
-month-omit = {9},
-  year = {2007},
-  acceptance = {69/592 (12\%) (regular papers)},
-url-omit = "http://cogcomp.org/papers/ConnorRo07.pdf",
-  funding = {ITR-EDU,Psych},
-  projects = {NLP,LP,TE,USS},
-  comment = {Trains a single classifier to decided context sensitive paraphrases of verbs. Bootstraps training set through unsupervised training of subtask classifiers and confident example selection.},
-}
-
-@inproceedings{KlementievRoSm07,
-  author = {A. Klementiev and D. Roth and K. Small},
-  title = {An Unsupervised Learning Algorithm for Rank Aggregation},
-  booktitle = {Proc. of the European Conference on Machine Learning (ECML)},
-month-omit = {9},
-  year = {2007},
-url-omit = "http://cogcomp.org/papers/KlementievRoSm07.pdf",
-  funding = {ITR-EDU, MIAS},
-  projects = {USS,RANK},
-}
-
-@article{RothYi07,
-  author = {D. Roth and W. Yih},
-  title = {Global Inference for Entity and Relation Identification via a Linear Programming Formulation},
-  booktitle = {Introduction to Statistical Relational Learning},
-  year = {2007},
-publisher-omit = {MIT Press},
-  editor = {Lise Getoor and Ben Taskar},
-url-omit = "http://cogcomp.org/papers/RothYi07.pdf",
-  funding = {ITR-BI,ARDA,XPRESSMP},
-  projects = {LT,LINL,ILP,CCM,NER,PL},
-  comment = {Learning and Inference with Constraints; Integer Linear Programming for Information extraction; Simultaneous recognition of entities and Relations},
-}
-
-@incollection{BrazAmRo07,
-  author = {R. de Salvo Braz and E. Amir and D. Roth},
-  title = {Lifted First-Order Probabilistic Inference},
-  booktitle = {Introduction to Statistical Relational Learning},
-  year = {2007},
-publisher-omit = {MIT Press},
-  editor = {Lise Getoor and Ben Taskar},
-url-omit = "http://cogcomp.org/papers/BrazAmRo07.pdf",
-  funding = {ARDA, ITR-BI, SoD},
-  projects = {FOPI},
-  comment = {Relational Inference; Probabilistic Relational (first order) Models; First-order probabilistic inference without propositionalization; Lifted Probabilistic Inference},
-}
-
-@inproceedings{Har-PeledRoZi07,
-  author = {S. Har-Peled and D. Roth and D. Zimak},
-  title = {Maximum Margin Coresets for Active and Noise Tolerant Learning},
-  booktitle = {Proc. of the International Joint Conference on Artificial Intelligence (IJCAI)},
-pages-omit = {LT},
-  year = {2007},
-  acceptance = {212/1353 (16\%)},
-url-omit = "http://cogcomp.org/papers/Har-PeledRoZi07.pdf",
-  funding = {KINDLE,REFLEX,MURI,XPRESSMP},
-  projects = {IE,LINL,SP,ILP,AL},
-  comment = {Learning large margin halfspaces using coresets; algorithm and analysis; applications include analysis of large margin active learning and an algorithm for agnostic learning in the presence of outlier noise.},
-}
-
-@article{ZTLHPRL07,
-  author = {Z. Zeng and J. Tu and M. Liu and T. Huang and B. Pianfetti and D. Roth and S. Levinson},
-  title = {Audio-Visual Affect Recognition},
-pages-omit = {424-428},
-  year = {2007},
-  journal = {IEEE Transactions on Multimedia},
-volume-omit = {9},
-number-omit = {2},
-url-omit = "http://cogcomp.org/papers/ZTLHPRL07.pdf",
-  funding = {ITR-BI},
-}
-
-%%%%%%%%%%%%%%
-%%%  2006  %%%
-%%%%%%%%%%%%%%
-@thesis{Zimak06,
-  author = {D. Zimak},
-  title = {Algorithms and Analysis for Multi-Category Classification},
-  booktitle = {UIUC PhD Thesis},
-  year = {2006},
-url-omit = "http://cogcomp.org/papers/Zimak06.pdf",
-}
-
-@inproceedings{ChangDoRo06,
-  author = {M. Chang and Q. Do and D. Roth},
-  title = {Multilingual Dependency Parsing: A Pipeline Approach},
-  booktitle = {Proc. of the Conference on Recent Advances in Natural Language Processing},
-pages-omit = {55--78},
-month-omit = {7},
-  year = {2006},
-  editor = {Nicolas Nicolov and Kalina Bontcheva and Galia Angelova and Ruslan Mitkov},
-url-omit = "http://cogcomp.org/papers/ChangDoRo06b.pdf",
-  funding = {ARDA,REFLEX,SoD},
-  projects = {DP,PL},
-  comment = {Analysis of A pipeline model with applications to dependency parsing. Combines ACL'06 and CoNLL'06},
-}
-
-@inproceedings{RothSm06a,
-  author = {D. Roth and K. Small},
-  title = {Margin-based Active Learning for Structured Output Spaces},
-  booktitle = {Proc. of the European Conference on Machine Learning (ECML)},
-month-omit = {9},
-  year = {2006},
-publisher-omit = {Springer},
-url-omit = "http://cogcomp.org/papers/RothSm06a.pdf",
-  funding = {MOTOROLA,ITR-EDU},
-  projects = {AL,SRL},
-  comment = {Active Learning; Structured Output},
-}
-
-@workshop{BrazAmRo06a,
-  author = {R. de Salvo Braz and E. Amir and D. Roth},
-  title = {MPE and Partial Inversion in Lifted Probabilistic Variable Elimination},
-  booktitle = {Proc. of the Conference on Artificial Intelligence (AAAI)},
-month-omit = {7},
-  year = {2006},
-url-omit = "http://cogcomp.org/papers/BrazAmRo06a.pdf",
-  funding = {ARDA,ITR-BI},
-  projects = {FOPI},
-  comment = {Relational Inference; Probabilistic Relational (first order) Models; First-order probabilistic inference without propositionalization; Lifted Probabilistic Inference},
-}
-
-@inproceedings{KlementievRo06a,
-  author = {A. Klementiev and D. Roth},
-  title = {Weakly Supervised Named Entity Transliteration and Discovery from Multilingual Comparable Corpora},
-  booktitle = {Proc. of the Annual Meeting of the Association for Computational Linguistics (ACL)},
-pages-omit = {USS,TL,ADAPT},
-month-omit = {7},
-  year = {2006},
-url-omit = "http://cogcomp.org/papers/KlementievRo06a.pdf",
-  funding = {KINDLE,REFLEX},
-  projects = {REFLEX,USS,TL,ADAPT},
-  comment = {Multilingual named entities; multilingual search; multilingual named entities discovery and recognition; discriminatory transliteration model; Fourier Transform for temporal sequence similarity},
-}
-
-@inproceedings{ChangDoRo06a,
-  author = {M. Chang and Q. Do and D. Roth},
-  title = {Local Search for Bottom-Up Dependency Parsing},
-  booktitle = {Proc. of the Annual Meeting of the Association for Computational Linguistics (ACL)},
-month-omit = {7},
-  year = {2006},
-url-omit = "http://cogcomp.org/papers/ChangDoRo06a.pdf",
-  funding = {ARDA,REFLEX},
-  projects = {DP},
-  comment = {Analysis of A pipeline model with applications to dependency parsing},
-}
-
-@inproceedings{ChangDoRo06,
-  author = {M. Chang and Q. Do and D. Roth},
-  title = {A Pipeline Model for Bottom-Up Dependency Parsing Shared Task Paper},
-  booktitle = {Proc. of the Conference on Computational Natural Language Learning (CoNLL)},
-pages-omit = {186--190},
-month-omit = {6},
-  year = {2006},
-url-omit = "http://cogcomp.org/papers/ChangDoRo06.pdf",
-  funding = {KINDLE,REFLEX},
-  projects = {DP,PL},
-  comment = {Multilingual Dependency Parsing; a shift reduced parsing model; study of shift reduced parsing as a pipeline model},
-}
-
-@workshop{BrazAmRo06,
-  author = {R. de Salvo Braz and E. Amir and D. Roth},
-  title = {MPE and Partial Inversion in Lifted Probabilistic Variable Elimination},
-  booktitle = {Proc. of the International Conference on Machine Learning (ICML)},
-month-omit = {6},
-  year = {2006},
-url-omit = "http://cogcomp.org/papers/BrazAmRo06.pdf",
-  funding = {ARDA},
-  projects = {FOPI},
-  comment = {Earlier Version of a AAAI'06 paper.},
-}
-
-@workshop{RothSm06,
-  author = {D. Roth and K. Small},
-  title = {Active Learning with Perceptron for Structured Output},
-  booktitle = {Proc. of the International Conference on Machine Learning (ICML)},
-month-omit = {6},
-  year = {2006},
-url-omit = "http://cogcomp.org/papers/RothSm06.pdf",
-  funding = {MOTOROLA,ITR-EDU},
-  projects = {AL},
-  comment = {Earlier Version of an ECML'06 paper},
-}
-
-@inproceedings{KlementievRo06,
-  author = {A. Klementiev and D. Roth},
-  title = {Named Entity Transliteration and Discovery from Multilingual Comparable Corpora},
-  booktitle = {Proc. of the Annual Conference of the North American Chapter of the Association for Computational Linguistics (NAACL)},
-pages-omit = {82--88},
-month-omit = {6},
-  year = {2006},
-url-omit = "http://cogcomp.org/papers/KlementievRo06.pdf",
-  funding = {KINDLE,REFLEX},
-  projects = {REFLEX,TL,USS,ADAPT},
-  comment = {Multilingual named entities; multilingual search; multilingual named entities discovery and recognition; discriminatory transliteration model; Fourier Transform for temporal sequence similarity},
-}
-
-@incollection{BGPRS06,
-  author = {R. de Salvo Braz and R. Girju and V. Punyakanok and D. Roth and M. Sammons},
-  title = {An Inference Model for Semantic Entailment in Natural Language},
-pages-omit = {261--286},
-  year = {2006},
-publisher-omit = {Springer},
-  editor = {J. Quinonero Candela and I. Dagan and B. Magnini and F. d'Alche-Buc},
-  journal = {Machine Learning Challenges, Evaluating Predictive Uncertainty, Visual Object Classification and Recognizing Textual Entailment, First PASCAL Machine Learning Challenges Workshop, Revised Selected Papers},
-volume-omit = {3944},
-url-omit = "http://cogcomp.org/papers/BGPRS06.pdf",
-  funding = {ARDA,ITR-BI,TRECC,CLUSTER,XPRESSMP},
-  projects = {KINDLE,TE,KRNLP},
-  comment = {Revised version of PASCAL RTE Challenge. Textual Entailment, integrating NLP text analyis, shallow semantic inference},
-}
-
-@techreport{Har-PeledRoZi06a,
-  author = {S. Har-Peled and D. Roth and D. Zimak},
-  title = {Maximum Margin Coresets for Active and Noise Tolerant Learning},
-  year = {2006},
-  institution = {UIUC Computer Science Department},
-number-omit = {No. UIUCDCS-R-2006-2784},
-url-omit = {},
-  funding = {ITR-BI,ITR-MIT},
-  projects = {AL},
-  invisible = {true},
-}
-
-@techreport{DoanLiRo06,
-  author = {A. Doan and X. Li and D. Roth},
-  title = {MEDIATE: Learning to match entity mentions across text and data bases},
-  year = {2006},
-  institution = {UIUC Computer Science Department},
-number-omit = {No. UIUCDCS-R-2006-2692},
-url-omit = "http://cogcomp.org/papers/DoanLiRo06.pdf",
-  funding = {MURI,ITR-BI},
-  projects = {MIRROR,COREF,NER},
-  comment = {UIUC Tech Report UIUCDCS-R-2006-2692. Semantic Integration; Entity Uncertainty; Automatic matching of entity mentions across text and databases.},
-  invisible = {true},
-}
-
-@article{MengshoelRoWi06,
-  author = {O. J. Mengshoel and D. Roth and D. C. Wilkins},
-  title = {Controlled generation of hard and easy Bayesian networks: Impact on maximal clique size in tree clustering},
-  year = {2006},
-  journal = {Artificial Intelligence},
-url-omit = "http://cogcomp.org/papers/MengshoelWiRo06.pdf",
-}
-
-%%%%%%%%%%%%%%
-%%%  2005  %%%
-%%%%%%%%%%%%%%
-@thesis{Yih05,
-  author = {W. Yih},
-  title = {Learning and Inference for Information Extraction},
-  booktitle = {UIUC PhD thesis},
-  year = {2005},
-url-omit = "http://cogcomp.org/papers/Yih05.pdf",
-}
-
-@inproceedings{RothYi05,
-  author = {D. Roth and W. Yih},
-  title = {Integer Linear Programming Inference for Conditional Random Fields},
-  booktitle = {Proc. of the International Conference on Machine Learning (ICML)},
-pages-omit = {737--744},
-  year = {2005},
-  acceptance = {143/491 (29\%)},
-url-omit = "http://cogcomp.org/papers/RothYi05.pdf",
-  funding = {MURI,ITR-BI,ITR-MIT,ARDA,XPRESSMP},
-  projects = {LT,LINL,ILP,CCM},
-  comment = {Extending Conditional Random Fields with expressive, non-sequential, constraints. Comparing multiple joint inference training paradigms for structure learning in the context of SRL.},
-}
-
-@inproceedings{PunyakanokRoYi05,
-  author = {V. Punyakanok and D. Roth and W. Yih},
-  title = {The Necessity of Syntactic Parsing for Semantic Role Labeling},
-  booktitle = {Proc. of the International Joint Conference on Artificial Intelligence (IJCAI)},
-pages-omit = {1117--1123},
-  year = {2005},
-  acceptance = {240/1329 (18\%)},
-url-omit = "http://cogcomp.org/papers/PunyakanokRoYi05.pdf",
-  funding = {KINDLE,REFLEX,MURI,XPRESSMP},
-  projects = {IE,LINL,SP,ILP,SRL},
-  comment = {An Analysis of the impact of syntactic parsing on semantic role labeling. Joint inference is used both to guarantee coherent SRL output and to combine several SRL systems.},
-}
-
-@inproceedings{PRYZ05,
-  author = {V. Punyakanok and D. Roth and W. Yih and D. Zimak},
-  title = {Learning and Inference over Constrained Output},
-  booktitle = {Proc. of the International Joint Conference on Artificial Intelligence (IJCAI)},
-pages-omit = {1124--1129},
-  year = {2005},
-  acceptance = {240/1329 (18\%)},
-url-omit = "http://cogcomp.org/papers/PRYZ05.pdf",
-  funding = {KINDLE,REFLEX,MURI,XPRESSMP,ITR-BI},
-  projects = {LT,CCM},
-  comment = {Structure Learning; Joint Inference; Learning + Inference vs. Inference based Training Algorithms},
-}
-
-@inproceedings{BrazAmRo05,
-  author = {R. de Salvo Braz and E. Amir and D. Roth},
-  title = {Lifted First-order Probabilistic Inference},
-  booktitle = {Proc. of the International Joint Conference on Artificial Intelligence (IJCAI)},
-pages-omit = {1319--1125},
-  year = {2005},
-  acceptance = {240/1329 (18\%)},
-url-omit = "http://cogcomp.org/papers/BrazAmRo05.pdf",
-  funding = {ITR-BI, CAREER},
-  comment = {Relational Inference; Probabilistic Relational (first order) Models; First-order probabilistic inference without propositionalization},
-}
-
-@inproceedings{BGPRS05,
-  author = {R. de Salvo Braz and R. Girju and V. Punyakanok and D. Roth and M. Sammons},
-  title = {An Inference Model for Semantic Entailment in Natural Language},
-  booktitle = {Proc. of the Conference on Artificial Intelligence (AAAI)},
-pages-omit = {1678--1679},
-  year = {2005},
-  acceptance = {223/803 (28\%)},
-url-omit = "http://cogcomp.org/papers/BGPRS05.pdf",
-  funding = {ARDA,ITR-BI,TRECC,CLUSTER,XPRESSMP},
-  projects = {KINDLE,TE,KRNLP},
-  comment = {Textual Entailment; Mapping sentences to a description logic based representation, Pascal Entailment Task},
-}
-
-@workshop{BGPRS05a,
-  author = {R. de Salvo Braz and R. Girju and V. Punyakanok and D. Roth and M. Sammons},
-  title = {Knowledge Representation for Semantic Entailment and Question-Answering},
-  booktitle = {Proc. of the International Joint Conference on Artificial Intelligence (IJCAI)},
-  year = {2005},
-url-omit = "http://cogcomp.org/papers/BGPRS05a.pdf",
-  funding = {ARDA,ITR-BI,TRECC,CLUSTER,XPRESSMP,TE},
-  projects = {KINDLE},
-  comment = {Analysis of our Textual Entailment system},
-}
-
-@inproceedings{BGPRS05b,
-  author = {R. de Salvo Braz and R. Girju and V. Punyakanok and D. Roth and M. Sammons},
-  title = {An Inference Model for Semantic Entailment in Natural Language},
-  booktitle = {Proc. of the International Joint Conference on Artificial Intelligence (IJCAI)},
-  year = {2005},
-  acceptance = {112/450 (25\%)},
-url-omit = "http://cogcomp.org/papers/BGPRS05b.pdf",
-  funding = {ARDA,ITR-BI,TRECC,CLUSTER,XPRESSMP},
-  projects = {KINDLE,TE},
-  comment = {Textual Entailment; Mapping sentences to a description logic based representation},
-}
-
-@inproceedings{AlmRoSp05,
-  author = {C. Alm and D. Roth and R. Sproat},
-  title = {Emotions from text: machine learning for text-based emotion prediction.},
-  booktitle = {Proc. of the Conference on Empirical Methods in Natural Language Processing (EMNLP)},
-  year = {2005},
-url-omit = "http://cogcomp.org/papers/AlmRoSp05.pdf",
-  funding = {ITR-EDU},
-}
-
-@inproceedings{AgarwalRo05,
-  author = {S. Agarwal and D. Roth},
-  title = {Learnability of Bipartite Ranking Functions},
-  booktitle = {Proc. of the ACM Conference on Computational Learning Theory (COLT)},
-pages-omit = {16--31},
-  year = {2005},
-  acceptance = {45/119 (37.8\%)},
-url-omit = "http://cogcomp.org/papers/Agarwalro05.pdf",
-  funding = {ITR-BI,ITR-MIT,TRECC},
-  projects = {LT,RANK},
-}
-
-@inproceedings{AgarwalHaRo05,
-  author = {S. Agarwal and S. Har-Peled and D. Roth},
-  title = {A Uniform Convergence Bound for the Area Under the ROC Curve},
-  booktitle = {Proc. of the International Workshop on Artificial Intelligence and Statistics (AISTATS)},
-pages-omit = {1-8},
-  year = {2005},
-  acceptance = {51/150 (34\%)},
-url-omit = "http://cogcomp.org/papers/AgarwalHaRo05.pdf",
-  funding = {ITR-BI,ITR-MIT,TRECC},
-  projects = {LT,RANK},
-  comment = {Bipartite Ranking: uniform convergence properties of the AUC in terms of bipartite rank-shatter coefficients.},
-}
-
-@inproceedings{AGHR05,
-  author = {S. Agarwal and T. Graepel and R. Herbrich and D. Roth},
-  title = {A Large Deviation Bound for the Area Under the ROC Curve},
-  booktitle = {Proc. of the Conference on Neural Information Processing Systems (NIPS)},
-pages-omit = {9--16},
-  year = {2005},
-  acceptance = {207/823 (25\%)},
-url-omit = "http://cogcomp.org/papers/AgarwalGrHeRo05.pdf",
-  funding = {ITR-BI,ITR-MIT,TRECC},
-  projects = {LT,RANK},
-  comment = {Bipartite Ranking: bounding the expected accuracy of a ranking function in terms of its empirical AUC.},
-}
-
-@article{AGHHR05,
-  author = {S. Agarwal and T. Graepel and R. Herbrich and S. Har-Peled and D. Roth},
-  title = {Generalization Bounds for the Area Under the ROC Curve},
-pages-omit = {393--425},
-  year = {2005},
-  journal = {Journal of Machine Learning Research},
-volume-omit = {6},
-url-omit = "http://cogcomp.org/papers/AgarwalGrHeHaRo05.pdf",
-  funding = {ITR-BI,ITR-MIT,TRECC},
-  projects = {LT,RANK},
-}
-
-@article{KhardonRoSe05,
-  author = {R. Khardon and D. Roth and R. Servedio},
-  title = {Efficiency versus Convergence of Boolean Kernels for On-Line Learning Algorithms},
-pages-omit = {341-356},
-  year = {2005},
-  journal = {Journal of Machine Learning Research},
-volume-omit = {24},
-url-omit = "http://cogcomp.org/papers/KhardonRoSe05.pdf",
-  funding = {ITR-MIT NSF98 CAREER},
-  projects = {KR,LT},
-}
-
-@article{FungRo05,
-  author = {P. Fung and D. Roth},
-  title = {Guest Editors Introduction: Machine Learning in Speech and Language Technologies},
-pages-omit = {1-6},
-  year = {2005},
-  journal = {Machine Learning},
-volume-omit = {60},
-number-omit = {1/2/3},
-url-omit = "http://cogcomp.org/papers/FungRo05.pdf",
-  funding = {ITR-BI,CAREER,MURI},
-  projects = {LNL,LT},
-}
-
-@article{Roth05,
-  author = {D. Roth},
-  title = {Learning based Programming},
-  year = {2005},
-publisher-omit = {Springer-Verlag},
-  editor = {L.C. Jain and D. Holmes},
-  journal = {Innovations in Machine Learning: Theory and Applications},
-url-omit = "http://cogcomp.org/papers/Roth05.pdf",
-  funding = {ITR-BI,MURI,TRECC},
-  projects = {LBP},
-  comment = {Suggests a paradigm and a programming language for the programming of learning intensive computer systems. Springer: http://dx.doi.org/10.1007/3-540-33486-6_3},
-}
-
-@workshop{GirjuRoSa05,
-  author = {R. Girju and D. Roth and M. Sammons},
-  title = {Token-level Disambiguation of VerbNet classes},
-  booktitle = {Proc. of the Interdisciplinary Workshop on Verb Features and Verb Classes (Verb Workshop)},
-  year = {2005},
-url-omit = "http://cogcomp.org/papers/GirjuRoSa05.pdf",
-  funding = {KINDLE,TRECC},
-  projects = {SM},
-  comment = {Context Sensitive Identification of VerbNet Classes; Levin Classes.},
-}
-
-@article{LiMoRo05,
-  author = {X. Li and P. Morie and D. Roth},
-  title = {Semantic Integration in Text: From Ambiguous Names to Identifiable Entities},
-pages-omit = {45--68},
-  year = {2005},
-  journal = {AI Magazine. Special Issue on Semantic Integration},
-url-omit = "http://cogcomp.org/papers/LiMoRo05.pdf",
-  funding = {MURI,TRECC,CLUSTER},
-  projects = {MIRROR,COREF,NER},
-  comment = {Named Entity Recognition; coreference resolution; entity identification; matching Entities Mentions within and across documents.},
-}
-
-@inproceedings{ShenLiDo05,
-  author = {W. Shen and X. Li and A. Doan},
-  title = {Constraint-Based Entity Matching},
-  booktitle = {Proc. of the Conference on Artificial Intelligence (AAAI)},
-  year = {2005},
-  acceptance = {223/803 (28\%)},
-url-omit = "http://cogcomp.org/papers/ShenLiDn05.pdf",
-  funding = {MURI,ITR-MIT},
-  projects = {MIRROR,NER,COREF},
-  comment = {Entity Identification, Generative Model, Record Linkage, Constraint, Relaxation Labeling},
-}
-
-@inproceedings{LiRo05,
-  author = {X. Li and D. Roth},
-  title = {Discriminative Training of Clustering Functions: Theory and Experiments with Entity Identification},
-  booktitle = {Proc. of the Conference on Computational Natural Language Learning (CoNLL)},
-pages-omit = {64--71},
-  year = {2005},
-publisher-omit = {Association for Computational Linguistics},
-  editor = {Ido Dagan and Dan Gildea},
-  acceptance = {19/70 (27\%)},
-url-omit = "http://cogcomp.org/papers/LiRo05.pdf",
-  funding = {ITR-BI,MURI,TRECC},
-  projects = {MIRROR,NER},
-  comment = {Clustering; metric learning; training metrics; entity identification},
-}
-
-@inproceedings{KPRY05,
-  author = {P. Koomen and V. Punyakanok and D. Roth and W. Yih},
-  title = {Generalized Inference with Multiple Semantic Role Labeling Systems Shared Task Paper},
-  booktitle = {Proc. of the Conference on Computational Natural Language Learning (CoNLL)},
-pages-omit = {181-184},
-  year = {2005},
-  editor = {Ido Dagan and Dan Gildea},
-url-omit = "http://cogcomp.org/papers/PunyakanokRoYi05a.pdf",
-  funding = {MURI,KINDLE,CLUSTER,XPRESSMP},
-  projects = {SM,KINDLE,SRL},
-  comment = {Semantic Parsing; joint inference; integer linear programming; combining SRL systems via joint inference; Top system in CoNLL shared task},
-}
-
-@article{LiRo05a,
-  author = {X. Li and D. Roth},
-  title = {Learning Question Classifiers: The Role of Semantic Information},
-  year = {2005},
-  journal = {Journal of Natural Language Engineering},
-volume-omit = {11},
-number-omit = {4},
-url-omit = "http://cogcomp.org/papers/LiRo05a.pdf",
-  funding = {MURI,ITR-MIT},
-  projects = {QA,MCR,TE},
-  comment = {Question Classification; Hierarchical classifiers; Sequential Model; Expressive Feature generation with semantic information.},
-}
-
-@techreport{PunyakanokRo05,
-  author = {V. Punyakanok and D. Roth},
-  title = {Inference with Classifiers: The Phrase Identification Problem},
-  year = {2005},
-  journal = {UIUC Technical Report},
-url-omit = "http://cogcomp.org/papers/Punyakanok-05.pdf",
-  funding = {CAREER,ITR-MIT,NSF98,KINDLE},
-  projects = {LnI,IE,NE,CCM},
-  comment = {Shallow Parsing; Chunking; HMMs, Conditional Models and Constraint Satisfaction Models. Top results on phrase chunking},
-}
-
-@inproceedings{ZDCR05,
-  author = {B. Ziebart and A. Dey and R. Campbell and D. Roth},
-  title = {Learning Automation Policies for Pervasive Computing Environments},
-  booktitle = {Proc. of the International Conference on Autonomic Computing (ICAC)},
-pages-omit = {204-215},
-  year = {2005},
-  acceptance = {64/150 (43\%)},
-url-omit = "http://cogcomp.org/papers/ZDRC05.pdf",
-  funding = {ITR-BI},
-  projects = {LBP},
-}
-
-@inproceedings{LiRo05b,
-  author = {X. Li and D. Roth},
-  title = {Discriminative Training of Clustering Functions: Theory and Experiments with Entity Identification},
-  booktitle = {Proc. of the Midwest Computational Linguistics Colloquium (MCLC)},
-month-omit = {5},
-  year = {2005},
-url-omit = {},
-  funding = {MURI,TRECC},
-  projects = {LT,NER},
-  comment = {Supervised Learning, Clustering, Metric Learning},
-  invisible = {true},
-}
-
-%%%%%%%%%%%%%%
-%%%  2004  %%%
-%%%%%%%%%%%%%%
-@inproceedings{LiMoRo04,
-  author = {X. Li and P. Morie and D. Roth},
-  title = {Identification and Tracing of Ambiguous Names: Discriminative and Generative Approaches},
-  booktitle = {Proc. of the Conference on Artificial Intelligence (AAAI)},
-pages-omit = {419--424},
-  year = {2004},
-  acceptance = {120/453 (26.5\%)},
-url-omit = "http://cogcomp.org/papers/LiMoRo04.pdf",
-  funding = {MURI,TRECC,CLUSTER},
-  projects = {MIRROR,COREF,NER},
-  comment = {Comparing discriminatory and generative models for entity identification; named entity recognition; coreference resolution; matching entities mentions within and across documents; distance metrics for named entities},
-}
-
-@inproceedings{LiMoRo04a,
-  author = {X. Li and P. Morie and D. Roth},
-  title = {Robust Reading: Identification and Tracing of Ambiguous Names},
-  booktitle = {Proc. of the Annual Conference of the North American Chapter of the Association for Computational Linguistics (NAACL)},
-pages-omit = {17--24},
-  year = {2004},
-url-omit = "http://cogcomp.org/papers/LiMoRo04a.pdf",
-  funding = {MURI,TRECC,CLUSTER},
-  projects = {MIRROR,NER,COREF},
-  comment = {A generative model for entity identification; Named Entity Recognition; coreference resolution; matching entities mentions within and across documents},
-}
-
-@inproceedings{DayaRoWi04,
-  author = {E. Daya and D. Roth and S. Wintner},
-  title = {Learning Hebrew Roots: Machine Learning with Linguistic Constraints},
-  booktitle = {Proc. of the Conference on Empirical Methods in Natural Language Processing (EMNLP)},
-pages-omit = {168--178},
-month-omit = {7},
-  year = {2004},
-url-omit = "http://cogcomp.org/papers/DayaRoWi04.pdf",
-  funding = {CAREER,MURI, REFLEX},
-  projects = {LnI,SI,NLP},
-  comment = {Inference with Classifiers; Learning and Inference with Constraints; Hebrew Morphology},
-}
-
-@inproceedings{RothYi04,
-  author = {D. Roth and W. Yih},
-  title = {A Linear Programming Formulation for Global Inference in Natural Language Tasks},
-  booktitle = {Proc. of the Conference on Computational Natural Language Learning (CoNLL)},
-pages-omit = {1--8},
-  year = {2004},
-publisher-omit = {Association for Computational Linguistics},
-  editor = {Hwee Tou Ng and Ellen Riloff},
-  acceptance = {11/23 (48\%)},
-url-omit = "http://cogcomp.org/papers/RothYi04.pdf",
-  funding = {ITR-BI,MURI,XPRESSMP},
-  projects = {IE,LnI,CCM,NER,PL},
-  comment = {Simultaneous recognition of Named Entities and Relations between them. Learning and Inference via an Integer Linear Programming framework; Structure Learning; Avoiding Pipeline Processing},
-}
-
-@inproceedings{PRYZ04,
-  author = {V. Punyakanok and D. Roth and W. Yih and D. Zimak},
-  title = {Semantic Role Labeling via Integer Linear Programming Inference},
-  booktitle = {Proc. of the International Conference on Computational Linguistics (COLING)},
-pages-omit = {1346--1352},
-month-omit = {8},
-  year = {2004},
-address-omit = {Geneva, Switzerland},
-url-omit = "http://cogcomp.org/papers/PRYZ04.pdf",
-  funding = {ITR-BI,MURI,KINDLE,XPRESSMP},
-  projects = {SP,LnI,CCM,SRL},
-  comment = {Semantic Parsing; Structure Learning with Expressive Constraints; Constraint Optimization; Integer Linear Programming},
-}
-
-@inproceedings{PRYZT04,
-  author = {V. Punyakanok and D. Roth and W. Yih and D. Zimak and Y. Tu},
-  title = {Semantic Role Labeling via Generalized Inference over Classifiers Shared Task Paper},
-  booktitle = {Proc. of the Conference on Computational Natural Language Learning (CoNLL)},
-pages-omit = {130--133},
-  year = {2004},
-  editor = {Hwee Tou Ng and Ellen Riloff},
-url-omit = "http://cogcomp.org/papers/PRYZT04.pdf",
-  funding = {CAREER,MURI,CAREER,KINDLE,CLUSTER,XPRESSMP},
-  projects = {SM,SRL,CCM},
-  comment = {Semantic Parsing; Structure Learning with Expressive Constraints; Constraint Optimization; Integer Linear Programming},
-}
-
-@inproceedings{ZTLZRZHRL04,
-  author = {Z. Zeng and J. Tu and M. Liu and T. Zhang and N. Rizzolo and Z. Zhang and T. Huang and D. Roth and S. Levinson},
-  title = {Bimodal HCI-related Affect Recognition},
-  booktitle = {Proc. of the International Conference on Multimodal Interfaces (ICMI)},
-pages-omit = {137--143},
-month-omit = {10},
-  year = {2004},
-  acceptance = {56/257 (28\%)},
-url-omit = "http://cogcomp.org/papers/ZTKZRZHRL04.pdf",
-  funding = {TRECC,ITR-BI},
-}
-
-@inproceedings{LiRoSm04,
-  author = {X. Li and D. Roth and K. Small},
-  title = {The Role of Semantic Information in Learning Question Classifiers},
-  booktitle = {Proc. of the International Joint Conference on Natural Language Processing (IJCNLP)},
-  year = {2004},
-  acceptance = {67/211 (32\%)},
-url-omit = "http://cogcomp.org/papers/LiRoSm04.pdf",
-  funding = {MURI,ITR-MIT},
-  projects = {QA,MCR,TE},
-  comment = {Question Classification; Hierarchical classifiers; Sequential Model; Expressive Feature Generation with semantic information.},
-}
-
-@article{AgarwalAwRo04,
-  author = {S. Agarwal and A. Awan and D. Roth},
-  title = {Learning to Detect Objects in Images via a Sparse, Part-Based Representation},
-pages-omit = {1475--1490},
-  year = {2004},
-  journal = {IEEE Transactions on Pattern Analysis and Machine Intelligence},
-volume-omit = {20},
-number-omit = {11},
-url-omit = "http://cogcomp.org/papers/AgarwalAwRo04.pdf",
-  funding = {CAREER,ITR-MIT},
-  projects = {LV,KR},
-}
-
-@inproceedings{YihChKi04,
-  author = {W. Yih and P. Chang and W. Kim},
-  title = {Mining Online Deal Forums for Hot Deals},
-  booktitle = {Proc. of the IEEE/WIC/ACM International Conference on Web Intelligence (WI)},
-pages-omit = {384--390},
-  year = {2004},
-publisher-omit = {IEEE Computer Society},
-url-omit = "http://scottyih.org/YihChKi-wi04.pdf",
-  funding = {ITR-BI,MURI},
-  projects = {IIA},
-  comment = {Applying topic and sentiment text classification to online web forums},
-}
-
-@unpublished{RothYi04a,
-  author = {D. Roth and W. Yih},
-  title = {A Linear Programming Formulation for Global Inference in Natural Language Tasks},
-  booktitle = {Proc. of the International Symposium on Artificial Intelligence and Mathematics (AIM)},
-pages-omit = {1--8},
-  year = {2004},
-url-omit = "http://cogcomp.org/papers/RothYi04a.pdf",
-  funding = {ITR-BI,MURI,CLUSTER,XPRESSMP},
-  projects = {IE,LnI,CCM},
-  comment = {An early version of the CoNLL paper},
-  invisible = {true},
-}
-
-@article{PunyakanokRoYi04a,
-  author = {V. Punyakanok and D. Roth and W. Yih},
-  title = {Mapping Dependencies Trees: An Application to Question Answering},
-  booktitle = {Proc. of the International Symposium on Artificial Intelligence and Mathematics (AIM)},
-month-omit = {1},
-  year = {2004},
-  acceptance = {30-64 (47\%)},
-url-omit = "http://cogcomp.org/papers/PunyakanokRoYi04a.pdf",
-  funding = {MURI,KINDLE},
-  projects = {QA,KINDLE,TE},
-}
-
-@inproceedings{LiRo04b,
-  author = {X. Li and D. Roth},
-  title = {Supervised Discriminative Clustering},
-  booktitle = {Proc. of the Conference on Neural Information Processing Systems (NIPS) Workshop on Learning Structured Output},
-  year = {2004},
-url-omit = {},
-  funding = {MURI,TRECC},
-  projects = {LT},
-  comment = {Supervised Learning, Clustering, Metric Learning},
-  invisible = {true},
-}
-
-@inproceedings{PRYZ04a,
-  author = {V. Punyakanok and D. Roth and W. Yih and D. Zimak},
-  title = {Learning via Inference over Structurally Constrained Output},
-  booktitle = {Proc. of the Conference on Neural Information Processing Systems (NIPS) Workshop on Learning Structured Output},
-  year = {2004},
-url-omit = "http://cogcomp.org/papers/PRYZ04a.pdf",
-  funding = {ITR-BI,ITR-MIT,MURI,KINDLE,XPRESSMP},
-  projects = {LT,CCM},
-  comment = {Learning + Inference vs. Inference based Training Algorithms},
-  invisible = {true},
-}
-
-@techreport{BrazRo04,
-  author = {R. de Salvo Braz and D. Roth},
-  title = {Functional Subsumption in Feature Description Logic},
-  year = {2004},
-  institution = {UIUC Computer Science Department},
-number-omit = {UIUCDCS-R-2004-2423},
-url-omit = {},
-  funding = {ITR-BI,CAREER},
-  projects = {KINDLE,KR},
-  invisible = {true},
-}
-
-@techreport{HannekeRo04,
-  author = {S. Hanneke and D. Roth},
-  title = {Iterative Labeling for Semi-Supervised Learning},
-month-omit = {6},
-  year = {2004},
-  institution = {UIUC Computer Science Department},
-number-omit = {UIUCDCS-R-2004-2442},
-url-omit = "http://cogcomp.org/papers/HannekeRo04.pdf",
-  funding = {ITR-MIT,MURI,TRECC,CLUSTER},
-  projects = {LP,USS},
-  invisible = {true},
-}
-
-@techreport{BrazRoAm04,
-  author = {R. de Salvo Braz and D. Roth and E. Amir},
-  title = {First-order probabilistic inference revisited},
-month-omit = {6},
-  year = {2004},
-  institution = {UIUC Computer Science Department},
-number-omit = {UIUCDCS-R-2004-2443},
-url-omit = {},
-  funding = {ITR-BI},
-  projects = {KR,FOPI},
-  comment = {First order Probabilistic Inference without grounding.},
-  invisible = {true},
-}
-
-%%%%%%%%%%%%%%
-%%%  2003  %%%
-%%%%%%%%%%%%%%
-@inproceedings{HinrichsRo03,
-  author = {E. Hinrichs and D. Roth Program Chairs},
-  title = {Proceedings of the 41st Annual Meeting of the Association for Computational Linguistics},
-  year = {2003},
-  editor = {E. Hinrichs and D. Roth},
-url-omit = {},
-}
-
-@inproceedings{Har-PeledRoZi03,
-  author = {S. Har-Peled and D. Roth and D. Zimak},
-  title = {Constraint Classification for Multiclass Classification and Ranking},
-  booktitle = {Proc. of the Conference on Neural Information Processing Systems (NIPS)},
-pages-omit = {785--792},
-  year = {2003},
-  acceptance = {207/694 (30\%)},
-url-omit = "http://cogcomp.org/papers/nips02.pdf",
-  funding = {ITR-MIT ITR-BI CAREER},
-  projects = {CCR,LT,MC},
-}
-
-@inproceedings{CumbyRo03,
-  author = {C. Cumby and D. Roth},
-  title = {On Kernel Methods for Relational Learning},
-  booktitle = {Proc. of the International Conference on Machine Learning (ICML)},
-pages-omit = {107--114},
-  year = {2003},
-  acceptance = {118-371 (32\%)},
-url-omit = "http://cogcomp.org/papers/CumbyRo03.pdf",
-  funding = {NSF98,ITR-BI,CAREER},
-  projects = {LT,KR},
-  comment = {Parameterized kernels over structures. Relational Kernels. Advantages and disadvantages of graph kernels.},
-}
-
-@inproceedings{GargRo03,
-  author = {A. Garg and D. Roth},
-  title = {Margin Distribution and Learning Algorithms},
-  booktitle = {Proc. of the International Conference on Machine Learning (ICML)},
-pages-omit = {210--217},
-  year = {2003},
-  acceptance = {118/371 (32\%)},
-url-omit = "http://cogcomp.org/papers/GargRo03.pdf",
-  funding = {ITR-BI,ITR-MIT,CAREER},
-  projects = {LT,LCC},
-  comment = {Linear classifiers that optimize the margin distribution},
-}
-
-@inproceedings{LiRoTu03,
-  author = {X. Li and D. Roth and Y. Tu},
-  title = {Phrasenet: towards context sensitive lexical semantics},
-  booktitle = {Proc. of the Conference on Computational Natural Language Learning (CoNLL)},
-  year = {2003},
-url-omit = "http://cogcomp.org/papers/LiRoTu.pdf",
-  funding = {MURI,ITR-BI},
-  projects = {NLP, PHRASENET,LS},
-  comment = {Extending WordNet to taxonomy over phrases},
-}
-
-@workshop{CumbyRo03a,
-  author = {C. Cumby and D. Roth},
-  title = {Feature Extraction Languages for Propositionalized Relational Learning},
-  booktitle = {Proc. of the International Joint Conference on Artificial Intelligence (IJCAI)},
-  year = {2003},
-  acceptance = {33/40 (83\%)},
-url-omit = "http://cogcomp.org/papers/CumbyRo03a.pdf",
-  funding = {NSF98,ITR-BI,CAREER},
-  projects = {LT,KR,KINDLE},
-}
-
-@inproceedings{BrazRo03,
-  author = {R. de Salvo Braz and D. Roth},
-  title = {Functional subsumption in Description Logics},
-  booktitle = {Proc. of the Conference on Neural Information Processing Systems (NIPS) Workshop on Feature Extraction and Selection},
-  year = {2003},
-url-omit = {},
-  funding = {ITR-BI,CAREER},
-  projects = {KR,KINDLE},
-  comment = {Relational Feature Extraction; Feature Description Logic},
-}
-
-@techreport{LiMoRo03,
-  author = {X. Li and P. Morie and D. Roth},
-  title = {Robust Reading of Ambiguous Writing},
-month-omit = {8},
-  year = {2003},
-  institution = {UIUC Computer Science Department},
-number-omit = {UIUCDCS-R-2003-2371},
-url-omit = "http://cogcomp.org/papers/LiMoRo03.pdf",
-  funding = {MURI,ITR-BI},
-  projects = {MIRROR,COREF,NER},
-  invisible = {true},
-}
-
-@techreport{CumbyRo03c,
-  author = {C. Cumby and D. Roth},
-  title = {Kernel Methods for Relational Learning},
-month-omit = {5},
-  year = {2003},
-  institution = {UIUC Computer Science Department},
-number-omit = {UIUCDCS-R-2003-2345},
-url-omit = "http://cogcomp.org/papers/CumbyRo03c.pdf",
-  funding = {NSF98,ITR-BI,CAREER},
-  projects = {LT,KR},
-  invisible = {true},
-}
-
-@techreport{CumbyRo03b,
-  author = {C. Cumby and D. Roth},
-  title = {Feature Extraction Languages for Propositionalized Relational Learning},
-month-omit = {5},
-  year = {2003},
-  institution = {UIUC Computer Science Department},
-number-omit = {UIUCDCS-R-2003-2346},
-url-omit = "http://cogcomp.org/papers/CumbyRo03b.pdf",
-  funding = {NSF98,ITR-BI,CAREER},
-  projects = {LT,KR},
-  invisible = {true},
-}
-
-@techreport{AgarwalRo03,
-  author = {S. Agarwal and D. Roth},
-  title = {Minimum Risk Feature Transformations},
-month-omit = {12},
-  year = {2003},
-  institution = {UIUC Computer Science Department},
-number-omit = {UIUCDCS-R-2003-2627},
-url-omit = "http://cogcomp.org/papers/AgarwalRo03.pdf",
-  comment = {UIUC Tech Report UIUCDCS-R-2003-2627. A preliminary framework for Feature Generation},
-}
-
-%%%%%%%%%%%%%%
-%%%  2002  %%%
-%%%%%%%%%%%%%%
-@inproceedings{Rothva02,
-  author = {D. Roth and A. van den Bosch Program Chairs},
-  title = {Proceedings of CoNLL 2002, the Sixth Workshop on Computational Natural Language Learning},
-  year = {2002},
-  editor = {D. Roth and A. van den Bosch},
-url-omit = {},
-}
-
-@inproceedings{GargHaRo02,
-  author = {A. Garg and S. Har-Peled and D. Roth},
-  title = {On generalization bounds, projection profile, and margin distribution},
-  booktitle = {Proc. of the International Conference on Machine Learning (ICML)},
-pages-omit = {171--178},
-  year = {2002},
-  acceptance = {86/261 (33\%)},
-url-omit = "http://cogcomp.org/papers/icml02.pdf",
-  funding = {ITR-MIT,ITR-BI,CAREER},
-  projects = {LCC,LT},
-  comment = {Random Projection; Generalization Bounds for Linear Classifiers.},
-}
-
-@inproceedings{CumbyRo02,
-  author = {C. Cumby and D. Roth},
-  title = {Learning with Feature Description Logics},
-  booktitle = {Proc. of the International Conference on Inductive Logic Programming (ILP)},
-pages-omit = {32--47},
-  year = {2002},
-url-omit = "http://cogcomp.org/papers/ilp02.pdf",
-  funding = {NSF98,ITR-MIT,CAREER},
-  projects = {KR,KINDLE},
-  comment = {A Description Logic based Formalism for Feature Extraction; Expressive Features; A language for Feature Extraction},
-}
-
-@inproceedings{RothYi02,
-  author = {D. Roth and W. Yih},
-  title = {Probabilistic Reasoning for Entity and Relation Recognition},
-  booktitle = {Proc. of the International Conference on Computational Linguistics (COLING)},
-pages-omit = {835--841},
-  year = {2002},
-  acceptance = {198-435 (45\%)},
-url-omit = "http://cogcomp.org/papers/er-coling02.pdf",
-  funding = {MURI,ITR-MIT},
-  projects = {IE,NE,LnI,NER},
-  comment = {Entity And Relation Recognition. Simultaneous Identification of Entities and Relations.},
-}
-
-@inproceedings{LiRo02,
-  author = {X. Li and D. Roth},
-  title = {Learning Question Classifiers},
-  booktitle = {Proc. of the International Conference on Computational Linguistics (COLING)},
-pages-omit = {556--562},
-  year = {2002},
-  acceptance = {198-435 (45\%)},
-url-omit = "http://cogcomp.org/papers/qc-coling02.pdf",
-  funding = {NSF98,MURI,ITR-MIT},
-  projects = {CCR,QA,TE},
-  comment = {Classifying Answer Type for Question Answering. Sequential Classification. Multiclass Classification.},
-}
-
-@inproceedings{CMPR02,
-  author = {X. Carreras and L. Marquez and V. Punyakanok and D. Roth},
-  title = {Learning and Inference for Clause Identification},
-  booktitle = {Proc. of the European Conference on Machine Learning (ECML)},
-pages-omit = {35--47},
-  year = {2002},
-  acceptance = {80/218 (37\%)},
-url-omit = "http://cogcomp.org/papers/ecml02.pdf",
-  funding = {MURI,SBC-MIT,CAREER},
-  projects = {LnI,SI,IE},
-  comment = {Shallow Parsing; Chunking and Clause identification.},
-}
-
-@inproceedings{Har-PeledRoZi02,
-  author = {S. Har-Peled and D. Roth and D. Zimak},
-  title = {Constraint Classification: a new approach to Multiclass Classification},
-  booktitle = {Proc. of the International Workshop on Algorithmic Learning Theory (ALT)},
-pages-omit = {135--150},
-  year = {2002},
-publisher-omit = {Springer-Verlag},
-  acceptance = {21/42 (50\%)},
-url-omit = "http://cogcomp.org/papers/Har-PeledRoZi02.pdf",
-  funding = {ITR-MIT,ITR-BI,CAREER},
-  projects = {CCR,LT,MC},
-}
-
-@inproceedings{AgarwalRo02,
-  author = {S. Agarwal and D. Roth},
-  title = {Learning a Sparse Representation for Object Detection},
-  booktitle = {Proc. of the European Conference on Computer Vision (ECCV)},
-pages-omit = {113--128},
-  year = {2002},
-  acceptance = {45/600 (7.5\%) Oral Presentations; 225/600 (37\%) overall},
-url-omit = "http://cogcomp.org/papers/AgarwalRo02.pdf",
-  funding = {MURI,SBC-MIT,CAREER},
-  projects = {LV,KR},
-}
-
-@inproceedings{YangRoAh02,
-  author = {M. Yang and D. Roth and N. Ahuja},
-  title = {A Tale of Two Classifiers: SNoW vs. SVM in Visual Recognition},
-  booktitle = {Proc. of the European Conference on Computer Vision (ECCV)},
-pages-omit = {685--700},
-  year = {2002},
-  acceptance = {45/600 (7.5\%) Oral Presentations; 225/600 (37\%) overall},
-url-omit = "http://cogcomp.org/papers/YangRoAh02.pdf",
-  funding = {NSF98,ITR-MIT},
-  projects = {LT,LV},
-}
-
-@article{RothYaAh02,
-  author = {D. Roth and M. Yang and N. Ahuja},
-  title = {Learning to Recognize 3D Objects},
-pages-omit = {1071--1104},
-  year = {2002},
-  journal = {Neural Computation},
-volume-omit = {14},
-number-omit = {5},
-  acceptance = {NSF98,ITR-MIT},
-url-omit = "http://cogcomp.org/papers/objectsJ.pdf",
-  funding = {LT,LV},
-}
-
-@inproceedings{RCLMNPRSY02,
-  author = {D. Roth and C. Cumby and X. Li and P. Morie and R. Nagarajan and V. Punyakanok and N. Rizzolo and K. Small and W. Yih},
-  title = {Question-Answering via Enhanced Understanding of Questions},
-  booktitle = {Proc. of the Text Retrieval Conference (TREC)},
-  year = {2002},
-url-omit = "http://cogcomp.org/papers/trec02.pdf",
-  funding = {NSF98,MURI,ITR-MIT},
-  projects = {QA,TE},
-}
-
-@article{GreinerGrRo02,
-  author = {R. Greiner and A. Grove and D. Roth},
-  title = {Learning Cost-Sensitive Active Classifiers},
-pages-omit = {137--174},
-  year = {2002},
-  journal = {Artificial Intelligence},
-volume-omit = {139},
-number-omit = {2},
-url-omit = "http://cogcomp.org/papers/activeJ.pdf",
-  funding = {NSF98 CAREER},
-  projects = {DPL,LT,LP},
-  comment = {Earlier version appeared in ICML'96},
-}
-
-%%%%%%%%%%%%%%
-%%%  2001  %%%
-%%%%%%%%%%%%%%
-@inproceedings{KhardonRoSe02,
-  author = {R. Khardon and D. Roth and R. Servedio},
-  title = {Efficiency versus Convergence of Boolean Kernels for On-Line Learning Algorithms},
-  booktitle = {Proc. of the Conference on Neural Information Processing Systems (NIPS)},
-  year = {2001},
-url-omit = "http://cogcomp.org/papers/kernels01.pdf",
-  funding = {ITR-MIT,NSF98,CAREER},
-  projects = {KR,LT},
-  comment = {Kernel Perceptron with Exponentially Many mistakes; Hardness of Kernel Winnow.},
-}
-
-@inproceedings{PunyakanokRo01,
-  author = {V. Punyakanok and D. Roth},
-  title = {The Use of Classifiers in Sequential Inference},
-  booktitle = {Proc. of the Conference on Neural Information Processing Systems (NIPS)},
-pages-omit = {995--1001},
-  year = {2001},
-publisher-omit = {MIT Press},
-  acceptance = {25/514 (4.8\%) Oral Presentations; 152/514 (29\%) overall},
-url-omit = "http://cogcomp.org/papers/nips01.pdf",
-  funding = {NSF98 CAREER},
-  projects = {LnI,SI,IE,NE,NLP,CCM},
-  comment = {Structured, sequential output; Sequence Prediction: HMM with classifiers, Conditional Models, Constraint Satisfaction},
-}
-
-@inproceedings{RothYi01,
-  author = {D. Roth and W. Yih},
-  title = {Relational Learning via Propositional Algorithms: An Information Extraction Case Study},
-  booktitle = {Proc. of the International Joint Conference on Artificial Intelligence (IJCAI)},
-pages-omit = {1257--1263},
-  year = {2001},
-  acceptance = {197/796 (25\%)},
-url-omit = "http://cogcomp.org/papers/ijcai01.pdf",
-  funding = {ITR-MIT NSF98 MURI},
-  projects = {KR,IE,NE},
-  comment = {Expressive, Relational Features for Information Extraction},
-}
-
-@inproceedings{Roth01,
-  author = {D. Roth},
-  title = {Reasoning with Classifiers},
-  booktitle = {Proc. of the European Conference on Machine Learning (ECML)},
-pages-omit = {506--510},
-  year = {2001},
-  acceptance = {197/796 (25\%)},
-url-omit = {},
-  funding = {ITR-MIT NSF98 CAREER},
-  projects = {LnI,SI,IE,NE},
-  comment = {Paper written to accompany an invited talk at ECML'01. Sequential Inference: Conditional Models, Constraint Satisfaction},
-}
-
-@inproceedings{GargRo01,
-  author = {A. Garg and D. Roth},
-  title = {Understanding Probabilistic Classifiers},
-  booktitle = {Proc. of the European Conference on Machine Learning (ECML)},
-pages-omit = {179--191},
-  year = {2001},
-  acceptance = {90/240 (37.5\%)},
-url-omit = "http://cogcomp.org/papers/ecml01.pdf",
-  funding = {ITR-MIT ITR-BI CAREER NSF98},
-  projects = {DPL,LT},
-  comment = {An Information Theory based explanation of the good performance of naive Bayes},
-}
-
-@inproceedings{GargRo01a,
-  author = {A. Garg and D. Roth},
-  title = {Learning Coherent Concepts},
-  booktitle = {Proc. of the International Workshop on Algorithmic Learning Theory (ALT)},
-pages-omit = {135--150},
-  year = {2001},
-publisher-omit = {Springer-Verlag},
-  acceptance = {21/42 (50\%)},
-url-omit = "http://cogcomp.org/papers/alt01.pdf",
-  funding = {ITR-MIT ITR-BI CAREER},
-  projects = {LCC,LT},
-}
-
-@inproceedings{LiRo01,
-  author = {X. Li and D. Roth},
-  title = {Exploring Evidence for Shallow Parsing},
-  booktitle = {Proc. of the Conference on Computational Natural Language Learning (CoNLL)},
-pages-omit = {107--110},
-  year = {2001},
-url-omit = "http://cogcomp.org/papers/conll01.pdf",
-  funding = {ITR-MIT,NSF98,MURI},
-  projects = {LnI,SI,IE,NE,NLP},
-  comment = {Learning Shallow Parsers vs. Full Parsers for Chunking tasks},
-}
-
-@inproceedings{Even-ZoharRo01,
-  author = {Y. Even-Zohar and D. Roth},
-  title = {A Sequential Model for Multi Class Classification},
-  booktitle = {Proc. of the Conference on Empirical Methods in Natural Language Processing (EMNLP)},
-pages-omit = {10-19},
-  year = {2001},
-  acceptance = {21/65 (32\%)},
-url-omit = "http://cogcomp.org/papers/emnlp01.pdf",
-  funding = {ITR-MIT,NSF98,KDI},
-  projects = {MCR,LT,MC},
-  comment = {Multiclass classification: reducing the number of candidate classes; part-of-speech (POS) tagging},
-}
-
-@inproceedings{ChuangRo01a,
-  author = {J. Chuang and D. Roth},
-  title = {Gene Recognition based on DAG shortest paths},
-  booktitle = {Proc. of the International Conference on Intelligent Systems for Molecular Biology (ISMB)},
-pages-omit = {1--9},
-  year = {2001},
-  acceptance = {40/180 (22\%)},
-url-omit = "http://cogcomp.org/papers/ismb01.pdf",
-  funding = {NSF98,CAREER},
-  projects = {LnI,SI,LT},
-}
-
-@article{ChuangRo01,
-  author = {J. Chuang and D. Roth},
-  title = {Gene Recognition based on DAG shortest paths},
-pages-omit = {S56--S64},
-month-omit = {7},
-  year = {2001},
-  journal = {Bioinformatics},
-volume-omit = {17},
-number-omit = {1},
-url-omit = "http://cogcomp.org/papers/ismb01.pdf",
-  funding = {NSF98,CAREER},
-  projects = {LnI,SI,LT},
-}
-
-@inproceedings{CarlsonRoRo01,
-  author = {A. Carlson and J. Rosen and D. Roth},
-  title = {Scaling Up Context Sensitive Text Correction},
-  booktitle = {Proc. of the Conference on Innovative Applications of Artificial Intelligence (IAAI)},
-pages-omit = {45--50},
-  year = {2001},
-  acceptance = {12/37 (32\%)},
-url-omit = "http://cogcomp.org/papers/iaai01.pdf",
-  funding = {NSF98,CAREER,IBM},
-  projects = {LT,NLP},
-}
-
-@inproceedings{RKLNPRYAM01,
-  author = {D. Roth and G. Kao and X. Li and R. Nagarajan and V. Punyakanok and N. Rizzolo and W. Yih and C. Alm and L. G. Moran},
-  title = {Learning Components for a Question Answering System},
-  booktitle = {Proc. of the Text Retrieval Conference (TREC)},
-pages-omit = {539-548},
-  year = {2001},
-url-omit = "http://cogcomp.org/papers/trec01.pdf",
-  funding = {NSF98,MURI,ITR-MIT},
-  projects = {QA,TE},
-}
-
-@inproceedings{YangRoAh01,
-  author = {M. Yang and D. Roth and N. Ahuja},
-  title = {Face Detection Using Large Margin Classifiers},
-  booktitle = {Proc. of the IEEE International Conference on Image Processing (ICIP)},
-pages-omit = {665--668},
-  year = {2001},
-url-omit = "http://cogcomp.org/papers/YangRoAh01.pdf",
-  funding = {NSF98,ITR-MIT,CAREER},
-  projects = {LV,LT},
-}
-
-@techreport{RothYi01a,
-  author = {D. Roth and W. Yih},
-  title = {Propositionalization of Relational Learning: An Information Extraction Case Study},
-month-omit = {3},
-  year = {2001},
-  institution = {UIUC Computer Science Department},
-number-omit = {UIUCDCS-R-2001-2206},
-url-omit = "http://cogcomp.org/papers/RothYi01a.pdf",
-  funding = {NSF98,MURI,ITR-MIT},
-  projects = {KR,IE,NE},
-}
-
-@techreport{KhardonRoSe01a,
-  author = {R. Khardon and D. Roth and R. Servedio},
-  title = {Efficiency versus Convergence of Boolean Kernels for On-Line Learning Algorithm},
-month-omit = {6},
-  year = {2001},
-  institution = {UIUC Computer Science Department},
-number-omit = {UIUCDCS-R-2001-2233},
-url-omit = "http://cogcomp.org/papers/KhardonRoSe01a.pdf",
-  funding = {ITR-MIT,NSF98,CAREER},
-  projects = {KR,LT},
-  invisible = {true},
-}
-
-@article{GroveRo01,
-  author = {A. Grove and D. Roth},
-  title = {Linear concepts and hidden variables},
-pages-omit = {123--141},
-  year = {2001},
-  journal = {Machine Learning},
-volume-omit = {42},
-number-omit = {1/2},
-url-omit = "http://cogcomp.org/papers/hiddenJ.pdf",
-  funding = {NSF98,CAREER},
-  projects = {DPL,LT},
-}
-
-@techreport{GargRo01b,
-  author = {A. Garg and D. Roth},
-  title = {Understanding Probabilistic Classifiers},
-month-omit = {3},
-  year = {2001},
-  institution = {UIUC Computer Science Department},
-number-omit = {UIUCDCS-R-2001-2205},
-url-omit = "http://cogcomp.org/papers/GargRo01b.pdf",
-  funding = {ITR-MIT,ITR-BI,CAREER,NSF98},
-  projects = {DPL,LT},
-  invisible = {true},
-}
-
-@techreport{GargHaRo01,
-  author = {A. Garg and S. Har-Peled and D. Roth},
-  title = {Generalization Bounds for Linear Learning Algorithms},
-month-omit = {6},
-  year = {2001},
-  institution = {UIUC Computer Science Department},
-number-omit = {UIUCDCS-R-2001-2232},
-url-omit = "http://cogcomp.org/papers/GargHaRo01.pdf",
-  funding = {ITR-MIT,ITR-BI,CAREER},
-  projects = {LCC,LT},
-  invisible = {true},
-}
-
-@thesis{Cumby01,
-  author = {C. Cumby},
-  title = {Learning family relationships via propositional means},
-month-omit = {5},
-  year = {2001},
-url-omit = "http://cogcomp.org/papers/family.pdf",
-  funding = {NSF98,KDI},
-  projects = {KR,LT},
-  comment = {Senior Thesis, UIUC, Dept. of Computer Science},
-}
-
-@thesis{Carlson01,
-  author = {A. Carlson},
-  title = {Learning Based Programming - An Implementation},
-  booktitle = {UIUC Senior Thesis},
-month-omit = {5},
-  year = {2001},
-url-omit = {},
-  comment = {Senior Thesis, UIUC, Dept. of Computer Science},
-}
-
-@unpublished{AgarwalRo01,
-  author = {S. Agarwal and D. Roth},
-  title = {Detecting objects by learning relations over parts},
-month-omit = {6},
-  year = {2001},
-  institution = {UIUC Computer Science Department},
-number-omit = {UIUCDCS-R-2001-2231},
-url-omit = "http://cogcomp.org/papers/AgarwalRo01.pdf",
-  invisible = {true},
-}
-
-%%%%%%%%%%%%%%
-%%%  2000  %%%
-%%%%%%%%%%%%%%
-@inproceedings{RothZe00,
-  author = {D. Roth and D. Zelenko},
-  title = {Towards a theory of Coherent Concepts},
-  booktitle = {Proc. of the Conference on Artificial Intelligence (AAAI)},
-pages-omit = {639--644},
-  year = {2000},
-  acceptance = {141/430 (33\%)},
-url-omit = "http://cogcomp.org/papers/aaai00.pdf",
-}
-
-@inproceedings{KDDKKPR00,
-  author = {E. F. T. Kim-Sang and W. Daelemans and H. Dejean and R. Koeling and Y. Krymolowski and V. Punyakanok and D. Roth},
-  title = {Applying System Combination to Base Noun Phrase Identification},
-  booktitle = {Proc. of the International Conference on Computational Linguistics and Annual Meeting of the Association for Computational Linguistics (COLING-ACL)},
-pages-omit = {857--863},
-  year = {2000},
-url-omit = "http://cogcomp.org/papers/KDDKKPR00.pdf",
-  funding = {NSF98,KDI},
-}
-
-@inproceedings{Even-ZoharRo00,
-  author = {Y. Even-Zohar and D. Roth},
-  title = {A classification approach to word prediction},
-  booktitle = {Proc. of the Annual Conference of the North American Chapter of the Association for Computational Linguistics (NAACL)},
-pages-omit = {124-131},
-  year = {2000},
-  acceptance = {43/166 (26\%)},
-url-omit = "http://cogcomp.org/papers/naacl00.pdf",
-  funding = {NSF98,KDI},
-  projects = {LT,KR},
-  comment = {Learning with expressive features; dependency parse based features; verb prediction},
-}
-
-@inproceedings{CumbyRo00,
-  author = {C. Cumby and D. Roth},
-  title = {Relational Representations that facilitate learning},
-  booktitle = {Proc. of the International Conference on Principles of Knowledge Representation and Reasoning (KR)},
-pages-omit = {425--434},
-  year = {2000},
-  acceptance = {62/172 (36\%)},
-url-omit = "http://cogcomp.org/papers/kr00.pdf",
-  funding = {NSF98,KDI},
-  projects = {LT,KR},
-  comment = {FEX: feature extraction language; relational features; relational generation functions},
-}
-
-@inproceedings{Roth00,
-  author = {D. Roth},
-  title = {Learning in Natural Language: Theory and Algorithmic Approaches},
-  booktitle = {Proc. of the Conference on Computational Natural Language Learning (CoNLL)},
-pages-omit = {1--6},
-  year = {2000},
-address-omit = {Lisbon, Portugal},
-url-omit = "http://cogcomp.org/papers/lnlp-conll.pdf",
-  funding = {ITR-MIT,NSF98,KDI},
-  comment = {A paper written to accompany and invited talk at CoNLL.},
-}
-
-@inproceedings{YangRoAh00b,
-  author = {M. Yang and D. Roth and N. Ahuja},
-  title = {A SNoW-based Face Detector},
-  booktitle = {Proc. of the Conference on Neural Information Processing Systems (NIPS)},
-pages-omit = {855--861},
-  year = {2000},
-publisher-omit = {MIT Press},
-  acceptance = {151/467 (32\%)},
-url-omit = "http://cogcomp.org/papers/nips00.pdf",
-  funding = {NSF98},
-}
-
-@inproceedings{YangRoAh00a,
-  author = {M. Yang and D. Roth and N. Ahuja},
-  title = {Learning To Recognize 3D Objects With SNoW},
-  booktitle = {Proc. of the European Conference on Computer Vision (ECCV)},
-month-omit = {6},
-  year = {2000},
-  acceptance = {43/266 (16\%) Oral Presentations; 115/266 (43\%) overall},
-url-omit = "http://cogcomp.org/papers/YangRoAh00a.pdf",
-}
-
-@inproceedings{YangRoAh00,
-  author = {M. Yang and D. Roth and N. Ahuja},
-  title = {View-Based 3D Object Recognition Using SNoW},
-  booktitle = {Proc. of the Asian Conference on Computer Vision (ACCV)},
-pages-omit = {830--835},
-month-omit = {1},
-  year = {2000},
-volume-omit = {2},
-  acceptance = {172/268 (64\%)},
-url-omit = "http://cogcomp.org/papers/accv00.pdf",
-}
-
-@inproceedings{RothYaAh00,
-  author = {D. Roth and M. Yang and N. Ahuja},
-  title = {Learning to Recognize Objects},
-  booktitle = {Proc. of the IEEE Conference on Computer Vision and Pattern Recognition (CVPR)},
-pages-omit = {724--731},
-  year = {2000},
-  acceptance = {200/466 (43\%)},
-url-omit = "http://cogcomp.org/papers/cvpr00.pdf",
-  funding = {NSF98},
-}
-
-@techreport{Roth00a,
-  author = {D. Roth},
-  title = {Learning in Natural Language},
-month-omit = {7},
-  year = {2000},
-  institution = {UIUC Computer Science Department},
-number-omit = {UIUCDCS-R-2000-2180},
-url-omit = "http://cogcomp.org/papers/Roth00a.pdf",
-  invisible = {true},
-}
-
-@techreport{PunyakanokRo00a,
-  author = {V. Punyakanok and D. Roth},
-  title = {The Use of Classifiers in Sequential Inference},
-month-omit = {7},
-  year = {2000},
-  institution = {UIUC Computer Science Department},
-number-omit = {UIUCDCS-R-2000-2181},
-url-omit = "http://cogcomp.org/papers/PunyakanokRo00a.pdf",
-  invisible = {true},
-}
-
-@inproceedings{PunyakanokRo00,
-  author = {V. Punyakanok and D. Roth},
-  title = {Shallow Parsing by Inferencing with Classifiers},
-  booktitle = {Proc. of the Conference on Computational Natural Language Learning (CoNLL)},
-pages-omit = {107--110},
-  year = {2000},
-url-omit = "http://cogcomp.org/papers/PunyakanokRo00.pdf",
-  funding = {ITR-MIT NSF98},
-}
-
-@techreport{MengshoelRoWi00b,
-  author = {O. Mengshoel and D. Roth and D. Wilkins},
-  title = {Hard and Easy Bayesian Networks for Computing the Most Probable Explanation},
-month-omit = {1},
-  year = {2000},
-  institution = {UIUC Computer Science Department},
-number-omit = {UIUCDCS-R-2000-2147},
-url-omit = "http://cogcomp.org/papers/MengshoelRoWi00b.pdf",
-  invisible = {true},
-}
-
-%%%%%%%%%%%%%%
-%%%  1999  %%%
-%%%%%%%%%%%%%%
-@inproceedings{Roth99,
-  author = {D. Roth},
-  title = {Learning in Natural Language},
-  booktitle = {Proc. of the International Joint Conference on Artificial Intelligence (IJCAI)},
-pages-omit = {898--904},
-  year = {1999},
-  acceptance = {195/760 (26\%)},
-url-omit = "http://cogcomp.org/papers/ijcai99r.pdf",
-  funding = {NSF98 KDI},
-  projects = {LT,DPL},
-  comment = {Probabilistic classifiers (Naive Bayes; HMM) as linear models; generative vs. discriminative; Best Paper Award},
-}
-
-@inproceedings{MPRZ99a,
-  author = {M. Munoz and V. Punyakanok and D. Roth and D. Zimak},
-  title = {A Learning Approach to Shallow Parsing},
-  booktitle = {Proc. of the Joint Conference on Empirical Methods in Natural Language Processing and Very Large Corpora (EMNLP-VLC)},
-pages-omit = {168--178},
-month-omit = {6},
-  year = {1999},
-url-omit = "http://cogcomp.org/papers/shallow-long.pdf",
-  funding = {NSF98 KDI},
-  projects = {LnI,SI,NLP},
-}
-
-@inproceedings{KhardonRoVa99,
-  author = {R. Khardon and D. Roth and L. G. Valiant},
-  title = {Relational Learning for NLP using Linear Threshold Elements},
-  booktitle = {Proc. of the International Joint Conference on Artificial Intelligence (IJCAI)},
-pages-omit = {911--917},
-  year = {1999},
-  acceptance = {195/750 (26\%)},
-url-omit = "http://cogcomp.org/papers/ijcai99krv.pdf",
-  funding = {NSF98 KDI},
-  projects = {KR,LT,NLP},
-}
-
-@article{KhardonRo99,
-  author = {R. Khardon and D. Roth},
-  title = {Learning to Reason with a Restricted View},
-pages-omit = {95--117},
-  year = {1999},
-  journal = {Machine Learning},
-volume-omit = {35},
-number-omit = {2},
-url-omit = "http://cogcomp.org/papers/partialJ.pdf",
-}
-
-@article{KhardonMaRo99,
-  author = {R. Khardon and H. Mannila and D. Roth},
-  title = {Reasoning with Examples: Propositional Formulae and Database Dependencies},
-pages-omit = {267--286},
-month-omit = {7},
-  year = {1999},
-  journal = {Acta Informatica},
-volume-omit = {36},
-number-omit = {4},
-url-omit = "http://cogcomp.org/papers/db.pdf",
-}
-
-@article{GoldingRo99,
-  author = {A. R. Golding and D. Roth},
-  title = {A Winnow based approach to Context-Sensitive Spelling Correction},
-pages-omit = {107--130},
-  year = {1999},
-  journal = {Machine Learning},
-volume-omit = {34},
-number-omit = {1-3},
-url-omit = "http://cogcomp.org/papers/spellJ.pdf",
-  funding = {NSF98 KDI},
-  projects = {KR,LT,NLP},
-  comment = {Special Issue on Machine Learning and Natural Language.},
-}
-
-@incollection{RothZe99,
-  author = {D. Roth and D. Zelenko},
-  title = {Coherent Concepts, Robust Learning Invited},
-  booktitle = {Proc. of the Conference on Current Trends in Theory and Practice of Informatics (SOFSEM)},
-pages-omit = {260--272},
-  year = {1999},
-publisher-omit = {Springer-verlag},
-  editor = {J. Pavelka and G. Tel and  M. Bartosek},
-url-omit = "http://cogcomp.org/papers/RothZe99.pdf",
-  comment = {Lecture notes in Artificial Intelligence, vol. 1725},
-}
-
-@techreport{Roth99c,
-  author = {D. Roth},
-  title = {Learning Based Programming},
-month-omit = {10},
-  year = {1999},
-  institution = {UIUC Computer Science Department},
-number-omit = {UIUCDCS-R-99-2127},
-url-omit = "http://cogcomp.org/papers/Roth99c.pdf",
-}
-
-@techreport{Roth99b,
-  author = {D. Roth},
-  title = {Relational Knowledge Representations that Facilitate Learning},
-month-omit = {10},
-  year = {1999},
-  institution = {UIUC Computer Science Department},
-number-omit = {UIUCDCS-R-99-2126},
-url-omit = "http://cogcomp.org/papers/Roth99b.pdf",
-  invisible = {true},
-}
-
-@techreport{Roth99a,
-  author = {D. Roth},
-  title = {Memory Based Learning in NLP},
-month-omit = {3},
-  year = {1999},
-  institution = {UIUC Computer Science Department},
-number-omit = {UIUCDCS-R-99-2125},
-url-omit = "http://cogcomp.org/papers/mbl.pdf",
-}
-
-@article{MavronicolasRo99,
-  author = {M. Mavronicolas and D. Roth},
-  title = {Linearizable Read/Write Objects},
-pages-omit = {267--319},
-month-omit = {6},
-  year = {1999},
-  journal = {Theoretical Computer Science},
-volume-omit = {220},
-number-omit = {1},
-url-omit = "http://cogcomp.org/papers/linearJ.pdf",
-}
-
-@techreport{MPRZ99b,
-  author = {M. Munoz and V. Punyakanok and D. Roth and D. Zimak},
-  title = {A Learning Approach to Shallow Parsing},
-month-omit = {4},
-  year = {1999},
-  institution = {UIUC Computer Science Department},
-number-omit = {UIUCDCS-R-99-2087},
-url-omit = "http://cogcomp.org/papers/MPRZ99b.pdf",
-  invisible = {true},
-}
-
-@inproceedings{Even-ZoharRoZe99,
-  author = {Y. Even-Zohar and D. Roth and D. Zelenko},
-  title = {Word Clustering via Classification},
-  booktitle = {Proc. of the Bar-Ilan Symposium on Foundations of Artificial Intelligence (BISFAI)},
-  year = {1999},
-address-omit = {Bar-Ilan, Israel},
-  acceptance = {78/160 (48\%)},
-url-omit = "http://cogcomp.org/papers/Even-ZoharRoZe99.pdf",
-  funding = {NSF98,KDI},
-}
-
-@techreport{CCRR99,
-  author = {A. Carlson and C. Cumby and J. Rosen and D. Roth},
-  title = {The SNoW Learning Architecture},
-month-omit = {5},
-  year = {1999},
-  institution = {UIUC Computer Science Department},
-number-omit = {UIUCDCS-R-99-2101},
-url-omit = "http://cogcomp.org/papers/CCRR99.pdf",
-}
-
-%%%%%%%%%%%%%%
-%%%  1998  %%%
-%%%%%%%%%%%%%%
-@inproceedings{RothZe98,
-  author = {D. Roth and D. Zelenko},
-  title = {Part of Speech Tagging Using a Network of Linear Separators},
-  booktitle = {Coling-Acl, The 17th International Conference on Computational Linguistics},
-pages-omit = {1136--1142},
-  year = {1998},
-  acceptance = {137/550 (25\%)},
-url-omit = "http://cogcomp.org/papers/pos.pdf",
-  funding = {NSF98,KDI},
-  projects = {SI,NLP},
-}
-
-@inproceedings{Roth98,
-  author = {D. Roth},
-  title = {Learning to Resolve Natural Language Ambiguities: A Unified Approach},
-  booktitle = {Proc. of the Conference on Artificial Intelligence (AAAI)},
-pages-omit = {806--813},
-  year = {1998},
-  acceptance = {143/475 (30\%)},
-url-omit = "http://cogcomp.org/papers/aaai98.pdf",
-  funding = {NSF98,KDI},
-  projects = {DPL,NLP},
-  comment = {Many Natural Language Classifiers are Linear; including probabilistic classifiers; argues for a discriminative approach; SNoW},
-}
-
-@article{Roth98a,
-  author = {D. Roth},
-  title = {Learning and Reasoning with Connectionist Representations},
-  booktitle = {Neural Computing Surveys},
-pages-omit = {1--40},
-  year = {1998},
-publisher-omit = {Lawrence Erlbaum Associates},
-  editor = {A. Jagota, T. Plate, L. Shastri, R. Sun},
-url-omit = "http://cogcomp.org/papers/Roth98a.pdf",
-  comment = {A contribution to ``Connectionist Symbol Processing: Dead or Alive''},
-}
-
-@workshop{KrymolowskiRo98,
-  author = {Y. Krymolowski and D. Roth},
-  title = {Incorporating Knowledge in Natural Language Learning: A Case Study},
-  booktitle = {Coling-Acl workshop on the Usage of WordNet in Natural Language Processing Systems},
-pages-omit = {121--127},
-  year = {1998},
-url-omit = "http://cogcomp.org/papers/pp-wn.pdf",
-  funding = {NSF98,KDI},
-  projects = {NLP},
-  comment = {Prepositional Phrase Attachment (PPA); using WordNet to generate expressive features.},
-}
-
-@inproceedings{GroveRo98,
-  author = {A. Grove and D. Roth},
-  title = {Linear concepts and hidden variables: An empirical study},
-  booktitle = {Proc. of the Conference on Neural Information Processing Systems (NIPS)},
-pages-omit = {500--506},
-  year = {1998},
-publisher-omit = {MIT Press},
-  acceptance = {150/491 (30\%)},
-url-omit = "http://cogcomp.org/papers/nips98.pdf",
-  comment = {Margin Winnow (Perceptron); discriminative vs. generative},
-}
-
-@inproceedings{BasriRoJa98,
-  author = {R. Basari and D. Roth and D. Jacobs},
-  title = {Clustering Appearances of 3D Objects},
-  booktitle = {Proc. of the IEEE Conference on Computer Vision and Pattern Recognition (CVPR)},
-pages-omit = {414-420},
-  year = {1998},
-  acceptance = {136/450 (30\%)},
-url-omit = "http://cogcomp.org/papers/cvpr98.pdf",
-  comment = {Clustering of Curves},
-}
-
-@article{ABKKPR98,
-  author = {H. Aizenstein and A. Blum and R. Khardon and A. Kushilevitz and L. Pitt and D. Roth},
-  title = {On learning read-k satisfy-j DNF},
-pages-omit = {1515--1530},
-month-omit = {7},
-  year = {1998},
-  journal = {SIAM Journal of Computing},
-volume-omit = {27},
-number-omit = {6},
-url-omit = "http://cogcomp.org/papers/rksjJ.pdf",
-}
-
-%%%%%%%%%%%%%%
-%%%  1997  %%%
-%%%%%%%%%%%%%%
-@incollection{Roth97,
-  author = {D. Roth},
-  title = {Learning to perform knowledge intensive inferences Invited Abstract},
-  booktitle = {Proc. of the International Symposium on the Mathematical Foundations of Computer Science (MFCS)},
-pages-omit = {108--109},
-  year = {1997},
-publisher-omit = {Springer-verlag},
-  editor = {I. Privara  and P. Ruzicka},
-url-omit = {},
-  comment = {Lecture notes in Computer Science (LNCS) 1295},
-}
-
-@article{KhardonRo97a,
-  author = {R. Khardon and D. Roth},
-  title = {Defaults and Relevance in Model Based Reasoning},
-pages-omit = {169--193},
-month-omit = {12},
-  year = {1997},
-  journal = {Artificial Intelligence},
-volume-omit = {97},
-number-omit = {1-2},
-url-omit = "http://cogcomp.org/papers/relevanceJ.pdf",
-}
-
-@article{KhardonRo97,
-  author = {R. Khardon and D. Roth},
-  title = {Learning to Reason},
-pages-omit = {697--725},
-  year = {1997},
-  journal = {Journal of the ACM},
-volume-omit = {44},
-number-omit = {5},
-url-omit = "http://cogcomp.org/papers/l2rJ.pdf",
-}
-
-@article{DanielsMiRo97,
-  author = {K. Daniels and V. J. Milenkovic and D. Roth},
-  title = {Finding the Maximum Area Axis-Parallel Rectangle in a Polygon},
-pages-omit = {125--148},
-month-omit = {1},
-  year = {1997},
-  journal = {Computational Geometry: Theory and Applications},
-volume-omit = {7},
-number-omit = {1-2},
-url-omit = "http://cogcomp.org/papers/maaprJ.pdf",
-}
-
-@inproceedings{DaganKaRo97,
-  author = {I. Dagan and Y. Karov and D. Roth},
-  title = {Mistake-Driven Learning in Text Categorization},
-  booktitle = {Proc. of the Conference on Empirical Methods in Natural Language Processing (EMNLP)},
-pages-omit = {55-63},
-month-omit = {8},
-  year = {1997},
-url-omit = "http://cogcomp.org/papers/DaganKaRo97.pdf",
-}
-
-%%%%%%%%%%%%%%
-%%%  1996  %%%
-%%%%%%%%%%%%%%
-@article{Roth96,
-  author = {D. Roth},
-  title = {On the hardness of approximate reasoning},
-pages-omit = {273--302},
-month-omit = {4},
-  year = {1996},
-  journal = {Artificial Intelligence},
-volume-omit = {82},
-number-omit = {1-2},
-url-omit = "http://cogcomp.org/papers/hardJ.pdf",
-  comment = {Hardness of Reasoning with Bayesian Networks; Exact inference is #P-Complete; Approximate Reasoning is NP-Hard.},
-}
-
-@article{KushilevitzRo96,
-  author = {A. Kushilevitz and D. Roth},
-  title = {On Learning Visual Concepts and DNF Formulae},
-pages-omit = {65--85},
-  year = {1996},
-  journal = {Machine Learning},
-volume-omit = {24},
-number-omit = {1},
-url-omit = "http://cogcomp.org/papers/visualJ.pdf",
-}
-
-@article{KhardonRo96,
-  author = {R. Khardon and D. Roth},
-  title = {Reasoning with Models},
-pages-omit = {187--213},
-  year = {1996},
-  journal = {Artificial Intelligence},
-volume-omit = {87},
-number-omit = {1-2},
-url-omit = "http://cogcomp.org/papers/modelsJ.pdf",
-  comment = {Characteristic Models of Boolean Functions},
-}
-
-@inproceedings{GreinerGrRo96,
-  author = {R. Greiner and A. Grove and D. Roth},
-  title = {Learning Active Classifiers},
-  booktitle = {Proc. of the International Conference on Machine Learning (ICML)},
-pages-omit = {207--215},
-  year = {1996},
-  acceptance = {63/257 (24\%)},
-url-omit = "http://cogcomp.org/papers/active.pdf",
-}
-
-@inproceedings{GoldingRo96,
-  author = {A. R. Golding and D. Roth},
-  title = {Applying Winnow to Context-Sensitive Spelling Correction},
-  booktitle = {Proc. of the International Conference on Machine Learning (ICML)},
-pages-omit = {182--190},
-  year = {1996},
-  acceptance = {63/257 (24\%)},
-url-omit = "http://cogcomp.org/papers/spell.pdf",
-}
-
-@inproceedings{Roth96d,
-  author = {D. Roth},
-  title = {Learning in Order to Reason Invited},
-  booktitle = {Proc. of the AAAI Fall Symposium on Learning Complex Behaviors in Adaptive Intelligent Systems},
-pages-omit = {46--52},
-  year = {1996},
-url-omit = "http://cogcomp.org/papers/approach.pdf",
-}
-
-@incollection{Roth96c,
-  author = {D. Roth},
-  title = {Learning in Order to Reason: The Approach},
-  booktitle = {Proc. of the Conference on Current Trends in Theory and Practice of Informatics (SOFSEM)},
-pages-omit = {113--124},
-  year = {1996},
-publisher-omit = {Springer-verlag},
-  editor = {K. G. Jeffery and J. Kral and M. Bartosek},
-url-omit = "http://cogcomp.org/papers/approach.pdf",
-  comment = {Lecture notes in Computer Science, vol. 1175},
-}
-
-@inproceedings{Roth96b,
-  author = {D. Roth},
-  title = {On the hardness of approximate reasoning},
-  booktitle = {Proc. of the AAAI Fall Symposium on AI and NP Hard Problems},
-pages-omit = {137-143},
-  year = {1996},
-url-omit = "http://cogcomp.org/papers/hardJ.pdf",
-}
-
-@inproceedings{Roth96a,
-  author = {D. Roth},
-  title = {A Connectionist Framework for Reasoning: Reasoning with Examples},
-  booktitle = {Proc. of the Conference on Artificial Intelligence (AAAI)},
-pages-omit = {1256--1261},
-  year = {1996},
-  acceptance = {197/640 (31\%)},
-url-omit = "http://cogcomp.org/papers/nreason.pdf",
-}
-
-%%%%%%%%%%%%%%
-%%%  1995  %%%
-%%%%%%%%%%%%%%
-@inproceedings{Roth95,
-  author = {D. Roth},
-  title = {Learning to Reason: The Non-Monotonic Case},
-  booktitle = {Proc. of the International Joint Conference on Artificial Intelligence (IJCAI)},
-pages-omit = {1178--1184},
-month-omit = {8},
-  year = {1995},
-  acceptance = {249/1112 (22\%)},
-url-omit = "http://cogcomp.org/papers/nonmon.pdf",
-}
-
-@techreport{KhardonRo95b,
-  author = {R. Khardon and D. Roth},
-  title = {Defaults and Relevance in Model Based Reasoning},
-month-omit = {10},
-  year = {1995},
-  institution = {Dept. of App. Math. and Computer Science, Weizmann Institute of Science},
-number-omit = {CS95-30},
-url-omit = "http://cogcomp.org/papers/KhardonRo95b.pdf",
-}
-
-@inproceedings{KhardonRo95a,
-  author = {R. Khardon and D. Roth},
-  title = {Learning to Reason with a Restricted View},
-  booktitle = {Proc. of the ACM Conference on Computational Learning Theory (COLT)},
-pages-omit = {301--310},
-month-omit = {7},
-  year = {1995},
-  acceptance = {24/74 (32\%)},
-url-omit = {},
-}
-
-@inproceedings{KhardonRo95,
-  author = {R. Khardon and D. Roth},
-  title = {Default-Reasoning with Models},
-  booktitle = {Proc. of the International Joint Conference on Artificial Intelligence (IJCAI)},
-pages-omit = {319--325},
-month-omit = {8},
-  year = {1995},
-  acceptance = {249/112 (22\%)},
-url-omit = {},
-}
-
-%%%%%%%%%%%%%%
-%%%  1994  %%%
-%%%%%%%%%%%%%%
-@inproceedings{KhardonRo94e,
-  author = {R. Khardon and D. Roth},
-  title = {A note on Horn Theories},
-  year = {1994},
-url-omit = {},
-  comment = {Manuscript.},
-}
-
-@techreport{KhardonRo94d,
-  author = {R. Khardon and D. Roth},
-  title = {Learning to Reason},
-month-omit = {1},
-  year = {1994},
-  institution = {Aiken Computation Lab., Harvard University},
-number-omit = {TR-2-94},
-url-omit = {},
-  invisible = {true},
-}
-
-@techreport{KhardonRo94c,
-  author = {R. Khardon and D. Roth},
-  title = {Reasoning with Models},
-month-omit = {1},
-  year = {1994},
-  institution = {Aiken Computation Lab., Harvard University},
-number-omit = {TR-1-94},
-url-omit = {},
-  invisible = {true},
-}
-
-@inproceedings{KhardonRo94b,
-  author = {R. Khardon and D. Roth},
-  title = {Exploiting Relevance through Model-based reasoning},
-  booktitle = {Proc. of the AAAI Fall Symposium on Relevance},
-pages-omit = {109-114},
-  year = {1994},
-url-omit = "http://cogcomp.org/papers/relevanceP.pdf",
-}
-
-@inproceedings{KhardonRo94a,
-  author = {R. Khardon and D. Roth},
-  title = {Learning to Reason},
-  booktitle = {Proc. of the Conference on Artificial Intelligence (AAAI)},
-pages-omit = {682--687},
-  year = {1994},
-  acceptance = {222/725 (31\%)},
-url-omit = "http://cogcomp.org/papers/KhardonRo94a.pdf",
-}
-
-@inproceedings{KhardonRo94,
-  author = {R. Khardon and D. Roth},
-  title = {Reasoning with Models},
-  booktitle = {Proc. of the Conference on Artificial Intelligence (AAAI)},
-pages-omit = {1148--1153},
-  year = {1994},
-  acceptance = {225/725 (31\%)},
-url-omit = "http://cogcomp.org/papers/KhardonRo94.pdf",
-}
-
-@inproceedings{BKKPR94,
-  author = {A. Blum and R. Khardon and A. Kushilevitz and L. Pitt and D. Roth},
-  title = {On learning read-k satisfy-j DNF},
-  booktitle = {Proc. of the ACM Conference on Computational Learning Theory (COLT)},
-pages-omit = {110--117},
-  year = {1994},
-url-omit = "http://cogcomp.org/papers/BKKPR94.pdf",
-}
-
-%%%%%%%%%%%%%%
-%%%  1993  %%%
-%%%%%%%%%%%%%%
-@inproceedings{Roth93,
-  author = {D. Roth},
-  title = {On the hardness of approximate reasoning},
-  booktitle = {Proc. of the International Joint Conference on Artificial Intelligence (IJCAI)},
-pages-omit = {613--618},
-month-omit = {8},
-  year = {1993},
-  acceptance = {220/876 (25\%)},
-url-omit = {},
-  comment = {Hardness of Reasoning with Bayesian Networks; Exact inference is #P-Complete; Approximate Reasoning is NP-Hard.},
-}
-
-@inproceedings{KushilevitzRo93,
-  author = {A. Kushilevitz and D. Roth},
-  title = {On Learning Visual Concepts and DNF Formulae},
-  booktitle = {Proc. of the ACM Conference on Computational Learning Theory (COLT)},
-pages-omit = {317--326},
-  year = {1993},
-url-omit = {},
-  comment = {30/83 (37%)},
-}
-
-@inproceedings{DanielsMiRo93,
-  author = {K. Daniels and V. J. Milenkovic and D. Roth},
-  title = {Finding the Maximum Area Axis-Parallel Rectangle in a Simple Polygon},
-  booktitle = {Proc. of the Canadian Conference on Computational Geometry (CCCG)},
-pages-omit = {322--327},
-  year = {1993},
-url-omit = {},
-}
-
-%%%%%%%%%%%%%%
-%%%  1992  %%%
-%%%%%%%%%%%%%%
-@inproceedings{MavronicolasRo92,
-  author = {M. Mavronicolas and D. Roth},
-  title = {Efficient, Strongly Consistent Implementation of Shared Memory},
-  booktitle = {Proc. of the Workshop on Distributed Algorithms (WDAG)},
-pages-omit = {346--361},
-  year = {1992},
-  acceptance = {24/38 (63\%)},
-url-omit = "http://cogcomp.org/papers/wdagP.pdf",
-}
-
-%%%%%%%%%%%%%%
-%%%  1991  %%%
-%%%%%%%%%%%%%%
-@inproceedings{MavronicolasRo91,
-  author = {M. Mavronicolas and D. Roth},
-  title = {Sequential Consistency and Linearizability: Read/Write Objects},
-  booktitle = {Proc. of the Allerton Conference on Communications, Control and Computing},
-pages-omit = {683--692},
-  year = {1991},
-  acceptance = {32/77 (42\%)},
-url-omit = {},
-}
-
-%%%%%%%%%%%%%%
-%%%  0  %%%
-%%%%%%%%%%%%%%
-{,
-  year = {0},
-url-omit = "http://cogcomp.org/papers/Resume.pdf",
+@Article{AgarwalAwRo04,
+  Title                    = {Learning to Detect Objects in Images via a Sparse, Part-Based Representation},
+  Author                   = {S. Agarwal and A. Awan and D. Roth},
+  Journal                  = {IEEE Transactions on Pattern Analysis and Machine Intelligence},
+  Year                     = {2004},
+Number-omit = {11},
+Pages-omit = {1475--1490},
+Volume-omit = {20},
+
+  Funding                  = {CAREER,ITR-MIT},
+  Projects                 = {LV,KR},
+Url-omit = {http://cogcomp.org/papers/AgarwalAwRo04.pdf}
+}
+
+@Article{AGHHR05,
+  Title                    = {Generalization Bounds for the Area Under the ROC Curve},
+  Author                   = {S. Agarwal and T. Graepel and R. Herbrich and S. Har-Peled and D. Roth},
+  Journal                  = {Journal of Machine Learning Research},
+  Year                     = {2005},
+Pages-omit = {393--425},
+Volume-omit = {6},
+
+  Funding                  = {ITR-BI,ITR-MIT,TRECC},
+  Projects                 = {LT,RANK},
+Url-omit = {http://cogcomp.org/papers/AgarwalGrHeHaRo05.pdf}
+}
+
+@InProceedings{AGHR05,
+  Title                    = {A Large Deviation Bound for the Area Under the ROC Curve},
+  Author                   = {S. Agarwal and T. Graepel and R. Herbrich and D. Roth},
+  Booktitle                = {Proc. of the Conference on Neural Information Processing Systems (NIPS)},
+  Year                     = {2005},
+Pages-omit = {9--16},
+
+  Acceptance               = {207/823 (25\%)},
+  Comment                  = {Bipartite Ranking: bounding the expected accuracy of a ranking function in terms of its empirical AUC.},
+  Funding                  = {ITR-BI,ITR-MIT,TRECC},
+  Projects                 = {LT,RANK},
+Url-omit = {http://cogcomp.org/papers/AgarwalGrHeRo05.pdf}
+}
+
+@InProceedings{AgarwalHaRo05,
+  Title                    = {A Uniform Convergence Bound for the Area Under the ROC Curve},
+  Author                   = {S. Agarwal and S. Har-Peled and D. Roth},
+  Booktitle                = {Proc. of the International Workshop on Artificial Intelligence and Statistics (AISTATS)},
+  Year                     = {2005},
+Pages-omit = {1-8},
+
+  Acceptance               = {51/150 (34\%)},
+  Comment                  = {Bipartite Ranking: uniform convergence properties of the AUC in terms of bipartite rank-shatter coefficients.},
+  Funding                  = {ITR-BI,ITR-MIT,TRECC},
+  Projects                 = {LT,RANK},
+Url-omit = {http://cogcomp.org/papers/AgarwalHaRo05.pdf}
+}
+
+@InProceedings{AgarwalRo05,
+  Title                    = {Learnability of Bipartite Ranking Functions},
+  Author                   = {S. Agarwal and D. Roth},
+  Booktitle                = {Proc. of the ACM Conference on Computational Learning Theory (COLT)},
+  Year                     = {2005},
+Pages-omit = {16--31},
+
+  Acceptance               = {45/119 (37.8\%)},
+  Funding                  = {ITR-BI,ITR-MIT,TRECC},
+  Projects                 = {LT,RANK},
+Url-omit = {http://cogcomp.org/papers/Agarwalro05.pdf}
+}
+
+@TechReport{AgarwalRo03,
+  Title                    = {Minimum Risk Feature Transformations},
+  Author                   = {S. Agarwal and D. Roth},
+  Institution              = {UIUC Computer Science Department},
+  Year                     = {2003},
+Month-omit = {12},
+Number-omit = {UIUCDCS-R-2003-2627},
+
+  Comment                  = {UIUC Tech Report UIUCDCS-R-2003-2627. A preliminary framework for Feature Generation},
+Url-omit = {http://cogcomp.org/papers/AgarwalRo03.pdf}
+}
+
+@InProceedings{AgarwalRo02,
+  Title                    = {Learning a Sparse Representation for Object Detection},
+  Author                   = {S. Agarwal and D. Roth},
+  Booktitle                = {Proc. of the European Conference on Computer Vision (ECCV)},
+  Year                     = {2002},
+Pages-omit = {113--128},
+
+  Acceptance               = {45/600 (7.5\%) Oral Presentations; 225/600 (37\%) overall},
+  Funding                  = {MURI,SBC-MIT,CAREER},
+  Projects                 = {LV,KR},
+Url-omit = {http://cogcomp.org/papers/AgarwalRo02.pdf}
+}
+
+@Unpublished{AgarwalRo01,
+  Title                    = {Detecting objects by learning relations over parts},
+  Author                   = {S. Agarwal and D. Roth},
+
+Month-omit = {6},
+  Year                     = {2001},
+
+  Institution              = {UIUC Computer Science Department},
+  Invisible                = {true},
+Number-omit = {UIUCDCS-R-2001-2231},
+Url-omit = {http://cogcomp.org/papers/AgarwalRo01.pdf}
+}
+
+@Article{ABKKPR98,
+  Title                    = {On learning read-k satisfy-j DNF},
+  Author                   = {H. Aizenstein and A. Blum and R. Khardon and A. Kushilevitz and L. Pitt and D. Roth},
+  Journal                  = {SIAM Journal of Computing},
+  Year                     = {1998},
+
+Month-omit = {7},
+Number-omit = {6},
+Pages-omit = {1515--1530},
+Volume-omit = {27},
+
+Url-omit = {http://cogcomp.org/papers/rksjJ.pdf}
+}
+
+@Other{Alm08,
+  Title                    = {Affect in Text and Speech},
+  Author                   = {C. Alm},
+  Booktitle                = {UIUC PhD Thesis},
+Url-omit = {http://cogcomp.org/papers/Alm thesis(1).pdf},
+  Year                     = {2008}
+}
+
+@InProceedings{AlmRoSp05,
+  Title                    = {Emotions from text: machine learning for text-based emotion prediction.},
+  Author                   = {C. Alm and D. Roth and R. Sproat},
+  Booktitle                = {Proc. of the Conference on Empirical Methods in Natural Language Processing (EMNLP)},
+  Year                     = {2005},
+
+  Funding                  = {ITR-EDU},
+Url-omit = {http://cogcomp.org/papers/AlmRoSp05.pdf}
+}
+
+@InProceedings{ArivazhaganChRo16,
+  Title                    = {Labeling the Semantic Roles of Commas},
+  Author                   = {Naveen Arivazhagan and Christos Christodoulopoulos and Dan Roth},
+  Booktitle                = {Proc. of the Conference on Artificial Intelligence (AAAI)},
+  Year                     = {2016},
+Month-omit = {2},
+
+  Projects                 = {DEFT},
+Url-omit = {http://cogcomp.org/papers/ArivazhaganChRo16.pdf}
+}
+
+@InProceedings{BasariRoJa98,
+  Title                    = {Clustering Appearances of 3D Objects},
+  Author                   = {R. Basari and D. Roth and D. Jacobs},
+  Booktitle                = {Proc. of the IEEE Conference on Computer Vision and Pattern Recognition (CVPR)},
+  Year                     = {1998},
+Pages-omit = {414-420},
+
+  Acceptance               = {136/450 (30\%)},
+  Comment                  = {Clustering of Curves},
+Url-omit = {http://cogcomp.org/papers/cvpr98.pdf}
+}
+
+@InProceedings{BengtsonRo08,
+  Title                    = {Understanding the Value of Features for Coreference Resolution},
+  Author                   = {E. Bengtson and D. Roth},
+  Booktitle                = {Proc. of the Conference on Empirical Methods in Natural Language Processing (EMNLP)},
+  Year                     = {2008},
+Month-omit = {10},
+
+  Comment                  = {The importance of good features for coreference resolution},
+  Funding                  = {Boeing,SoD},
+  Projects                 = {COREF,TE},
+Url-omit = {http://cogcomp.org/papers/BengtsonRo08.pdf}
+}
+
+@InProceedings{BKKPR94,
+  Title                    = {On learning read-k satisfy-j DNF},
+  Author                   = {A. Blum and R. Khardon and A. Kushilevitz and L. Pitt and D. Roth},
+  Booktitle                = {Proc. of the ACM Conference on Computational Learning Theory (COLT)},
+  Year                     = {1994},
+Pages-omit = {110--117},
+
+Url-omit = {http://cogcomp.org/papers/BKKPR94.pdf}
+}
+
+@Article{BBCRWZ14,
+  Title                    = {Introduction to the special issue on learning semantics},
+  Author                   = {Antoine Bordes and L�on Bottou and Ronan Collobert and Dan Roth and Jason Weston and Luke Zettlemoyer},
+  Journal                  = {Machine Learning},
+  Year                     = {2014},
+
+Month-omit = {2},
+Number-omit = {2},
+Pages-omit = {127-131},
+Volume-omit = {94},
+
+Publisher-omit = {Springer},
+Url-omit = {http://cogcomp.org/papers/BBCRWZ14.pdf}
+}
+
+@InProceedings{BurgardCh11,
+  Title                    = {Proceedings of the 25th AAAI Conference on Artificial Intelligence},
+  Author                   = {W. Burgard and D. Roth Program Chairs},
+  Booktitle                = {Proc. of the Conference on Artificial Intelligence (AAAI)},
+  Year                     = {2011},
+  Editor                   = {W. Burgard and D. Roth}
+}
+
+@Other{Carlson01,
+  Title                    = {Learning Based Programming - An Implementation},
+  Author                   = {A. Carlson},
+  Booktitle                = {UIUC Senior Thesis},
+  Comment                  = {Senior Thesis, UIUC, Dept. of Computer Science},
+Month-omit = {5},
+  Year                     = {2001}
+}
+
+@TechReport{CCRR99,
+  Title                    = {The SNoW Learning Architecture},
+  Author                   = {A. Carlson and C. Cumby and J. Rosen and D. Roth},
+  Institution              = {UIUC Computer Science Department},
+  Year                     = {1999},
+Month-omit = {5},
+Number-omit = {UIUCDCS-R-99-2101},
+
+Url-omit = {http://cogcomp.org/papers/CCRR99.pdf}
+}
+
+@InProceedings{CarlsonRoRo01,
+  Title                    = {Scaling Up Context Sensitive Text Correction},
+  Author                   = {A. Carlson and J. Rosen and D. Roth},
+  Booktitle                = {Proc. of the Conference on Innovative Applications of Artificial Intelligence (IAAI)},
+  Year                     = {2001},
+Pages-omit = {45--50},
+
+  Acceptance               = {12/37 (32\%)},
+  Funding                  = {NSF98,CAREER,IBM},
+  Projects                 = {LT,NLP},
+Url-omit = {http://cogcomp.org/papers/iaai01.pdf}
+}
+
+@InProceedings{CMPR02,
+  Title                    = {Learning and Inference for Clause Identification},
+  Author                   = {X. Carreras and L. Marquez and V. Punyakanok and D. Roth},
+  Booktitle                = {Proc. of the European Conference on Machine Learning (ECML)},
+  Year                     = {2002},
+Pages-omit = {35--47},
+
+  Acceptance               = {80/218 (37\%)},
+  Comment                  = {Shallow Parsing; Chunking and Clause identification.},
+  Funding                  = {MURI,SBC-MIT,CAREER},
+  Projects                 = {LnI,SI,IE},
+Url-omit = {http://cogcomp.org/papers/ecml02.pdf}
+}
+
+@InProceedings{ChanRo11,
+  Title                    = {Exploiting Syntactico-Semantic Structures for Relation Extraction},
+  Author                   = {Y. Chan and D. Roth},
+  Booktitle                = {Proc. of the Annual Meeting of the Association for Computational Linguistics (ACL)},
+  Year                     = {2011},
+
+Address-omit = {Portland, Oregon},
+
+  Funding                  = {MR},
+  Projects                 = {NLP, IE},
+Url-omit = {http://cogcomp.org/papers/ChanRo11.pdf}
+}
+
+@InProceedings{ChanRo10,
+  Title                    = {Exploiting Background Knowledge for Relation Extraction},
+  Author                   = {Y. Chan and D. Roth},
+  Booktitle                = {Proc. of the International Conference on Computational Linguistics (COLING)},
+  Year                     = {2010},
+
+Address-omit = {Beijing, China},
+Month-omit = {8},
+
+  Comment                  = {Relation extraction, background knowledge, constraints, information extraction},
+  Funding                  = {MR},
+  Projects                 = {NLP, IE},
+Url-omit = {http://cogcomp.org/papers/ChanRo10.pdf}
+}
+
+@Other{Chang15,
+  Title                    = {Selective Algorithms for Large-Scale Classification and Structured Learning},
+  Author                   = {Kai-Wei Chang},
+  Booktitle                = {UIUC PhD Thesis},
+Url-omit = {http://cogcomp.org/papers/Chang15.pdf},
+  Year                     = {2015}
+}
+
+@InProceedings{CDHR12,
+  Title                    = {Efficient Pattern-Based Time Series Classification on GPU },
+  Author                   = {Kai-Wei Chang and Biplab Deka and Wen-Mei W. Hwu and Dan Roth},
+  Booktitle                = {Proc. of the IEEE International Conference on Data Mining (ICDM)},
+  Year                     = {2012},
+
+  Acceptance               = {10.7\%},
+  Funding                  = {MR, BL},
+Url-omit = {http://cogcomp.org/papers/undefined.pdf}
+}
+
+@InProceedings{ChangRo11,
+  Title                    = {Selective Block Minimization for Faster Convergence of Limited Memory Large-scale Linear Models},
+  Author                   = {K.-W. Chang and D. Roth},
+  Booktitle                = {Proc. of the ACM SIGKDD Conference on Knowledge Discovery and Data Mining (KDD)},
+  Year                     = {2011},
+
+  Acceptance               = {17.5\%},
+  Funding                  = {BL, MR},
+Url-omit = {http://cogcomp.org/papers/ChangRo11(4).pdf}
+}
+
+@InProceedings{ChangSaRo13,
+  Title                    = {A Constrained Latent Variable Model for Coreference Resolution},
+  Author                   = {Kai-Wei Chang and Rajhans Samdani and Dan Roth},
+  Booktitle                = {Proc. of the Conference on Empirical Methods in Natural Language Processing (EMNLP)},
+  Year                     = {2013},
+
+Url-omit = {http://cogcomp.org/papers/ChangSaRo13.pdf}
+}
+
+@InProceedings{CSRRSR11,
+  Title                    = {Inference Protocols for Coreference Resolution},
+  Author                   = {K.-W. Chang and R. Samdani and A. Rozovskaya and N. Rizzolo and M. Sammons and D. Roth},
+  Booktitle                = {Proc. of the Conference on Computational Natural Language Learning (CoNLL)},
+  Year                     = {2011},
+
+Address-omit = {Portland, Oregon, USA},
+Pages-omit = {40--44},
+Publisher-omit = {Association for Computational Linguistics},
+
+  Funding                  = {MR},
+Url-omit = {http://cogcomp.org/papers/CSRRSR11.pdf}
+}
+
+@InProceedings{CSRSR12,
+  Title                    = {Illinois-Coref: The UI System in the CoNLL-2012 Shared Task},
+  Author                   = {Kai-Wei Chang and Rajhans Samdani and Alla Rozovskaya and Mark Sammons and Dan Roth},
+  Booktitle                = {Proc. of the Conference on Computational Natural Language Learning (CoNLL)},
+  Year                     = {2012},
+
+  Funding                  = {Machine Reading, ARL},
+  Projects                 = {Coreference Within and Across Documents},
+Url-omit = {http://cogcomp.org/papers/CSRSR12.pdf}
+}
+
+@InProceedings{ChangSrRo13,
+  Title                    = {Multi-core Structural SVM Training},
+  Author                   = {K.-W. Chang and V. Srikumar and D. Roth},
+  Booktitle                = {Proc. of the European Conference on Machine Learning and Principles and Practice of Knowledge Discovery in Databases (ECML PKDD)},
+  Year                     = {2013},
+
+  Acceptance               = {25\%},
+  Funding                  = {ONR, DEFT},
+Url-omit = {http://cogcomp.org/papers/ChangSrRo13.pdf}
+}
+
+@InProceedings{CUKR15,
+  Title                    = {Structural Learning with Amortized Inference},
+  Author                   = {Kai-Wei Chang and Shyam Upadhyay and Gourab Kundu and Dan Roth},
+  Booktitle                = {Proc. of the Conference on Artificial Intelligence (AAAI)},
+  Year                     = {2015},
+
+  Funding                  = {ONR,ARL,DEFT},
+Url-omit = {http://cogcomp.org/papers/CUKR15.pdf}
+}
+
+@Other{Chang11,
+  Title                    = {Structured Prediction with Indirect Supervision},
+  Author                   = {M. Chang},
+  Booktitle                = {UIUC PhD Thesis},
+Url-omit = {http://cogcomp.org/papers/Chang11.pdf},
+  Year                     = {2011}
+}
+
+@InProceedings{ChangCoRo10,
+  Title                    = {The Necessity of Combining Adaptation Methods},
+  Author                   = {M. Chang and M. Connor and D. Roth},
+  Booktitle                = {Proc. of the Conference on Empirical Methods in Natural Language Processing (EMNLP)},
+  Year                     = {2010},
+
+Address-omit = {Massachusetts, USA},
+Month-omit = {10},
+
+  Funding                  = {DARPA},
+  Projects                 = {Adaptation},
+Url-omit = {http://cogcomp.org/papers/ChangCoRo10.pdf}
+}
+
+@InProceedings{ChangDoRo06,
+  Title                    = {Multilingual Dependency Parsing: A Pipeline Approach},
+  Author                   = {M. Chang and Q. Do and D. Roth},
+  Booktitle                = {Proc. of the Conference on Recent Advances in Natural Language Processing},
+  Year                     = {2006},
+  Editor                   = {Nicolas Nicolov and Kalina Bontcheva and Galia Angelova and Ruslan Mitkov},
+Month-omit = {7},
+Pages-omit = {55--78},
+
+  Comment                  = {Analysis of A pipeline model with applications to dependency parsing. Combines ACL'06 and CoNLL'06},
+  Funding                  = {ARDA,REFLEX,SoD},
+  Projects                 = {DP,PL},
+Url-omit = {http://cogcomp.org/papers/ChangDoRo06b.pdf}
+}
+
+@InProceedings{ChangDoRo06a,
+  Title                    = {Local Search for Bottom-Up Dependency Parsing},
+  Author                   = {M. Chang and Q. Do and D. Roth},
+  Booktitle                = {Proc. of the Annual Meeting of the Association for Computational Linguistics (ACL)},
+  Year                     = {2006},
+Month-omit = {7},
+
+  Comment                  = {Analysis of A pipeline model with applications to dependency parsing},
+  Funding                  = {ARDA,REFLEX},
+  Projects                 = {DP},
+Url-omit = {http://cogcomp.org/papers/ChangDoRo06a.pdf}
+}
+
+@InProceedings{ChangDoRo06b,
+  Title                    = {A Pipeline Model for Bottom-Up Dependency Parsing Shared Task Paper},
+  Author                   = {M. Chang and Q. Do and D. Roth},
+  Booktitle                = {Proc. of the Conference on Computational Natural Language Learning (CoNLL)},
+  Year                     = {2006},
+Month-omit = {6},
+Pages-omit = {186--190},
+
+  Comment                  = {Multilingual Dependency Parsing; a shift reduced parsing model; study of shift reduced parsing as a pipeline model},
+  Funding                  = {KINDLE,REFLEX},
+  Projects                 = {DP,PL},
+Url-omit = {http://cogcomp.org/papers/ChangDoRo06.pdf}
+}
+
+@InProceedings{CGRS10,
+  Title                    = {Discriminative Learning over Constrained Latent Representations},
+  Author                   = {M. Chang and D. Goldwasser and D. Roth and V. Srikumar},
+  Booktitle                = {Proc. of the Annual Conference of the North American Chapter of the Association for Computational Linguistics (NAACL)},
+  Year                     = {2010},
+Month-omit = {6},
+
+  Comment                  = {learning over latent representation, learning feature representation, intermediate representation, generalized alignment for various NLP tasks},
+  Funding                  = {DARPA,SoD,MIAS,MR},
+  Projects                 = {CCM,TL},
+Url-omit = {http://cogcomp.org/papers/CGRS10.pdf}
+}
+
+@InProceedings{CGRT09,
+  Title                    = {Unsupervised Constraint Driven Learning For Transliteration Discovery},
+  Author                   = {M. Chang and D. Goldwasser and D. Roth and Y. Tu},
+  Booktitle                = {Proc. of the Annual Conference of the North American Chapter of the Association for Computational Linguistics (NAACL)},
+  Year                     = {2009},
+Month-omit = {5},
+
+  Comment                  = {Transliteration; Constrained optimization; constrained conditional models, unsupervised learning; named entity discovery; multilingual corpora; bootstrapping, romanization table, feature selection for transliteration; Discriminative training of Objective function; Dynamic Programming},
+  Funding                  = {DARPA,SoD,MIAS},
+  Projects                 = {CCM,TL},
+Url-omit = {http://cogcomp.org/papers/CGRT09.pdf}
+}
+
+@InProceedings{CRRR08,
+  Title                    = {Learning and Inference with Constraints},
+  Author                   = {M. Chang and L. Ratinov and N. Rizzolo and D. Roth},
+  Booktitle                = {Proc. of the Conference on Artificial Intelligence (AAAI)},
+  Year                     = {2008},
+Month-omit = {7},
+
+  Funding                  = {SoD,MIAS,Library,Boeing},
+  Projects                 = {CCM,LBP},
+Url-omit = {http://cogcomp.org/papers/CRRR08.pdf}
+}
+
+@Other{ChangRaRo08,
+  Title                    = {Constraints as Prior Knowledge},
+  Author                   = {M. Chang and L. Ratinov and D. Roth},
+  Booktitle                = {Proc. of the International Conference on Machine Learning (ICML)},
+  Funding                  = {SoD, LIBRARY, MIAS},
+Month-omit = {7},
+Pages-omit = {32-39},
+  Projects                 = {USS,IE,CCM},
+Url-omit = {http://cogcomp.org/papers/ChangRaRo08.pdf},
+  Year                     = {2008}
+}
+
+@InProceedings{ChangRaRo07,
+  Title                    = {Guiding Semi-Supervision with Constraint-Driven Learning},
+  Author                   = {M. Chang and L. Ratinov and D. Roth},
+  Booktitle                = {Proc. of the Annual Meeting of the Association for Computational Linguistics (ACL)},
+  Year                     = {2007},
+
+Address-omit = {Prague, Czech Republic},
+Month-omit = {6},
+Pages-omit = {280--287},
+Publisher-omit = {Association for Computational Linguistics},
+
+  Comment                  = {Semi-supervised learning with very little supervision; Constraints; Constraints Driven Learning; Information Extraction},
+  Funding                  = {SoD,Boeing},
+  Projects                 = {USS,CCM,IE},
+Url-omit = {http://cogcomp.org/papers/ChangRaRo07.pdf}
+}
+
+@InProceedings{CRRS08,
+  Title                    = {Importance of Semantic Representation: Dataless Classification},
+  Author                   = {M. Chang and L. Ratinov and D. Roth and V. Srikumar},
+  Booktitle                = {Proc. of the Conference on Artificial Intelligence (AAAI)},
+  Year                     = {2008},
+Month-omit = {7},
+
+  Funding                  = {SoD,MIAS,Library,Boeing},
+  Projects                 = {DC},
+Url-omit = {http://cogcomp.org/papers/CRRS08.pdf}
+}
+
+@InProceedings{CSGR10,
+  Title                    = {Structured Output Learning with Indirect Supervision},
+  Author                   = {M. Chang and V. Srikumar and D. Goldwasser and D. Roth},
+  Booktitle                = {Proc. of the International Conference on Machine Learning (ICML)},
+  Year                     = {2010},
+
+  Comment                  = {indirect supervision, structured learning, joint learning of binary and structured learning tasks},
+  Funding                  = {DARPA,SoD,MIAS,MR},
+  Projects                 = {CCM,TL},
+Url-omit = {http://cogcomp.org/papers/CSGR10.pdf}
+}
+
+@Article{ChangRaRo12,
+  Title                    = {Structured Learning with Constrained Conditional Models},
+  Author                   = {Ming-Wei Chang and Lev Ratinov and Dan Roth},
+  Journal                  = {Machine Learning},
+  Year                     = {2012},
+
+Month-omit = {6},
+Number-omit = {3},
+Pages-omit = {399-431},
+Volume-omit = {88},
+
+  Editor                   = {Hal Daume III},
+Publisher-omit = {Springer},
+Url-omit = {http://cogcomp.org/papers/ChangRaRo12.pdf}
+}
+
+@InProceedings{ChaturvediPeRo17,
+  Title                    = {Story Comprehension for Predicting What Happens Next},
+  Author                   = {Snigdha Chaturvedi and Haoruo Peng and Dan Roth},
+  Booktitle                = {In proceedings of the Conference on Empirical Methods in Natural Language Processing},
+  Year                     = {2017},
+
+  Funding                  = { IBM-ILLINOIS Center for Cognitive Computing Systems Research (C3SR), US Defense Advanced Research Projects Agency (DARPA) under contract FA8750-13-2-0008, Army Research Laboratory (ARL) under agreement W911NF-09-2-0053},
+Url-omit = {http://cogcomp.org/papers/ChaturvediPeRo17.pdf}
+}
+
+@InProceedings{CCSCFSWRWR13,
+  Title                    = {Illinois Cognitive Computation Group UI-CCG TAC 2013 Entity Linking and Slot Filler Validation Systems},
+  Author                   = {Xiao Cheng and Bingling Chen and Rajhans Samdani and Kai-Wei Chang and Zhiye Fei and Mark Sammons and John Wieting and Subhro Roy and Chizheng Wang and Dan Roth},
+  Booktitle                = {Proc. of the Text Analysis Conference (TAC)},
+  Year                     = {2013},
+
+Url-omit = {http://cogcomp.org/papers/UI_CCG.TAC2013.proceedings.pdf}
+}
+
+@InProceedings{ChengRo13,
+  Title                    = {Relational Inference for Wikification},
+  Author                   = {Xiao Cheng and Dan Roth},
+  Booktitle                = {Proc. of the Conference on Empirical Methods in Natural Language Processing (EMNLP)},
+  Year                     = {2013},
+
+  Funding                  = {DEFT,ARL,MIAS},
+Url-omit = {http://cogcomp.org/papers/ChengRo13.pdf}
+}
+
+@Other{ChristodoulopoulosRoFi16,
+  Title                    = {An incremental model of syntactic bootstrapping},
+  Author                   = { Christos Christodoulopoulos and Dan Roth and Cynthia Fisher},
+  Booktitle                = {7th Workshop on Cognitive Aspects of Computational Language Learning, Proc. of the Annual Meeting of the Association for Computational Linguistics (ACL)},
+Month-omit = {8},
+Url-omit = {http://cogcomp.org/papers/christodoulopoulos_16_incremental.pdf},
+  Year                     = {2016}
+}
+
+@InProceedings{ChuangRo01,
+  Title                    = {Gene Recognition based on DAG shortest paths},
+  Author                   = {J. Chuang and D. Roth},
+  Booktitle                = {Proc. of the International Conference on Intelligent Systems for Molecular Biology (ISMB)},
+  Year                     = {2001},
+Pages-omit = {1--9},
+
+  Acceptance               = {40/180 (22\%)},
+  Funding                  = {NSF98,CAREER},
+  Projects                 = {LnI,SI,LT},
+Url-omit = {http://cogcomp.org/papers/ismb01.pdf}
+}
+
+@Article{ChuangRo01a,
+  Title                    = {Gene Recognition based on DAG shortest paths},
+  Author                   = {J. Chuang and D. Roth},
+  Journal                  = {Bioinformatics},
+  Year                     = {2001},
+
+Month-omit = {7},
+Number-omit = {1},
+Pages-omit = {S56--S64},
+Volume-omit = {17},
+
+  Funding                  = {NSF98,CAREER},
+  Projects                 = {LnI,SI,LT},
+Url-omit = {http://cogcomp.org/papers/ismb01.pdf}
+}
+
+@InProceedings{CGCR10,
+  Title                    = {Driving Semantic Parsing from the World's Response},
+  Author                   = {J. Clarke and D. Goldwasser and M. Chang and D. Roth},
+  Booktitle                = {Proc. of the Conference on Computational Natural Language Learning (CoNLL)},
+  Year                     = {2010},
+Month-omit = {7},
+
+  Comment                  = {Learning semantic parsers without complex logical form annotations. Supervision provided in the form of a binary feedback signal recieved from an external world.},
+  Funding                  = {BL,MR},
+  Projects                 = {NLP, SP, COMP, USS},
+Url-omit = {http://cogcomp.org/papers/CGCR10.pdf}
+}
+
+@InProceedings{CSSR12,
+  Title                    = {An NLP Curator (or: How I Learned to Stop Worrying and Love NLP Pipelines)},
+  Author                   = {James Clarke and Vivek Srikumar and Mark Sammons and Dan Roth},
+  Booktitle                = {Proc. of the International Conference on Language Resources and Evaluation (LREC)},
+  Year                     = {2012},
+Month-omit = {5},
+
+Url-omit = {http://cogcomp.org/papers/ClarkeSrSaRo2012.pdf}
+}
+
+@Other{Connor11,
+  Title                    = {Minimal Supervision for Language Learning: Bootstrapping Global Patterns from Local Knowledge},
+  Author                   = {M. Connor},
+  Booktitle                = {UIUC PhD Thesis},
+Url-omit = {http://cogcomp.org/papers/Connor11.pdf},
+  Year                     = {2011}
+}
+
+@InCollection{ConnorFiRo12,
+  Title                    = {Starting from Scratch in Semantic Role Labeling: Early Indirect Supervision},
+  Author                   = {Michael Connor and Cynthia Fisher and Dan Roth},
+Publisher-omit = {Springer},
+  Year                     = {2012},
+  Editor                   = {A. Alishahi and T. Poibeau and A. Korhonen},
+Month-omit = {11},
+
+  Journal                  = {Cognitive Aspects of Computational Language Acquisition},
+Url-omit = {http://cogcomp.org/papers/ConnorFiRo12.pdf}
+}
+
+@InProceedings{ConnorFiRo11,
+  Title                    = {The Origin of Syntactic Bootstrapping: A computational Model},
+  Author                   = {M. Connor and C. Fisher and D. Roth},
+  Booktitle                = {Proc. of the Boston University Conference on Language Development},
+  Year                     = {2011}
+}
+
+@InProceedings{ConnorFiRo11a,
+  Title                    = {Online Latent Structure Training for Language Acquisition},
+  Author                   = {M. Connor and C. Fisher and D. Roth},
+  Booktitle                = {Proc. of the International Joint Conference on Artificial Intelligence (IJCAI)},
+  Year                     = {2011},
+Month-omit = {7},
+
+  Comment                  = {Indirect supervision; language acquisition; BabySRL; psycholinguistically plausible features; },
+  Funding                  = {Psych},
+  Projects                 = {PSYCHO},
+Url-omit = {http://cogcomp.org/papers/ConnorFiRo11.pdf}
+}
+
+@InProceedings{CGFR10,
+  Title                    = {Starting from Scratch in Semantic Role Labeling},
+  Author                   = {M. Connor and Y. Gertner and C. Fisher and D. Roth},
+  Booktitle                = {Proc. of the Annual Meeting of the Association for Computational Linguistics (ACL)},
+  Year                     = {2010},
+
+Address-omit = {Uppsala, Sweden},
+Month-omit = {7},
+Publisher-omit = {Association for Computational Linguistics},
+
+  Comment                  = {Minimal supervision; language acquisition; BabySRL; psycholinguistically plausible features; unsupervised HMM; background knowledge and linguistic constraints},
+  Funding                  = {Psych},
+  Projects                 = {PSYCHO},
+Url-omit = {http://cogcomp.org/papers/CGFR10.pdf}
+}
+
+@InProceedings{CGFR09,
+  Title                    = {Minimally Supervised Model of Early Language Acquisition},
+  Author                   = {M. Connor and Y. Gertner and C. Fisher and D. Roth},
+  Booktitle                = {Proc. of the Conference on Computational Natural Language Learning (CoNLL)},
+  Year                     = {2009},
+Month-omit = {6},
+
+  Comment                  = {Minimal supervision; language acquisition; BabySRL; a semantic role labeling system with simple, psycholinguistically plausible features; trained using background knowledge plus linguistic constraints},
+  Funding                  = {Psych},
+  Projects                 = {PSYCHO},
+Url-omit = {http://cogcomp.org/papers/CGFR09.pdf}
+}
+
+@InProceedings{CGFR08,
+  Title                    = {Baby SRL: Modeling Early Language Acquisition},
+  Author                   = {M. Connor and Y. Gertner and C. Fisher and D. Roth},
+  Booktitle                = {Proc. of the Conference on Computational Natural Language Learning (CoNLL)},
+  Year                     = {2008},
+Month-omit = {8},
+
+  Comment                  = {Evaluating the psycholinguistics structure-mapping assumption; a semantic role labeling system with simple, psycholinguistically plausible features; language acquisition},
+  Funding                  = {Psych},
+  Projects                 = {PSYCHO},
+Url-omit = {http://cogcomp.org/papers/CGFR08.pdf}
+}
+
+@InProceedings{ConnorRo07,
+  Title                    = {Context Sensitive Paraphrasing with a Single Unsupervised Classifier},
+  Author                   = {M. Connor and D. Roth},
+  Booktitle                = {Proc. of the European Conference on Machine Learning (ECML)},
+  Year                     = {2007},
+Month-omit = {9},
+
+  Acceptance               = {69/592 (12\%) (regular papers)},
+  Comment                  = {Trains a single classifier to decided context sensitive paraphrases of verbs. Bootstraps training set through unsupervised training of subtask classifiers and confident example selection.},
+  Funding                  = {ITR-EDU,Psych},
+  Projects                 = {NLP,LP,TE,USS},
+Url-omit = {http://cogcomp.org/papers/ConnorRo07.pdf}
+}
+
+@Other{Cumby01,
+  Title                    = {Learning family relationships via propositional means},
+  Author                   = {C. Cumby},
+  Comment                  = {Senior Thesis, UIUC, Dept. of Computer Science},
+  Funding                  = {NSF98,KDI},
+Month-omit = {5},
+  Projects                 = {KR,LT},
+Url-omit = {http://cogcomp.org/papers/family.pdf},
+  Year                     = {2001}
+}
+
+@InProceedings{CumbyRo03,
+  Title                    = {On Kernel Methods for Relational Learning},
+  Author                   = {C. Cumby and D. Roth},
+  Booktitle                = {Proc. of the International Conference on Machine Learning (ICML)},
+  Year                     = {2003},
+Pages-omit = {107--114},
+
+  Acceptance               = {118-371 (32\%)},
+  Comment                  = {Parameterized kernels over structures. Relational Kernels. Advantages and disadvantages of graph kernels.},
+  Funding                  = {NSF98,ITR-BI,CAREER},
+  Projects                 = {LT,KR},
+Url-omit = {http://cogcomp.org/papers/CumbyRo03.pdf}
+}
+
+@Other{CumbyRo03a,
+  Title                    = {Feature Extraction Languages for Propositionalized Relational Learning},
+  Acceptance               = {33/40 (83\%)},
+  Author                   = {C. Cumby and D. Roth},
+  Booktitle                = {Proc. of the International Joint Conference on Artificial Intelligence (IJCAI)},
+  Funding                  = {NSF98,ITR-BI,CAREER},
+  Projects                 = {LT,KR,KINDLE},
+Url-omit = {http://cogcomp.org/papers/CumbyRo03a.pdf},
+  Year                     = {2003}
+}
+
+@TechReport{CumbyRo03b,
+  Title                    = {Kernel Methods for Relational Learning},
+  Author                   = {C. Cumby and D. Roth},
+  Institution              = {UIUC Computer Science Department},
+  Year                     = {2003},
+Month-omit = {5},
+Number-omit = {UIUCDCS-R-2003-2345},
+
+  Funding                  = {NSF98,ITR-BI,CAREER},
+  Invisible                = {true},
+  Projects                 = {LT,KR},
+Url-omit = {http://cogcomp.org/papers/CumbyRo03c.pdf}
+}
+
+@TechReport{CumbyRo03c,
+  Title                    = {Feature Extraction Languages for Propositionalized Relational Learning},
+  Author                   = {C. Cumby and D. Roth},
+  Institution              = {UIUC Computer Science Department},
+  Year                     = {2003},
+Month-omit = {5},
+Number-omit = {UIUCDCS-R-2003-2346},
+
+  Funding                  = {NSF98,ITR-BI,CAREER},
+  Invisible                = {true},
+  Projects                 = {LT,KR},
+Url-omit = {http://cogcomp.org/papers/CumbyRo03b.pdf}
+}
+
+@InProceedings{CumbyRo02,
+  Title                    = {Learning with Feature Description Logics},
+  Author                   = {C. Cumby and D. Roth},
+  Booktitle                = {Proc. of the International Conference on Inductive Logic Programming (ILP)},
+  Year                     = {2002},
+Pages-omit = {32--47},
+
+  Comment                  = {A Description Logic based Formalism for Feature Extraction; Expressive Features; A language for Feature Extraction},
+  Funding                  = {NSF98,ITR-MIT,CAREER},
+  Projects                 = {KR,KINDLE},
+Url-omit = {http://cogcomp.org/papers/ilp02.pdf}
+}
+
+@InProceedings{CumbyRo00,
+  Title                    = {Relational Representations that facilitate learning},
+  Author                   = {C. Cumby and D. Roth},
+  Booktitle                = {Proc. of the International Conference on Principles of Knowledge Representation and Reasoning (KR)},
+  Year                     = {2000},
+Pages-omit = {425--434},
+
+  Acceptance               = {62/172 (36\%)},
+  Comment                  = {FEX: feature extraction language; relational features; relational generation functions},
+  Funding                  = {NSF98,KDI},
+  Projects                 = {LT,KR},
+Url-omit = {http://cogcomp.org/papers/kr00.pdf}
+}
+
+@Article{DDMR09,
+  Title                    = {Guest Editors Introduction: Recognizing Textual Entailment: Rational, Evaluation and Approaches},
+  Author                   = {I. Dagan and B. Dolan and B. Magnini and D. Roth},
+  Journal                  = {Journal of Natural Language Engineering},
+  Year                     = {2009},
+Pages-omit = {459--476},
+Volume-omit = {15},
+
+  Projects                 = {TE},
+Publisher-omit = {Cambridge University Press}
+}
+
+@InProceedings{DaganKaRo97,
+  Title                    = {Mistake-Driven Learning in Text Categorization},
+  Author                   = {I. Dagan and Y. Karov and D. Roth},
+  Booktitle                = {Proc. of the Conference on Empirical Methods in Natural Language Processing (EMNLP)},
+  Year                     = {1997},
+Month-omit = {8},
+Pages-omit = {55-63},
+
+Url-omit = {http://cogcomp.org/papers/DaganKaRo97.pdf}
+}
+
+@Unpublished{DRSZ13,
+  Title                    = {Recognizing Textual Entailment: Models and Applications},
+  Author                   = {Ido Dagan and Dan Roth and Mark Sammons and Fabio Massimo Zanzoto},
+
+Month-omit = {7},
+  Year                     = {2013},
+
+  Booktitle                = {Recognizing Textual Entailment: Models and Applications},
+Publisher-omit = {Morgan and Claypool}
+}
+
+@Article{DanielsMiRo97,
+  Title                    = {Finding the Maximum Area Axis-Parallel Rectangle in a Polygon},
+  Author                   = {K. Daniels and V. J. Milenkovic and D. Roth},
+  Journal                  = {Computational Geometry: Theory and Applications},
+  Year                     = {1997},
+
+Month-omit = {1},
+Number-omit = {1-2},
+Pages-omit = {125--148},
+Volume-omit = {7},
+
+Url-omit = {http://cogcomp.org/papers/maaprJ.pdf}
+}
+
+@InProceedings{DanielsMiRo93,
+  Title                    = {Finding the Maximum Area Axis-Parallel Rectangle in a Simple Polygon},
+  Author                   = {K. Daniels and V. J. Milenkovic and D. Roth},
+  Booktitle                = {Proc. of the Canadian Conference on Computational Geometry (CCCG)},
+  Year                     = {1993},
+Pages-omit = {322--327}
+}
+
+@Article{DayaRoWi08,
+  Title                    = {Learning Hebrew Roots: Machine Learning with Linguistic Constraints},
+  Author                   = {E. Daya and D. Roth and S. Wintner},
+  Journal                  = {Computational Linguistics},
+  Year                     = {2008},
+Number-omit = {3},
+Volume-omit = {34},
+
+  Funding                  = {CAREER,MURI, REFLEX},
+  Projects                 = {LnI,SI,NLP},
+Url-omit = {http://cogcomp.org/papers/DayaRoWi08.pdf}
+}
+
+@InProceedings{DayaRoWi04,
+  Title                    = {Learning Hebrew Roots: Machine Learning with Linguistic Constraints},
+  Author                   = {E. Daya and D. Roth and S. Wintner},
+  Booktitle                = {Proc. of the Conference on Empirical Methods in Natural Language Processing (EMNLP)},
+  Year                     = {2004},
+Month-omit = {7},
+Pages-omit = {168--178},
+
+  Comment                  = {Inference with Classifiers; Learning and Inference with Constraints; Hebrew Morphology},
+  Funding                  = {CAREER,MURI, REFLEX},
+  Projects                 = {LnI,SI,NLP},
+Url-omit = {http://cogcomp.org/papers/DayaRoWi04.pdf}
+}
+
+@Other{Do12,
+  Title                    = {Background Knowledge in Learning-Based Relation Extraction},
+  Author                   = {Quang Do},
+  Booktitle                = {UIUC PhD Thesis},
+Url-omit = {http://cogcomp.org/papers/Do12.pdf},
+  Year                     = {2012}
+}
+
+@InProceedings{DoChRo11,
+  Title                    = {Minimally Supervised Event Causality Identification},
+  Author                   = {Q. Do and Y. Chan and D. Roth},
+  Booktitle                = {Proc. of the Conference on Empirical Methods in Natural Language Processing (EMNLP)},
+  Year                     = {2011},
+
+Address-omit = {Edinburgh, Scotland},
+Month-omit = {7},
+
+  Funding                  = {MR},
+Url-omit = {http://cogcomp.org/papers/DoChaRo11.pdf}
+}
+
+@InProceedings{DoLuRo12,
+  Title                    = {Joint Inference for Event Timeline Construction},
+  Author                   = {Quang Do and Wei Lu and Dan Roth},
+  Booktitle                = {Proc. of the Conference on Empirical Methods in Natural Language Processing (EMNLP)},
+  Year                     = {2012},
+
+Url-omit = {http://cogcomp.org/papers/DoLuRo12.pdf}
+}
+
+@Article{DoRo12,
+  Title                    = {Exploiting the Wikipedia Structure in Local and Global Classification of Taxonomic Relations},
+  Author                   = {Quang Do and Dan Roth},
+  Journal                  = {Journal of Natural Language Engineering (JNLE)},
+  Year                     = {2012},
+
+Month-omit = {4},
+Number-omit = {2},
+Pages-omit = {235-262},
+Volume-omit = {18},
+
+  Comment                  = {http://journals.cambridge.org/action/displayAbstract?fromPage=online&aid=8511905&fulltextType=RA&fileId=S1351324912000046},
+Publisher-omit = {Cambridge University Press},
+Url-omit = {http://cogcomp.org/papers/DoRo12.pdf}
+}
+
+@InProceedings{DoRo10,
+  Title                    = {Relational Constraints based Taxonomic Relation Classification},
+  Author                   = {Q. Do and D. Roth},
+  Booktitle                = {Proc. of the Conference on Empirical Methods in Natural Language Processing (EMNLP)},
+  Year                     = {2010},
+
+Address-omit = {Massachusetts, USA},
+Month-omit = {10},
+Pages-omit = {1099-1109},
+
+  Funding                  = {DARPA},
+  Projects                 = {Machine Reading},
+Url-omit = {http://cogcomp.org/papers/DoRo10.pdf}
+}
+
+@TechReport{DRSTV09,
+  Title                    = {Robust, Light-weight Approaches to compute Lexical Similarity},
+  Author                   = {Q. Do and D. Roth and M. Sammons and Y. Tu and V. Vydiswaran},
+  Year                     = {2009},
+
+  Booktitle                = {Computer Science Research and Technical Reports, University of Illinois},
+Url-omit = {http://cogcomp.org/papers/DRSTV09.pdf}
+}
+
+@TechReport{DoanLiRo06,
+  Title                    = {MEDIATE: Learning to match entity mentions across text and data bases},
+  Author                   = {A. Doan and X. Li and D. Roth},
+  Institution              = {UIUC Computer Science Department},
+  Year                     = {2006},
+Number-omit = {No. UIUCDCS-R-2006-2692},
+
+  Comment                  = {UIUC Tech Report UIUCDCS-R-2006-2692. Semantic Integration; Entity Uncertainty; Automatic matching of entity mentions across text and databases.},
+  Funding                  = {MURI,ITR-BI},
+  Invisible                = {true},
+  Projects                 = {MIRROR,COREF,NER},
+Url-omit = {http://cogcomp.org/papers/DoanLiRo06.pdf}
+}
+
+@InProceedings{ECGR09,
+  Title                    = {Reading to Learn: Constructing Features from Semantic Abstracts},
+  Author                   = {J. Eisenstein and J. Clarke and D. Goldwasser and D. Roth},
+  Booktitle                = {Proc. of the Conference on Empirical Methods in Natural Language Processing (EMNLP)},
+  Year                     = {2009},
+
+Address-omit = {Singapore},
+
+  Comment                  = {Proposes a novel form of semantic analysis where the goal is to obtain a high-level semantic abstract of documents in a representation that facilitates learning. The abstract is obtained through a generative model that requires no labeled data. The semantic abstract is converted into a transformed feature space for relational learning.},
+  Funding                  = {SoD, BL},
+  Projects                 = {COMP, USS},
+Url-omit = {http://cogcomp.org/papers/ECGR09.pdf}
+}
+
+@InProceedings{Even-ZoharRo01,
+  Title                    = {A Sequential Model for Multi Class Classification},
+  Author                   = {Y. Even-Zohar and D. Roth},
+  Booktitle                = {Proc. of the Conference on Empirical Methods in Natural Language Processing (EMNLP)},
+  Year                     = {2001},
+Pages-omit = {10-19},
+
+  Acceptance               = {21/65 (32\%)},
+  Comment                  = {Multiclass classification: reducing the number of candidate classes; part-of-speech (POS) tagging},
+  Funding                  = {ITR-MIT,NSF98,KDI},
+  Projects                 = {MCR,LT,MC},
+Url-omit = {http://cogcomp.org/papers/emnlp01.pdf}
+}
+
+@InProceedings{Even-ZoharRo00,
+  Title                    = {A classification approach to word prediction},
+  Author                   = {Y. Even-Zohar and D. Roth},
+  Booktitle                = {Proc. of the Annual Conference of the North American Chapter of the Association for Computational Linguistics (NAACL)},
+  Year                     = {2000},
+Pages-omit = {124-131},
+
+  Acceptance               = {43/166 (26\%)},
+  Comment                  = {Learning with expressive features; dependency parse based features; verb prediction},
+  Funding                  = {NSF98,KDI},
+  Projects                 = {LT,KR},
+Url-omit = {http://cogcomp.org/papers/naacl00.pdf}
+}
+
+@InProceedings{Even-ZoharRoZe99,
+  Title                    = {Word Clustering via Classification},
+  Author                   = {Y. Even-Zohar and D. Roth and D. Zelenko},
+  Booktitle                = {Proc. of the Bar-Ilan Symposium on Foundations of Artificial Intelligence (BISFAI)},
+  Year                     = {1999},
+
+Address-omit = {Bar-Ilan, Israel},
+
+  Acceptance               = {78/160 (48\%)},
+  Funding                  = {NSF98,KDI},
+Url-omit = {http://cogcomp.org/papers/Even-ZoharRoZe99.pdf}
+}
+
+@Other{FKPWR15,
+  Title                    = {ILLINOIS-PROFILER: Knowledge Schemas at Scale},
+  Author                   = {Zhiye Fei and Daniel Khashabi and Haoruo Peng and Hao Wu and Dan Roth},
+  Booktitle                = {Workshop on Cognitive Knowledge Acquisition and Applications, Proc. of the International Joint Conference on Artificial Intelligence (IJCAI)},
+Url-omit = {http://cogcomp.org/papers/profiler_ijcai.pdf},
+  Year                     = {2015}
+}
+
+@Article{FungRo05,
+  Title                    = {Guest Editors Introduction: Machine Learning in Speech and Language Technologies},
+  Author                   = {P. Fung and D. Roth},
+  Journal                  = {Machine Learning},
+  Year                     = {2005},
+Number-omit = {1/2/3},
+Pages-omit = {1-6},
+Volume-omit = {60},
+
+  Funding                  = {ITR-BI,CAREER,MURI},
+  Projects                 = {LNL,LT},
+Url-omit = {http://cogcomp.org/papers/FungRo05.pdf}
+}
+
+@InProceedings{GargHaRo02,
+  Title                    = {On generalization bounds, projection profile, and margin distribution},
+  Author                   = {A. Garg and S. Har-Peled and D. Roth},
+  Booktitle                = {Proc. of the International Conference on Machine Learning (ICML)},
+  Year                     = {2002},
+Pages-omit = {171--178},
+
+  Acceptance               = {86/261 (33\%)},
+  Comment                  = {Random Projection; Generalization Bounds for Linear Classifiers.},
+  Funding                  = {ITR-MIT,ITR-BI,CAREER},
+  Projects                 = {LCC,LT},
+Url-omit = {http://cogcomp.org/papers/icml02.pdf}
+}
+
+@TechReport{GargHaRo01,
+  Title                    = {Generalization Bounds for Linear Learning Algorithms},
+  Author                   = {A. Garg and S. Har-Peled and D. Roth},
+  Institution              = {UIUC Computer Science Department},
+  Year                     = {2001},
+Month-omit = {6},
+Number-omit = {UIUCDCS-R-2001-2232},
+
+  Funding                  = {ITR-MIT,ITR-BI,CAREER},
+  Invisible                = {true},
+  Projects                 = {LCC,LT},
+Url-omit = {http://cogcomp.org/papers/GargHaRo01.pdf}
+}
+
+@InProceedings{GargRo03,
+  Title                    = {Margin Distribution and Learning Algorithms},
+  Author                   = {A. Garg and D. Roth},
+  Booktitle                = {Proc. of the International Conference on Machine Learning (ICML)},
+  Year                     = {2003},
+Pages-omit = {210--217},
+
+  Acceptance               = {118/371 (32\%)},
+  Comment                  = {Linear classifiers that optimize the margin distribution},
+  Funding                  = {ITR-BI,ITR-MIT,CAREER},
+  Projects                 = {LT,LCC},
+Url-omit = {http://cogcomp.org/papers/GargRo03.pdf}
+}
+
+@InProceedings{GargRo01,
+  Title                    = {Understanding Probabilistic Classifiers},
+  Author                   = {A. Garg and D. Roth},
+  Booktitle                = {Proc. of the European Conference on Machine Learning (ECML)},
+  Year                     = {2001},
+Pages-omit = {179--191},
+
+  Acceptance               = {90/240 (37.5\%)},
+  Comment                  = {An Information Theory based explanation of the good performance of naive Bayes},
+  Funding                  = {ITR-MIT ITR-BI CAREER NSF98},
+  Projects                 = {DPL,LT},
+Url-omit = {http://cogcomp.org/papers/ecml01.pdf}
+}
+
+@InProceedings{GargRo01a,
+  Title                    = {Learning Coherent Concepts},
+  Author                   = {A. Garg and D. Roth},
+  Booktitle                = {Proc. of the International Workshop on Algorithmic Learning Theory (ALT)},
+  Year                     = {2001},
+Pages-omit = {135--150},
+Publisher-omit = {Springer-Verlag},
+
+  Acceptance               = {21/42 (50\%)},
+  Funding                  = {ITR-MIT ITR-BI CAREER},
+  Projects                 = {LCC,LT},
+Url-omit = {http://cogcomp.org/papers/alt01.pdf}
+}
+
+@TechReport{GargRo01b,
+  Title                    = {Understanding Probabilistic Classifiers},
+  Author                   = {A. Garg and D. Roth},
+  Institution              = {UIUC Computer Science Department},
+  Year                     = {2001},
+Month-omit = {3},
+Number-omit = {UIUCDCS-R-2001-2205},
+
+  Funding                  = {ITR-MIT,ITR-BI,CAREER,NSF98},
+  Invisible                = {true},
+  Projects                 = {DPL,LT},
+Url-omit = {http://cogcomp.org/papers/GargRo01b.pdf}
+}
+
+@Other{GirjuRoSa05,
+  Title                    = {Token-level Disambiguation of VerbNet classes},
+  Author                   = {R. Girju and D. Roth and M. Sammons},
+  Booktitle                = {Proc. of the Interdisciplinary Workshop on Verb Features and Verb Classes (Verb Workshop)},
+  Comment                  = {Context Sensitive Identification of VerbNet Classes; Levin Classes.},
+  Funding                  = {KINDLE,TRECC},
+  Projects                 = {SM},
+Url-omit = {http://cogcomp.org/papers/GirjuRoSa05.pdf},
+  Year                     = {2005}
+}
+
+@Article{GHJKRRC09,
+  Title                    = {Who's Who in Your Digital Collection: Developing a Tool for Name Disambiguation and Identity Resolution},
+  Author                   = {C. Godby and P. Hswe and L. Jackson and J. Klavans and L. Ratinov and D. Roth and H. Cho},
+  Year                     = {2009},
+
+  Booktitle                = {Journal of the Chicago Colloquium on Digital Humanities and Computer Science (Proc. of the Chicago Colloquium on Digital Humanities and Computer Science (DHCS))},
+  Comment                  = {Named Entity Recognition (NER) and Wikification; Applications to Digital Libraries},
+  Funding                  = {DARPA,LIBRARY},
+  Projects                 = {IR,LBJ},
+Url-omit = {http://cogcomp.org/papers/GHJKRRC09.pdf}
+}
+
+@Article{GoldingRo99,
+  Title                    = {A Winnow based approach to Context-Sensitive Spelling Correction},
+  Author                   = {A. R. Golding and D. Roth},
+  Journal                  = {Machine Learning},
+  Year                     = {1999},
+Number-omit = {1-3},
+Pages-omit = {107--130},
+Volume-omit = {34},
+
+  Comment                  = {Special Issue on Machine Learning and Natural Language.},
+  Funding                  = {NSF98 KDI},
+  Projects                 = {KR,LT,NLP},
+Url-omit = {http://cogcomp.org/papers/spellJ.pdf}
+}
+
+@InProceedings{GoldingRo96,
+  Title                    = {Applying Winnow to Context-Sensitive Spelling Correction},
+  Author                   = {A. R. Golding and D. Roth},
+  Booktitle                = {Proc. of the International Conference on Machine Learning (ICML)},
+  Year                     = {1996},
+Pages-omit = {182--190},
+
+  Acceptance               = {63/257 (24\%)},
+Url-omit = {http://cogcomp.org/papers/spell.pdf}
+}
+
+@Other{Goldwasser12,
+  Title                    = {Learning from Natural Instructions},
+  Author                   = {Dan Goldwasser },
+  Booktitle                = {UIUC PhD Thesis},
+Url-omit = {http://cogcomp.org/papers/Goldwasser12.pdf},
+  Year                     = {2012}
+}
+
+@InProceedings{GCTR09,
+  Title                    = {Constraint Driven Transliteration Discovery},
+  Author                   = {D. Goldwasser and M. Chang and Y. Tu and D. Roth},
+  Booktitle                = {Proc. of the Conference on Recent Advances in Natural Language Processing},
+  Year                     = {2009},
+  Editor                   = {Nicolas Nicolov},
+Publisher-omit = {John Benjamins},
+
+  Comment                  = {Extending Constrained Conditional Model based transliteration; Combines EMNLP'08 and NAACL'09},
+  Funding                  = {BL,SoD},
+  Projects                 = {CCG,TL},
+Url-omit = {http://cogcomp.org/papers/GCTR09.pdf}
+}
+
+@InProceedings{GRCR11,
+  Title                    = {Confidence Driven Unsupervised Semantic Parsing },
+  Author                   = {D. Goldwasser and R. Reichart and J. Clarke and D. Roth },
+  Booktitle                = {Proc. of the Annual Meeting of the Association for Computational Linguistics (ACL)},
+  Year                     = {2011},
+
+Url-omit = {http://cogcomp.org/papers/main(2).pdf}
+}
+
+@Article{GoldwasserRo14,
+  Title                    = {Learning from Natural Instructions},
+  Author                   = {Dan Goldwasser and Dan Roth},
+  Journal                  = {Machine Learning},
+  Year                     = {2014},
+
+Month-omit = {2},
+Number-omit = {2},
+Pages-omit = {205-232},
+Volume-omit = {94},
+
+Publisher-omit = {Springer},
+Url-omit = {http://cogcomp.org/papers/GoldwasserRo14.pdf}
+}
+
+@InProceedings{GoldwasserRo13,
+  Title                    = {Leveraging Domain-Independent Information in Semantic Parsing},
+  Author                   = {Dan Goldwasser and Dan Roth},
+  Booktitle                = {Proc. of the Annual Meeting of the Association for Computational Linguistics (ACL)},
+  Year                     = {2013},
+
+Url-omit = {http://cogcomp.org/papers/GoldwasserRoth13.pdf}
+}
+
+@InProceedings{GoldwasserRo11,
+  Title                    = {Learning from Natural Instructions},
+  Author                   = {D. Goldwasser and D. Roth},
+  Booktitle                = {Proc. of the International Joint Conference on Artificial Intelligence (IJCAI)},
+  Year                     = {2011},
+
+Url-omit = {http://cogcomp.org/papers/GoldwasserRo11(2).pdf}
+}
+
+@InProceedings{GoldwasserRo08,
+  Title                    = {Transliteration as Constrained Optimization},
+  Author                   = {D. Goldwasser and D. Roth},
+  Booktitle                = {Proc. of the Conference on Empirical Methods in Natural Language Processing (EMNLP)},
+  Year                     = {2008},
+Month-omit = {10},
+
+  Comment                  = {Transliteration; Constrained optimization; Named entity discovery; bilingual corpora; feature selection for transliteration; Discriminative training of Objective function; Integer Linear Programming;ILP; Hebrew transliteration},
+  Funding                  = {DARPA,SoD},
+  Projects                 = {CCM,TL},
+Url-omit = {http://cogcomp.org/papers/GoldwasserRo08a.pdf}
+}
+
+@InProceedings{GoldwasserRo08a,
+  Title                    = {Active Sample Selection for Named Entity Transliteration},
+  Author                   = {D. Goldwasser and D. Roth},
+  Booktitle                = {Proc. of the Annual Conference of the North American Chapter of the Association for Computational Linguistics (NAACL)},
+  Year                     = {2008},
+
+Address-omit = {Columbus, OH, USA},
+Month-omit = {6},
+Publisher-omit = {Association for Computational Linguistics},
+
+  Comment                  = {Named entity discovery; bilingual corpora; active sampling; data selection; domain adaptation; Russian transliteration; Hebrew transliteration},
+  Funding                  = {Darpa},
+  Projects                 = {AL,TL},
+Url-omit = {http://cogcomp.org/papers/GoldwasserRo08.pdf}
+}
+
+@Article{GreinerGrRo02,
+  Title                    = {Learning Cost-Sensitive Active Classifiers},
+  Author                   = {R. Greiner and A. Grove and D. Roth},
+  Journal                  = {Artificial Intelligence},
+  Year                     = {2002},
+Number-omit = {2},
+Pages-omit = {137--174},
+Volume-omit = {139},
+
+  Comment                  = {Earlier version appeared in ICML'96},
+  Funding                  = {NSF98 CAREER},
+  Projects                 = {DPL,LT,LP},
+Url-omit = {http://cogcomp.org/papers/activeJ.pdf}
+}
+
+@InProceedings{GreinerGrRo96,
+  Title                    = {Learning Active Classifiers},
+  Author                   = {R. Greiner and A. Grove and D. Roth},
+  Booktitle                = {Proc. of the International Conference on Machine Learning (ICML)},
+  Year                     = {1996},
+Pages-omit = {207--215},
+
+  Acceptance               = {63/257 (24\%)},
+Url-omit = {http://cogcomp.org/papers/active.pdf}
+}
+
+@Article{GroveRo01,
+  Title                    = {Linear concepts and hidden variables},
+  Author                   = {A. Grove and D. Roth},
+  Journal                  = {Machine Learning},
+  Year                     = {2001},
+Number-omit = {1/2},
+Pages-omit = {123--141},
+Volume-omit = {42},
+
+  Funding                  = {NSF98,CAREER},
+  Projects                 = {DPL,LT},
+Url-omit = {http://cogcomp.org/papers/hiddenJ.pdf}
+}
+
+@InProceedings{GroveRo98,
+  Title                    = {Linear concepts and hidden variables: An empirical study},
+  Author                   = {A. Grove and D. Roth},
+  Booktitle                = {Proc. of the Conference on Neural Information Processing Systems (NIPS)},
+  Year                     = {1998},
+Pages-omit = {500--506},
+Publisher-omit = {MIT Press},
+
+  Acceptance               = {150/491 (30\%)},
+  Comment                  = {Margin Winnow (Perceptron); discriminative vs. generative},
+Url-omit = {http://cogcomp.org/papers/nips98.pdf}
+}
+
+@InProceedings{GuptaSaRo16,
+  Title                    = {Will I Get in? - Modeling the Graduate Admission Process for American Universities},
+  Author                   = {Narender Gupta and Aman Sawhney and Dan Roth},
+  Booktitle                = {2016 IEEE 16th International Conference on Data Mining Workshops (ICDMW)},
+  Year                     = {2016},
+Pages-omit = {631--638},
+
+Url-omit = {http://cogcomp.org/papers/Will_I_Get_In.pdf}
+}
+
+@InProceedings{GuptaSiRo17,
+  Title                    = {Entity Linking via Joint Encoding of Types, Descriptions, and Context},
+  Author                   = {Nitish Gupta and Sameer Singh and Dan Roth},
+  Booktitle                = {Proc. of the Conference on Empirical Methods in Natural Language Processing (EMNLP)},
+  Year                     = {2017},
+
+Url-omit = {http://cogcomp.org/papers/GuptaSiRo17.pdf}
+}
+
+@TechReport{HannekeRo04,
+  Title                    = {Iterative Labeling for Semi-Supervised Learning},
+  Author                   = {S. Hanneke and D. Roth},
+  Institution              = {UIUC Computer Science Department},
+  Year                     = {2004},
+Month-omit = {6},
+Number-omit = {UIUCDCS-R-2004-2442},
+
+  Funding                  = {ITR-MIT,MURI,TRECC,CLUSTER},
+  Invisible                = {true},
+  Projects                 = {LP,USS},
+Url-omit = {http://cogcomp.org/papers/HannekeRo04.pdf}
+}
+
+@InProceedings{Har-PeledRoZi07,
+  Title                    = {Maximum Margin Coresets for Active and Noise Tolerant Learning},
+  Author                   = {S. Har-Peled and D. Roth and D. Zimak},
+  Booktitle                = {Proc. of the International Joint Conference on Artificial Intelligence (IJCAI)},
+  Year                     = {2007},
+Pages-omit = {LT},
+
+  Acceptance               = {212/1353 (16\%)},
+  Comment                  = {Learning large margin halfspaces using coresets; algorithm and analysis; applications include analysis of large margin active learning and an algorithm for agnostic learning in the presence of outlier noise.},
+  Funding                  = {KINDLE,REFLEX,MURI,XPRESSMP},
+  Projects                 = {IE,LINL,SP,ILP,AL},
+Url-omit = {http://cogcomp.org/papers/Har-PeledRoZi07.pdf}
+}
+
+@TechReport{Har-PeledRoZi06,
+  Title                    = {Maximum Margin Coresets for Active and Noise Tolerant Learning},
+  Author                   = {S. Har-Peled and D. Roth and D. Zimak},
+  Institution              = {UIUC Computer Science Department},
+  Year                     = {2006},
+Number-omit = {No. UIUCDCS-R-2006-2784},
+
+  Funding                  = {ITR-BI,ITR-MIT},
+  Invisible                = {true},
+  Projects                 = {AL}
+}
+
+@InProceedings{Har-PeledRoZi03,
+  Title                    = {Constraint Classification for Multiclass Classification and Ranking},
+  Author                   = {S. Har-Peled and D. Roth and D. Zimak},
+  Booktitle                = {Proc. of the Conference on Neural Information Processing Systems (NIPS)},
+  Year                     = {2003},
+Pages-omit = {785--792},
+
+  Acceptance               = {207/694 (30\%)},
+  Funding                  = {ITR-MIT ITR-BI CAREER},
+  Projects                 = {CCR,LT,MC},
+Url-omit = {http://cogcomp.org/papers/nips02.pdf}
+}
+
+@InProceedings{Har-PeledRoZi02,
+  Title                    = {Constraint Classification: a new approach to Multiclass Classification},
+  Author                   = {S. Har-Peled and D. Roth and D. Zimak},
+  Booktitle                = {Proc. of the International Workshop on Algorithmic Learning Theory (ALT)},
+  Year                     = {2002},
+Pages-omit = {135--150},
+Publisher-omit = {Springer-Verlag},
+
+  Acceptance               = {21/42 (50\%)},
+  Funding                  = {ITR-MIT,ITR-BI,CAREER},
+  Projects                 = {CCR,LT,MC},
+Url-omit = {http://cogcomp.org/papers/Har-PeledRoZi02.pdf}
+}
+
+@InProceedings{HinrichsCh03,
+  Title                    = {Proceedings of the 41st Annual Meeting of the Association for Computational Linguistics},
+  Author                   = {E. Hinrichs and D. Roth Program Chairs},
+  Year                     = {2003},
+  Editor                   = {E. Hinrichs and D. Roth}
+}
+
+@Other{Jindal13,
+  Title                    = {Information Extraction for Clinical Narratives},
+  Author                   = {Prateek Jindal},
+  Booktitle                = {UIUC PhD Thesis},
+Url-omit = {http://cogcomp.org/papers/Jindal13.pdf},
+  Year                     = {2013}
+}
+
+@InProceedings{JindalGuRo14,
+  Title                    = {Detecting Privacy-Sensitive Events in Medical Text},
+  Author                   = {Prateek Jindal and Carl A. Gunter and Dan Roth},
+  Booktitle                = {Proc. of the ACM Conference on Proc. of the International Conference on Bioinformatics Models, Methods and Algorithms, Computational Biology, and Health Informatics},
+  Year                     = {2014},
+Month-omit = {9},
+
+Url-omit = {http://cogcomp.org/papers/JindalGR14.pdf}
+}
+
+@Article{JindalRo13c,
+  Title                    = {Using Domain Knowledge and Domain-Inspired Discourse Model for Coreference Resolution for Clinical Narratives},
+  Author                   = {Prateek Jindal and Dan Roth},
+  Year                     = {2013},
+
+Month-omit = {3},
+Number-omit = {2},
+Pages-omit = {356-362},
+Volume-omit = {20},
+
+  Acceptance               = {19\%},
+  Booktitle                = {Journal of the American Medical Informatics Association (JAMIA)},
+  Editor                   = {Professor Lucila Ohno-Machado},
+Publisher-omit = {BMJ Publishing Group Ltd},
+Url-omit = {http://cogcomp.org/papers/JindalRo12.pdf}
+}
+
+@Article{JindalRo13,
+  Title                    = {Extraction of Events and Temporal Expressions from Clinical Narratives},
+  Author                   = {P. Jindal and D. Roth},
+  Journal                  = {Journal of Biomedical Informatics (JBI)},
+  Year                     = {2013},
+
+Month-omit = {10},
+
+  Editor                   = {E.H. Shortliffe},
+Url-omit = {http://cogcomp.org/papers/JindalRo13d.pdf}
+}
+
+@InProceedings{JindalRo13a,
+  Title                    = {Using Soft Constraints in Joint Inference for Clinical Concept Recognition},
+  Author                   = {Prateek Jindal and Dan Roth},
+  Booktitle                = {Proc. of the Conference on Empirical Methods in Natural Language Processing (EMNLP)},
+  Year                     = {2013},
+Month-omit = {10},
+
+Url-omit = {http://cogcomp.org/papers/JindalRo13c.pdf}
+}
+
+@InProceedings{JindalRo13b,
+  Title                    = {End-to-End Coreference Resolution for Clinical Narratives},
+  Author                   = {Prateek Jindal and Dan Roth},
+  Booktitle                = {Proc. of the International Joint Conference on Artificial Intelligence (IJCAI)},
+  Year                     = {2013},
+Month-omit = {8},
+Pages-omit = {2106-2112},
+
+  Acceptance               = {19\%},
+  Funding                  = {HHS 90TR003/01},
+Url-omit = {http://cogcomp.org/papers/JindalRo13.pdf}
+}
+
+@InProceedings{JindalRo12,
+  Title                    = {Using Knowledge and Constraints to Find the Best Antecedent},
+  Author                   = {Prateek Jindal and Dan Roth},
+  Booktitle                = {Proc. of the International Conference on Computational Linguistics (COLING)},
+  Year                     = {2012},
+Month-omit = {12},
+Pages-omit = {1327-1342},
+
+  Acceptance               = {20\%},
+  Funding                  = {Grant HHS 90TR0003/01},
+Url-omit = {http://cogcomp.org/papers/JindalRo12b.pdf}
+}
+
+@InProceedings{JindalRo11,
+  Title                    = {Learning from Negative Examples in Set-Expansion},
+  Author                   = {P. Jindal and D. Roth},
+  Booktitle                = {Proc. of the IEEE International Conference on Data Mining (ICDM)},
+  Year                     = {2011},
+Month-omit = {12},
+Pages-omit = {1110-1115},
+
+  Acceptance               = {18\%},
+Url-omit = {http://cogcomp.org/papers/JindalRo11.pdf}
+}
+
+@InProceedings{JindalRoGu14,
+  Title                    = {Joint Inference for End-to-End Coreference Resolution for Clinical Notes},
+  Author                   = {Prateek Jindal and Dan Roth and Carl A. Gunter},
+  Booktitle                = {Proc. of the ACM Conference on Proc. of the International Conference on Bioinformatics Models, Methods and Algorithms, Computational Biology, and Health Informatics},
+  Year                     = {2014},
+Month-omit = {9},
+
+Url-omit = {http://cogcomp.org/papers/p192-jindal.pdf}
+}
+
+@Other{JohriRoTu10,
+  Title                    = {Experts' Retrieval with Multiword-Enhanced Author Topic Model},
+  Author                   = {N. Johri and D. Roth and Y. Tu},
+  Booktitle                = {Proc. of the Annual Conference of the North American Chapter of the Association for Computational Linguistics (NAACL)},
+  Comment                  = {author topic model; multiword expression; expert search; information retrieval},
+  Funding                  = {MIAS},
+  Projects                 = {SEARCH},
+Url-omit = {http://cogcomp.org/papers/JohriRoTu10(1).pdf},
+  Year                     = {2010}
+}
+
+@Article{KhardonMaRo99,
+  Title                    = {Reasoning with Examples: Propositional Formulae and Database Dependencies},
+  Author                   = {R. Khardon and H. Mannila and D. Roth},
+  Journal                  = {Acta Informatica},
+  Year                     = {1999},
+
+Month-omit = {7},
+Number-omit = {4},
+Pages-omit = {267--286},
+Volume-omit = {36},
+
+Url-omit = {http://cogcomp.org/papers/db.pdf}
+}
+
+@Article{KhardonRo99,
+  Title                    = {Learning to Reason with a Restricted View},
+  Author                   = {R. Khardon and D. Roth},
+  Journal                  = {Machine Learning},
+  Year                     = {1999},
+Number-omit = {2},
+Pages-omit = {95--117},
+Volume-omit = {35},
+
+Url-omit = {http://cogcomp.org/papers/partialJ.pdf}
+}
+
+@Article{KhardonRo97,
+  Title                    = {Defaults and Relevance in Model Based Reasoning},
+  Author                   = {R. Khardon and D. Roth},
+  Journal                  = {Artificial Intelligence},
+  Year                     = {1997},
+
+Month-omit = {12},
+Number-omit = {1-2},
+Pages-omit = {169--193},
+Volume-omit = {97},
+
+Url-omit = {http://cogcomp.org/papers/relevanceJ.pdf}
+}
+
+@Article{KhardonRo97a,
+  Title                    = {Learning to Reason},
+  Author                   = {R. Khardon and D. Roth},
+  Journal                  = {Journal of the ACM},
+  Year                     = {1997},
+Number-omit = {5},
+Pages-omit = {697--725},
+Volume-omit = {44},
+
+Url-omit = {http://cogcomp.org/papers/l2rJ.pdf}
+}
+
+@Article{KhardonRo96,
+  Title                    = {Reasoning with Models},
+  Author                   = {R. Khardon and D. Roth},
+  Journal                  = {Artificial Intelligence},
+  Year                     = {1996},
+Number-omit = {1-2},
+Pages-omit = {187--213},
+Volume-omit = {87},
+
+  Comment                  = {Characteristic Models of Boolean Functions},
+Url-omit = {http://cogcomp.org/papers/modelsJ.pdf}
+}
+
+@TechReport{KhardonRo95,
+  Title                    = {Defaults and Relevance in Model Based Reasoning},
+  Author                   = {R. Khardon and D. Roth},
+  Institution              = {Dept. of App. Math. and Computer Science, Weizmann Institute of Science},
+  Year                     = {1995},
+Month-omit = {10},
+Number-omit = {CS95-30},
+
+Url-omit = {http://cogcomp.org/papers/KhardonRo95b.pdf}
+}
+
+@InProceedings{KhardonRo95a,
+  Title                    = {Learning to Reason with a Restricted View},
+  Author                   = {R. Khardon and D. Roth},
+  Booktitle                = {Proc. of the ACM Conference on Computational Learning Theory (COLT)},
+  Year                     = {1995},
+Month-omit = {7},
+Pages-omit = {301--310},
+
+  Acceptance               = {24/74 (32\%)}
+}
+
+@InProceedings{KhardonRo95b,
+  Title                    = {Default-Reasoning with Models},
+  Author                   = {R. Khardon and D. Roth},
+  Booktitle                = {Proc. of the International Joint Conference on Artificial Intelligence (IJCAI)},
+  Year                     = {1995},
+Month-omit = {8},
+Pages-omit = {319--325},
+
+  Acceptance               = {249/112 (22\%)}
+}
+
+@InProceedings{KhardonRo94,
+  Title                    = {A note on Horn Theories},
+  Author                   = {R. Khardon and D. Roth},
+  Year                     = {1994},
+
+  Comment                  = {Manuscript.}
+}
+
+@TechReport{KhardonRo94a,
+  Title                    = {Learning to Reason},
+  Author                   = {R. Khardon and D. Roth},
+  Institution              = {Aiken Computation Lab., Harvard University},
+  Year                     = {1994},
+Month-omit = {1},
+Number-omit = {TR-2-94},
+
+  Invisible                = {true}
+}
+
+@TechReport{KhardonRo94b,
+  Title                    = {Reasoning with Models},
+  Author                   = {R. Khardon and D. Roth},
+  Institution              = {Aiken Computation Lab., Harvard University},
+  Year                     = {1994},
+Month-omit = {1},
+Number-omit = {TR-1-94},
+
+  Invisible                = {true}
+}
+
+@InProceedings{KhardonRo94c,
+  Title                    = {Exploiting Relevance through Model-based reasoning},
+  Author                   = {R. Khardon and D. Roth},
+  Booktitle                = {Proc. of the AAAI Fall Symposium on Relevance},
+  Year                     = {1994},
+Pages-omit = {109-114},
+
+Url-omit = {http://cogcomp.org/papers/relevanceP.pdf}
+}
+
+@InProceedings{KhardonRo94d,
+  Title                    = {Learning to Reason},
+  Author                   = {R. Khardon and D. Roth},
+  Booktitle                = {Proc. of the Conference on Artificial Intelligence (AAAI)},
+  Year                     = {1994},
+Pages-omit = {682--687},
+
+  Acceptance               = {222/725 (31\%)},
+Url-omit = {http://cogcomp.org/papers/KhardonRo94a.pdf}
+}
+
+@InProceedings{KhardonRo94e,
+  Title                    = {Reasoning with Models},
+  Author                   = {R. Khardon and D. Roth},
+  Booktitle                = {Proc. of the Conference on Artificial Intelligence (AAAI)},
+  Year                     = {1994},
+Pages-omit = {1148--1153},
+
+  Acceptance               = {225/725 (31\%)},
+Url-omit = {http://cogcomp.org/papers/KhardonRo94.pdf}
+}
+
+@Article{KhardonRoSe05,
+  Title                    = {Efficiency versus Convergence of Boolean Kernels for On-Line Learning Algorithms},
+  Author                   = {R. Khardon and D. Roth and R. Servedio},
+  Journal                  = {Journal of Machine Learning Research},
+  Year                     = {2005},
+Pages-omit = {341-356},
+Volume-omit = {24},
+
+  Funding                  = {ITR-MIT NSF98 CAREER},
+  Projects                 = {KR,LT},
+Url-omit = {http://cogcomp.org/papers/KhardonRoSe05.pdf}
+}
+
+@InProceedings{KhardonRoSe01,
+  Title                    = {Efficiency versus Convergence of Boolean Kernels for On-Line Learning Algorithms},
+  Author                   = {R. Khardon and D. Roth and R. Servedio},
+  Booktitle                = {Proc. of the Conference on Neural Information Processing Systems (NIPS)},
+  Year                     = {2001},
+
+  Comment                  = {Kernel Perceptron with Exponentially Many mistakes; Hardness of Kernel Winnow.},
+  Funding                  = {ITR-MIT,NSF98,CAREER},
+  Projects                 = {KR,LT},
+Url-omit = {http://cogcomp.org/papers/kernels01.pdf}
+}
+
+@TechReport{KhardonRoSe01a,
+  Title                    = {Efficiency versus Convergence of Boolean Kernels for On-Line Learning Algorithm},
+  Author                   = {R. Khardon and D. Roth and R. Servedio},
+  Institution              = {UIUC Computer Science Department},
+  Year                     = {2001},
+Month-omit = {6},
+Number-omit = {UIUCDCS-R-2001-2233},
+
+  Funding                  = {ITR-MIT,NSF98,CAREER},
+  Invisible                = {true},
+  Projects                 = {KR,LT},
+Url-omit = {http://cogcomp.org/papers/KhardonRoSe01a.pdf}
+}
+
+@InProceedings{KhardonRoVa99,
+  Title                    = {Relational Learning for NLP using Linear Threshold Elements},
+  Author                   = {R. Khardon and D. Roth and L. G. Valiant},
+  Booktitle                = {Proc. of the International Joint Conference on Artificial Intelligence (IJCAI)},
+  Year                     = {1999},
+Pages-omit = {911--917},
+
+  Acceptance               = {195/750 (26\%)},
+  Funding                  = {NSF98 KDI},
+  Projects                 = {KR,LT,NLP},
+Url-omit = {http://cogcomp.org/papers/ijcai99krv.pdf}
+}
+
+@InProceedings{KKSCER16,
+  Title                    = {Question Answering via Integer Programming over Semi-Structured Knowledge},
+  Author                   = {Daniel Khashabi and Tushar Khot and Ashish Sabharwal and Peter Clark and Oren Etzioni and Dan Roth },
+  Booktitle                = {Proc. of the International Joint Conference on Artificial Intelligence (IJCAI)},
+  Year                     = {2016},
+
+Url-omit = {http://cogcomp.org/papers/KKSCER16.pdf}
+}
+
+@InProceedings{KKSR17,
+  Title                    = {Learning What is Essential in Questions},
+  Author                   = {Daniel Khashabi and Tushar Khot and Ashish Sabharwal and Dan Roth },
+  Booktitle                = {The Conference on Computational Natural Language Learning (Proc. of the Conference on Computational Natural Language Learning (CoNLL))},
+  Year                     = {2017},
+
+Url-omit = {http://cogcomp.org/papers/2017_conll_essential_terms.pdf}
+}
+
+@InProceedings{KDDKKPR00,
+  Title                    = {Applying System Combination to Base Noun Phrase Identification},
+  Author                   = {E. F. T. Kim-Sang and W. Daelemans and H. Dejean and R. Koeling and Y. Krymolowski and V. Punyakanok and D. Roth},
+  Booktitle                = {Proc. of the International Conference on Computational Linguistics and Annual Meeting of the Association for Computational Linguistics (COLING-ACL)},
+  Year                     = {2000},
+Pages-omit = {857--863},
+
+  Funding                  = {NSF98,KDI},
+Url-omit = {http://cogcomp.org/papers/KDDKKPR00.pdf}
+}
+
+@Other{Klementiev09,
+  Title                    = {Learning with Incidental Supervision},
+  Author                   = {A. Klementiev},
+  Booktitle                = {UIUC PhD Thesis },
+Url-omit = {http://cogcomp.org/papers/Klementiev09.pdf},
+  Year                     = {2009}
+}
+
+@InCollection{KlementievRo08,
+  Title                    = {Named Entity Transliteration and Discovery in Multilingual Corpora},
+  Author                   = {A. Klementiev and D. Roth},
+  Booktitle                = {Learning Machine Translation},
+Publisher-omit = {MIT Press},
+  Year                     = {2008},
+  Editor                   = {Cyril Goutte and Nicola Cancedda and Marc Dymetman and George Foster},
+
+  Funding                  = {KINDLE,REFLEX},
+  Projects                 = {REFLEX,USS,TL,ADAPT},
+Url-omit = {http://cogcomp.org/papers/KlementievRo08.pdf}
+}
+
+@InProceedings{KlementievRo06,
+  Title                    = {Weakly Supervised Named Entity Transliteration and Discovery from Multilingual Comparable Corpora},
+  Author                   = {A. Klementiev and D. Roth},
+  Booktitle                = {Proc. of the Annual Meeting of the Association for Computational Linguistics (ACL)},
+  Year                     = {2006},
+Month-omit = {7},
+Pages-omit = {USS,TL,ADAPT},
+
+  Comment                  = {Multilingual named entities; multilingual search; multilingual named entities discovery and recognition; discriminatory transliteration model; Fourier Transform for temporal sequence similarity},
+  Funding                  = {KINDLE,REFLEX},
+  Projects                 = {REFLEX,USS,TL,ADAPT},
+Url-omit = {http://cogcomp.org/papers/KlementievRo06a.pdf}
+}
+
+@InProceedings{KlementievRo06a,
+  Title                    = {Named Entity Transliteration and Discovery from Multilingual Comparable Corpora},
+  Author                   = {A. Klementiev and D. Roth},
+  Booktitle                = {Proc. of the Annual Conference of the North American Chapter of the Association for Computational Linguistics (NAACL)},
+  Year                     = {2006},
+Month-omit = {6},
+Pages-omit = {82--88},
+
+  Comment                  = {Multilingual named entities; multilingual search; multilingual named entities discovery and recognition; discriminatory transliteration model; Fourier Transform for temporal sequence similarity},
+  Funding                  = {KINDLE,REFLEX},
+  Projects                 = {REFLEX,TL,USS,ADAPT},
+Url-omit = {http://cogcomp.org/papers/KlementievRo06.pdf}
+}
+
+@Other{KlementievRoSm08,
+  Title                    = {A Framework for Unsupervised Rank Aggregation},
+  Author                   = {A. Klementiev and D. Roth and K. Small},
+  Booktitle                = {Proc. of the ACM SIGIR Conference (SIGIR)},
+  Funding                  = {ITR-EDU, BL, MIAS},
+Month-omit = {7},
+Pages-omit = {32-39},
+  Projects                 = {USS,RANK},
+Url-omit = {http://cogcomp.org/papers/KlementievRoSm08a.pdf},
+  Year                     = {2008}
+}
+
+@InProceedings{KlementievRoSm08a,
+  Title                    = {Unsupervised Rank Aggregation with Distance-Based Models},
+  Author                   = {A. Klementiev and D. Roth and K. Small},
+  Booktitle                = {Proc. of the International Conference on Machine Learning (ICML)},
+  Year                     = {2008},
+Month-omit = {7},
+
+  Acceptance               = {158/583 (27\%) (regular papers)},
+  Comment                  = {We propose a mathematical and algorithmic framework for learning to aggregate (partial) rankings without supervision. We instantiate the framework for the cases of combining permutations and combining top-k lists, and propose a novel metric for the latter.},
+  Funding                  = {ITR-EDU, BL, MIAS},
+  Projects                 = {USS,RANK},
+Url-omit = {http://cogcomp.org/papers/KlementievRoSm08.pdf}
+}
+
+@InProceedings{KlementievRoSm07,
+  Title                    = {An Unsupervised Learning Algorithm for Rank Aggregation},
+  Author                   = {A. Klementiev and D. Roth and K. Small},
+  Booktitle                = {Proc. of the European Conference on Machine Learning (ECML)},
+  Year                     = {2007},
+Month-omit = {9},
+
+  Funding                  = {ITR-EDU, MIAS},
+  Projects                 = {USS,RANK},
+Url-omit = {http://cogcomp.org/papers/KlementievRoSm07.pdf}
+}
+
+@InProceedings{KRST09,
+  Title                    = {Unsupervised Rank Aggregation with Domain-Specific Expertise},
+  Author                   = {A. Klementiev and D. Roth and K. Small and I. Titov},
+  Booktitle                = {Proc. of the International Joint Conference on Artificial Intelligence (IJCAI)},
+  Year                     = {2009},
+Month-omit = {7},
+
+  Acceptance               = {331/1290 (25.7 \%)},
+  Comment                  = {Proposes a framework for learning to aggregate votes of rankers with domain specific expertise without supervision. Applies the learning framework to the settings of aggregating full rankings and aggregating top-k lists, demonstrating significant improvements over a domain-agnostic baseline in both cases.},
+  Funding                  = {ITR-EDU, BL, MIAS},
+  Projects                 = {USS, RANK},
+Url-omit = {http://cogcomp.org/papers/KRST09.pdf}
+}
+
+@InProceedings{KPRY05,
+  Title                    = {Generalized Inference with Multiple Semantic Role Labeling Systems Shared Task Paper},
+  Author                   = {P. Koomen and V. Punyakanok and D. Roth and W. Yih},
+  Booktitle                = {Proc. of the Conference on Computational Natural Language Learning (CoNLL)},
+  Year                     = {2005},
+  Editor                   = {Ido Dagan and Dan Gildea},
+Pages-omit = {181-184},
+
+  Comment                  = {Semantic Parsing; joint inference; integer linear programming; combining SRL systems via joint inference; Top system in CoNLL shared task},
+  Funding                  = {MURI,KINDLE,CLUSTER,XPRESSMP},
+  Projects                 = {SM,KINDLE,SRL},
+Url-omit = {http://cogcomp.org/papers/PunyakanokRoYi05a.pdf}
+}
+
+@InProceedings{KKCMSR16,
+  Title                    = {Better call Saul: Flexible Programming for Learning and Inference in NLP},
+  Author                   = {Parisa Kordjamshidi and Daniel Khashabi and Christos Christodoulopoulos and Bhargav Mangipudi and Sameer Singh and Dan Roth },
+  Booktitle                = {Proc. of the International Conference on Computational Linguistics (COLING)},
+  Year                     = {2016},
+
+Url-omit = {http://cogcomp.org/papers/KKCMSR16.pdf}
+}
+
+@Article{KordjamshidiRoMo15,
+  Title                    = {Structured Learning for Spatial Information Extraction from Biomedical Text: Bacteria Biotopes},
+  Author                   = {Parisa Kordjamshidi and Dan Roth and Marie-Francine Moens},
+  Year                     = {2015},
+
+Month-omit = {4},
+Number-omit = {126},
+Volume-omit = {16},
+
+  Booktitle                = {BMC Proc. of the International Conference on Bioinformatics Models, Methods and Algorithms},
+Url-omit = {http://cogcomp.org/papers/BMC_Bacteria_Biotope.pdf}
+}
+
+@InProceedings{KSKCSSR17,
+  Title                    = {Relational Learning and Feature Extraction by Querying over Heterogeneous Information Networks},
+  Author                   = {Parisa Kordjamshidi and Sameer Singh and Daniel Khashabi and Christos Christodoulopoulos and Mark Summons and Saurabh Sinha and Dan Roth },
+  Booktitle                = {Seventh International Workshop on Statistical Relational AI (StarAI)},
+  Year                     = {2017},
+
+Url-omit = {http://cogcomp.org/papers/2017_saul_relational_learning_starai.pdf}
+}
+
+@InProceedings{KordjamshidiWuRo15,
+  Title                    = {Saul: Towards Declarative Learning Based Programming},
+  Author                   = {Parisa Kordjamshidi and Hao Wu and Dan Roth},
+  Booktitle                = {Proc. of the International Joint Conference on Artificial Intelligence (IJCAI)},
+  Year                     = {2015},
+Month-omit = {7},
+
+Url-omit = {http://cogcomp.org/papers/KordjamshidiRoWu15.pdf}
+}
+
+@Other{KrymolowskiRo98,
+  Title                    = {Incorporating Knowledge in Natural Language Learning: A Case Study},
+  Author                   = {Y. Krymolowski and D. Roth},
+  Booktitle                = {Coling-Acl workshop on the Usage of WordNet in Natural Language Processing Systems},
+  Comment                  = {Prepositional Phrase Attachment (PPA); using WordNet to generate expressive features.},
+  Funding                  = {NSF98,KDI},
+Pages-omit = {121--127},
+  Projects                 = {NLP},
+Url-omit = {http://cogcomp.org/papers/pp-wn.pdf},
+  Year                     = {1998}
+}
+
+@Other{KunduChRo11,
+  Title                    = {Prior Knowledge Driven Domain Adaptation},
+  Author                   = {G. Kundu and M. Chang and D. Roth},
+  Booktitle                = {Proc. of the International Conference on Machine Learning (ICML)},
+  Funding                  = {ARL and DARPA Machine Reading},
+Month-omit = {7},
+Url-omit = {http://cogcomp.org/papers/KunduChRo11(3).pdf},
+  Year                     = {2011}
+}
+
+@InProceedings{KunduRo11,
+  Title                    = {Adapting Text Instead of the Model: An Open Domain Approach},
+  Author                   = {G. Kundu and D. Roth},
+  Booktitle                = {Proc. of the Conference on Computational Natural Language Learning (CoNLL)},
+  Year                     = {2011},
+Month-omit = {6},
+
+  Funding                  = {Darpa MR and ARL},
+Url-omit = {http://cogcomp.org/papers/KunduRo11.pdf}
+}
+
+@Other{KunduRoSa11,
+  Title                    = {Constrained Conditional Models For Information Fusion},
+  Author                   = {G. Kundu and D. Roth and R. Samdani},
+  Booktitle                = {Proc. of the International Conference on Information Fusion},
+Url-omit = {http://cogcomp.org/papers/SamdaniRothKunduFusion2011.pdf},
+  Year                     = {2011}
+}
+
+@InProceedings{KunduSrRo13,
+  Title                    = {Margin-based Decomposed Amortized Inference},
+  Author                   = {Gourab Kundu and Vivek Srikumar and Dan Roth},
+  Booktitle                = {Proc. of the Annual Meeting of the Association for Computational Linguistics (ACL)},
+  Year                     = {2013},
+Month-omit = {8},
+
+Url-omit = {http://cogcomp.org/papers/KunduSrRo13.pdf}
+}
+
+@Article{KushilevitzRo96,
+  Title                    = {On Learning Visual Concepts and DNF Formulae},
+  Author                   = {A. Kushilevitz and D. Roth},
+  Journal                  = {Machine Learning},
+  Year                     = {1996},
+Number-omit = {1},
+Pages-omit = {65--85},
+Volume-omit = {24},
+
+Url-omit = {http://cogcomp.org/papers/visualJ.pdf}
+}
+
+@InProceedings{KushilevitzRo93,
+  Title                    = {On Learning Visual Concepts and DNF Formulae},
+  Author                   = {A. Kushilevitz and D. Roth},
+  Booktitle                = {Proc. of the ACM Conference on Computational Learning Theory (COLT)},
+  Year                     = {1993},
+Pages-omit = {317--326},
+
+  Comment                  = {30/83 (37%)}
+}
+
+@Other{LPAGSAHRSA11,
+  Title                    = {Apollo: Towards Factfinding in Participatory Sensing},
+  Author                   = {H. Khac Le and J. Pasternack and H. Ahmadi and M. Gupta and Y. Sun and T. Abdelzaher and J. Han and D. Roth and B. Szymanski and S. Adali},
+  Booktitle                = {Proc. of the International Conference on Information Processing in Sensor Networks (IPSN)},
+Url-omit = {http://cogcomp.org/papers/LePa11.pdf},
+  Year                     = {2011}
+}
+
+@Other{LCUR15,
+  Title                    = {Distributed Training of Structured SVM},
+  Author                   = {Ching-pei Lee and Kai-Wei Chang and Shyam Upadhyay and Dan Roth},
+  Booktitle                = {OPT Workshop, Proc. of the Conference on Neural Information Processing Systems (NIPS)},
+Url-omit = {http://cogcomp.org/papers/OPT2015_paper_1.pdf},
+  Year                     = {2015}
+}
+
+@InProceedings{LeeRo15,
+  Title                    = {Distributed Box-Constrained Quadratic Optimization for Dual Linear SVM},
+  Author                   = {Ching-pei Lee and Dan Roth},
+  Booktitle                = {Proc. of the International Conference on Machine Learning (ICML)},
+  Year                     = {2015},
+Month-omit = {7},
+
+  Acceptance               = {26\%},
+  Funding                  = {DEFT},
+Url-omit = {http://cogcomp.org/papers/distcd.pdf}
+}
+
+@InProceedings{LDWSVR10,
+  Title                    = {Automatic Model Adaptation for Complex Structured Domains},
+  Author                   = {G. Levine and G. DeJong and L. Wang and R. Samdani and S. Vembu and D. Roth},
+  Booktitle                = {Proc. of the European Conference on Machine Learning and Principles and Practice of Knowledge Discovery in Databases (ECML PKDD)},
+  Year                     = {2010}
+}
+
+@Article{LiMoRo05,
+  Title                    = {Semantic Integration in Text: From Ambiguous Names to Identifiable Entities},
+  Author                   = {X. Li and P. Morie and D. Roth},
+  Journal                  = {AI Magazine. Special Issue on Semantic Integration},
+  Year                     = {2005},
+Pages-omit = {45--68},
+
+  Comment                  = {Named Entity Recognition; coreference resolution; entity identification; matching Entities Mentions within and across documents.},
+  Funding                  = {MURI,TRECC,CLUSTER},
+  Projects                 = {MIRROR,COREF,NER},
+Url-omit = {http://cogcomp.org/papers/LiMoRo05.pdf}
+}
+
+@InProceedings{LiMoRo04,
+  Title                    = {Identification and Tracing of Ambiguous Names: Discriminative and Generative Approaches},
+  Author                   = {X. Li and P. Morie and D. Roth},
+  Booktitle                = {Proc. of the Conference on Artificial Intelligence (AAAI)},
+  Year                     = {2004},
+Pages-omit = {419--424},
+
+  Acceptance               = {120/453 (26.5\%)},
+  Comment                  = {Comparing discriminatory and generative models for entity identification; named entity recognition; coreference resolution; matching entities mentions within and across documents; distance metrics for named entities},
+  Funding                  = {MURI,TRECC,CLUSTER},
+  Projects                 = {MIRROR,COREF,NER},
+Url-omit = {http://cogcomp.org/papers/LiMoRo04.pdf}
+}
+
+@InProceedings{LiMoRo04a,
+  Title                    = {Robust Reading: Identification and Tracing of Ambiguous Names},
+  Author                   = {X. Li and P. Morie and D. Roth},
+  Booktitle                = {Proc. of the Annual Conference of the North American Chapter of the Association for Computational Linguistics (NAACL)},
+  Year                     = {2004},
+Pages-omit = {17--24},
+
+  Comment                  = {A generative model for entity identification; Named Entity Recognition; coreference resolution; matching entities mentions within and across documents},
+  Funding                  = {MURI,TRECC,CLUSTER},
+  Projects                 = {MIRROR,NER,COREF},
+Url-omit = {http://cogcomp.org/papers/LiMoRo04a.pdf}
+}
+
+@TechReport{LiMoRo03,
+  Title                    = {Robust Reading of Ambiguous Writing},
+  Author                   = {X. Li and P. Morie and D. Roth},
+  Institution              = {UIUC Computer Science Department},
+  Year                     = {2003},
+Month-omit = {8},
+Number-omit = {UIUCDCS-R-2003-2371},
+
+  Funding                  = {MURI,ITR-BI},
+  Invisible                = {true},
+  Projects                 = {MIRROR,COREF,NER},
+Url-omit = {http://cogcomp.org/papers/LiMoRo03.pdf}
+}
+
+@InProceedings{LiRo05,
+  Title                    = {Discriminative Training of Clustering Functions: Theory and Experiments with Entity Identification},
+  Author                   = {X. Li and D. Roth},
+  Booktitle                = {Proc. of the Conference on Computational Natural Language Learning (CoNLL)},
+  Year                     = {2005},
+  Editor                   = {Ido Dagan and Dan Gildea},
+Pages-omit = {64--71},
+Publisher-omit = {Association for Computational Linguistics},
+
+  Acceptance               = {19/70 (27\%)},
+  Comment                  = {Clustering; metric learning; training metrics; entity identification},
+  Funding                  = {ITR-BI,MURI,TRECC},
+  Projects                 = {MIRROR,NER},
+Url-omit = {http://cogcomp.org/papers/LiRo05.pdf}
+}
+
+@Article{LiRo05a,
+  Title                    = {Learning Question Classifiers: The Role of Semantic Information},
+  Author                   = {X. Li and D. Roth},
+  Journal                  = {Journal of Natural Language Engineering},
+  Year                     = {2005},
+Number-omit = {4},
+Volume-omit = {11},
+
+  Comment                  = {Question Classification; Hierarchical classifiers; Sequential Model; Expressive Feature generation with semantic information.},
+  Funding                  = {MURI,ITR-MIT},
+  Projects                 = {QA,MCR,TE},
+Url-omit = {http://cogcomp.org/papers/LiRo05a.pdf}
+}
+
+@InProceedings{LiRo05b,
+  Title                    = {Discriminative Training of Clustering Functions: Theory and Experiments with Entity Identification},
+  Author                   = {X. Li and D. Roth},
+  Booktitle                = {Proc. of the Midwest Computational Linguistics Colloquium (MCLC)},
+  Year                     = {2005},
+Month-omit = {5},
+
+  Comment                  = {Supervised Learning, Clustering, Metric Learning},
+  Funding                  = {MURI,TRECC},
+  Invisible                = {true},
+  Projects                 = {LT,NER}
+}
+
+@InProceedings{LiRo04,
+  Title                    = {Supervised Discriminative Clustering},
+  Author                   = {X. Li and D. Roth},
+  Booktitle                = {Proc. of the Conference on Neural Information Processing Systems (NIPS) Workshop on Learning Structured Output},
+  Year                     = {2004},
+
+  Comment                  = {Supervised Learning, Clustering, Metric Learning},
+  Funding                  = {MURI,TRECC},
+  Invisible                = {true},
+  Projects                 = {LT}
+}
+
+@InProceedings{LiRo02,
+  Title                    = {Learning Question Classifiers},
+  Author                   = {X. Li and D. Roth},
+  Booktitle                = {Proc. of the International Conference on Computational Linguistics (COLING)},
+  Year                     = {2002},
+Pages-omit = {556--562},
+
+  Acceptance               = {198-435 (45\%)},
+  Comment                  = {Classifying Answer Type for Question Answering. Sequential Classification. Multiclass Classification.},
+  Funding                  = {NSF98,MURI,ITR-MIT},
+  Projects                 = {CCR,QA,TE},
+Url-omit = {http://cogcomp.org/papers/qc-coling02.pdf}
+}
+
+@InProceedings{LiRo01,
+  Title                    = {Exploring Evidence for Shallow Parsing},
+  Author                   = {X. Li and D. Roth},
+  Booktitle                = {Proc. of the Conference on Computational Natural Language Learning (CoNLL)},
+  Year                     = {2001},
+Pages-omit = {107--110},
+
+  Comment                  = {Learning Shallow Parsers vs. Full Parsers for Chunking tasks},
+  Funding                  = {ITR-MIT,NSF98,MURI},
+  Projects                 = {LnI,SI,IE,NE,NLP},
+Url-omit = {http://cogcomp.org/papers/conll01.pdf}
+}
+
+@InProceedings{LiRoSm04,
+  Title                    = {The Role of Semantic Information in Learning Question Classifiers},
+  Author                   = {X. Li and D. Roth and K. Small},
+  Booktitle                = {Proc. of the International Joint Conference on Natural Language Processing (IJCNLP)},
+  Year                     = {2004},
+
+  Acceptance               = {67/211 (32\%)},
+  Comment                  = {Question Classification; Hierarchical classifiers; Sequential Model; Expressive Feature Generation with semantic information.},
+  Funding                  = {MURI,ITR-MIT},
+  Projects                 = {QA,MCR,TE},
+Url-omit = {http://cogcomp.org/papers/LiRoSm04.pdf}
+}
+
+@InProceedings{LiRoTu03,
+  Title                    = {Phrasenet: towards context sensitive lexical semantics},
+  Author                   = {X. Li and D. Roth and Y. Tu},
+  Booktitle                = {Proc. of the Conference on Computational Natural Language Learning (CoNLL)},
+  Year                     = {2003},
+
+  Comment                  = {Extending WordNet to taxonomy over phrases},
+  Funding                  = {MURI,ITR-BI},
+  Projects                 = {NLP, PHRASENET,LS},
+Url-omit = {http://cogcomp.org/papers/LiRoTu.pdf}
+}
+
+@InProceedings{LRSS08,
+  Title                    = {Proactive Intrusion Detection},
+  Author                   = {B. Liebald and D. Roth and N. Shah and V. Srikumar},
+  Booktitle                = {Proc. of the Conference on Artificial Intelligence (AAAI)},
+  Year                     = {2008},
+Month-omit = {7},
+
+  Funding                  = {DARPA,Boeing},
+Url-omit = {http://cogcomp.org/papers/LRSS08.pdf}
+}
+
+@InProceedings{LingSoRo16,
+  Title                    = {Word Embeddings with Limited Memory},
+  Author                   = {Shaoshi Ling and Yangqiu Song and Dan Roth},
+  Booktitle                = {Proc. of the Annual Meeting of the Association for Computational Linguistics (ACL)},
+  Year                     = {2016},
+
+Url-omit = {http://cogcomp.org/papers/LingSoRo16.pdf}
+}
+
+@InProceedings{LuRo12,
+  Title                    = {Automatic Event Extraction with Structured Preference Modeling},
+  Author                   = {Wei Lu and Dan Roth},
+  Booktitle                = {Proc. of the Annual Meeting of the Association for Computational Linguistics (ACL)},
+  Year                     = {2012},
+Month-omit = {7},
+Pages-omit = {10},
+
+  Acceptance               = {19\%},
+  Funding                  = {Machine Reading},
+  Projects                 = {Machine Reading},
+Url-omit = {http://cogcomp.org/papers/LuRo12.pdf}
+}
+
+@InProceedings{LWZR12,
+  Title                    = {Unsupervised Discovery of Opposing Opinion Networks From Forum Discussions},
+  Author                   = {Yue Lu and Hongning Wang and ChengXiang Zhai and Dan Roth},
+  Booktitle                = {Proc. of the ACM Conference on Information and Knowledge Management (CIKM)},
+  Year                     = {2012},
+Month-omit = {10},
+
+Url-omit = {http://cogcomp.org/papers/LWZR12.pdf}
+}
+
+@InProceedings{MKPM15,
+  Title                    = {Machine Reading of Biological Texts: Bacteria-Biotope Extraction},
+  Author                   = {Wouter Massa and Parisa Kordjamshidi and Thomas Provoost and Marie-Francine Moens},
+  Booktitle                = {Proc. of the International Conference on Bioinformatics Models, Methods and Algorithms},
+  Year                     = {2015},
+Pages-omit = {55-64},
+Publisher-omit = {SCITEPRESS},
+
+Url-omit = {http://cogcomp.org/papers/MassaetalBIOSTEC2015.pdf}
+}
+
+@Article{MavronicolasRo99,
+  Title                    = {Linearizable Read/Write Objects},
+  Author                   = {M. Mavronicolas and D. Roth},
+  Journal                  = {Theoretical Computer Science},
+  Year                     = {1999},
+
+Month-omit = {6},
+Number-omit = {1},
+Pages-omit = {267--319},
+Volume-omit = {220},
+
+Url-omit = {http://cogcomp.org/papers/linearJ.pdf}
+}
+
+@InProceedings{MavronicolasRo92,
+  Title                    = {Efficient, Strongly Consistent Implementation of Shared Memory},
+  Author                   = {M. Mavronicolas and D. Roth},
+  Booktitle                = {Proc. of the Workshop on Distributed Algorithms (WDAG)},
+  Year                     = {1992},
+Pages-omit = {346--361},
+
+  Acceptance               = {24/38 (63\%)},
+Url-omit = {http://cogcomp.org/papers/wdagP.pdf}
+}
+
+@InProceedings{MavronicolasRo91,
+  Title                    = {Sequential Consistency and Linearizability: Read/Write Objects},
+  Author                   = {M. Mavronicolas and D. Roth},
+  Booktitle                = {Proc. of the Allerton Conference on Communications, Control and Computing},
+  Year                     = {1991},
+Pages-omit = {683--692},
+
+  Acceptance               = {32/77 (42\%)}
+}
+
+@InProceedings{MayhewTsRo17,
+  Title                    = {Cheap Translation for Cross-Lingual Named Entity Recognition},
+  Author                   = {Stephen Mayhew and Chen-Tse Tsai and Dan Roth},
+  Booktitle                = {Proc. of the Conference on Empirical Methods in Natural Language Processing (EMNLP)},
+  Year                     = {2017},
+
+  Funding                  = {LORELEI, DEFT},
+Url-omit = {http://cogcomp.org/papers/MayhewTsRo17.pdf}
+}
+
+@TechReport{MengshoelRoWi00,
+  Title                    = {Hard and Easy Bayesian Networks for Computing the Most Probable Explanation},
+  Author                   = {O. Mengshoel and D. Roth and D. Wilkins},
+  Institution              = {UIUC Computer Science Department},
+  Year                     = {2000},
+Month-omit = {1},
+Number-omit = {UIUCDCS-R-2000-2147},
+
+  Invisible                = {true},
+Url-omit = {http://cogcomp.org/papers/MengshoelRoWi00b.pdf}
+}
+
+@Article{MengshoelRoWi11,
+  Title                    = {Portfolios in Stochastic Local Search: Efficiently Computing Most Probable Explanations in Bayesian Networks},
+  Author                   = {O. J. Mengshoel and D. Roth and D. C. Wilkins},
+  Journal                  = {Journal of Automated Reasoning},
+  Year                     = {2011},
+Number-omit = {2},
+Pages-omit = {103-160},
+Volume-omit = {46},
+
+Url-omit = {http://cogcomp.org/papers/MengshoelRoWi11.pdf}
+}
+
+@Article{MengshoelRoWi06,
+  Title                    = {Controlled generation of hard and easy Bayesian networks: Impact on maximal clique size in tree clustering},
+  Author                   = {O. J. Mengshoel and D. Roth and D. C. Wilkins},
+  Journal                  = {Artificial Intelligence},
+  Year                     = {2006},
+
+Url-omit = {http://cogcomp.org/papers/MengshoelWiRo06.pdf}
+}
+
+@Article{MengshoelWiRo11,
+  Title                    = {Initialization and Restart in Stochastic Local Search: Computing a Most Probable Explanation in Bayesian Networks},
+  Author                   = {O. J. Mengshoel and D. C. Wilkins and D. Roth},
+  Journal                  = {IEEE Transactions on Knowledge and Data Engineering},
+  Year                     = {2011},
+Number-omit = {2},
+Pages-omit = {235-247},
+Volume-omit = {23},
+
+Url-omit = {http://cogcomp.org/papers/MengshoelWiRo11.pdf}
+}
+
+@InProceedings{MPRZ99,
+  Title                    = {A Learning Approach to Shallow Parsing},
+  Author                   = {M. Munoz and V. Punyakanok and D. Roth and D. Zimak},
+  Booktitle                = {Proc. of the Joint Conference on Empirical Methods in Natural Language Processing and Very Large Corpora (EMNLP-VLC)},
+  Year                     = {1999},
+Month-omit = {6},
+Pages-omit = {168--178},
+
+  Funding                  = {NSF98 KDI},
+  Projects                 = {LnI,SI,NLP},
+Url-omit = {http://cogcomp.org/papers/shallow-long.pdf}
+}
+
+@TechReport{MPRZ99a,
+  Title                    = {A Learning Approach to Shallow Parsing},
+  Author                   = {M. Munoz and V. Punyakanok and D. Roth and D. Zimak},
+  Institution              = {UIUC Computer Science Department},
+  Year                     = {1999},
+Month-omit = {4},
+Number-omit = {UIUCDCS-R-99-2087},
+
+  Invisible                = {true},
+Url-omit = {http://cogcomp.org/papers/MPRZ99b.pdf}
+}
+
+@Other{NGDIDNDHPR17,
+  Title                    = {Towards Problem Solving Agents that Communicate and Learn},
+  Author                   = {Anjali Narayan-Chen and Colin Graber and Mayukh Das and Md Rakibul Islam and Soham Dan and Sriraam Natarajan and Janardhan Rao Doppa and Julia Hockenmaier and Martha Palmer and Dan Roth},
+Url-omit = {http://cogcomp.org/papers/ngdidndhpr17.pdf},
+  Year                     = {2017}
+}
+
+@InProceedings{NingFeRo17,
+  Title                    = {A Structured Learning Approach to Temporal Relation Extraction},
+  Author                   = {Qiang Ning and Zhili Feng and Dan Roth},
+  Booktitle                = {Proc. of the Conference on Empirical Methods in Natural Language Processing (EMNLP)},
+  Year                     = {2017},
+
+Address-omit = {Copenhagen, Denmark},
+Month-omit = {9},
+Pages-omit = {1038--1048},
+Publisher-omit = {Association for Computational Linguistics},
+
+  Funding                  = {AI2, IBM-ILLINOIS C3SR, DARPA, ARL},
+Url-omit = {http://cogcomp.org/papers/NingFeRo17.pdf}
+}
+
+@Other{Pasternack11,
+  Title                    = {Knowing Who to Trust and What to Believe in the Presence of Conflicting Information},
+  Author                   = {J. Pasternack},
+  Booktitle                = {UIUC PhD Thesis},
+  Invisible                = {true},
+Url-omit = {http://cogcomp.org/papers/Pasternack11.pdf},
+  Year                     = {2011}
+}
+
+@InCollection{PasternackRo14,
+  Title                    = {Judging the Veracity of Claims and Reliability of Sources With Fact-Finders},
+  Author                   = {Jeff Pasternack and Dan Roth},
+  Booktitle                = {Computational Trust Models and Machine Learning},
+Publisher-omit = {Chapman and Hall/CRC},
+  Year                     = {2014},
+  Editor                   = {Xin Liu, Anwitaman Datta, and Ee-Peng Lim},
+Pages-omit = {39-72},
+
+Url-omit = {http://cogcomp.org/papers/fact_finder_chapter_clean.pdf}
+}
+
+@InProceedings{PasternackRo13,
+  Title                    = {Latent Credibility Analysis},
+  Author                   = {Jeff Pasternack and Dan Roth},
+  Booktitle                = {Proc. of the International World Wide Web Conference (WWW)},
+  Year                     = {2013},
+
+Url-omit = {http://cogcomp.org/papers/PasternackRo13.pdf}
+}
+
+@InProceedings{PasternackRo11,
+  Title                    = {Making Better Informed Trust Decisions with Generalized Fact-Finding},
+  Author                   = {J. Pasternack and D. Roth},
+  Booktitle                = {Proc. of the International Joint Conference on Artificial Intelligence (IJCAI)},
+  Year                     = {2011},
+
+  Funding                  = {ARL, DHS},
+Url-omit = {http://cogcomp.org/papers/PasternackRo11b.pdf}
+}
+
+@InProceedings{PasternackRo11a,
+  Title                    = {Generalized Fact-Finding},
+  Author                   = {J. Pasternack and D. Roth},
+  Booktitle                = {Proc. of the International World Wide Web Conference (WWW)},
+  Year                     = {2011},
+
+Url-omit = {http://cogcomp.org/papers/PasternackRo11.pdf}
+}
+
+@InProceedings{PasternackRo10,
+  Title                    = {Comprehensive Trust Metrics for Information Networks},
+  Author                   = {J. Pasternack and D. Roth},
+  Booktitle                = {Proc. of the Army Science Conference (ASC)},
+  Year                     = {2010},
+
+Address-omit = {Orlando, Florida},
+Month-omit = {12},
+
+Url-omit = {http://cogcomp.org/papers/PasternackRo10b.pdf}
+}
+
+@InProceedings{PasternackRo10a,
+  Title                    = {Knowing What to Believe (when you already know something)},
+  Author                   = {J. Pasternack and D. Roth},
+  Booktitle                = {Proc. of the International Conference on Computational Linguistics (COLING)},
+  Year                     = {2010},
+
+Address-omit = {Beijing, China},
+Month-omit = {8},
+
+  Comment                  = {Trustworthiness. Truth Finders. Using prior knowledge to both improve the accuracy of trust and belief decisions and permit such decisions to be made subjectively relative to the user},
+  Funding                  = {ARL},
+  Projects                 = {TRUST, IE, USS},
+Url-omit = {http://cogcomp.org/papers/PasternackRo10.pdf}
+}
+
+@InProceedings{PasternackRo09,
+  Title                    = {Learning Better Transliterations},
+  Author                   = {J. Pasternack and D. Roth},
+  Booktitle                = {Proc. of the ACM Conference on Information and Knowledge Management (CIKM)},
+  Year                     = {2009},
+Month-omit = {11},
+
+  Comment                  = {State-of-the-art transliteration with unbounded substring-to-substring productions and capable of both discovery and generation.},
+  Funding                  = {MIAS},
+  Projects                 = {TL},
+Url-omit = {http://cogcomp.org/papers/PasternackRo09a.pdf}
+}
+
+@InProceedings{PasternackRo09a,
+  Title                    = {Extracting Article Text from the Web with Maximum Subsequence Segmentation},
+  Author                   = {J. Pasternack and D. Roth},
+  Booktitle                = {Proc. of the International World Wide Web Conference (WWW)},
+  Year                     = {2009},
+Month-omit = {4},
+
+  Comment                  = {A new global optimization technique, maximum subsequence, is used to accurately identify and extract article text from HTML documents in linear time},
+  Projects                 = {IE},
+Url-omit = {http://cogcomp.org/papers/PasternackRo09.pdf}
+}
+
+@TechReport{PasternackRo08,
+  Title                    = {The Wikipedia Corpus},
+  Author                   = {J. Pasternack and D. Roth},
+  Year                     = {2008},
+
+  Journal                  = {University of Illinois Technical Report},
+Url-omit = {http://cogcomp.org/papers/PasternackRo08.pdf}
+}
+
+@InProceedings{PengChRo15,
+  Title                    = {A Joint Framework for Coreference Resolution and Mention Head Detection},
+  Author                   = {Haoruo Peng and Kai-Wei Chang and Dan Roth},
+  Booktitle                = {Proc. of the Conference on Computational Natural Language Learning (CoNLL)},
+  Year                     = {2015},
+
+Address-omit = {University of Illinois, Urbana-Champaign, Urbana, IL, 61801},
+Month-omit = {7},
+Pages-omit = {10},
+Publisher-omit = {ACL},
+
+  Institution              = {University of Illinois at Urbana-Champaign},
+Url-omit = {http://cogcomp.org/papers/MentionDetection.pdf}
+}
+
+@InProceedings{PengChRo17,
+  Title                    = {A Joint Model for Semantic Sequences: Frames, Entities, Sentiments},
+  Author                   = {Haoruo Peng and Snigdha Chaturvedi and Dan Roth},
+  Booktitle                = {Proc. of the Conference on Computational Natural Language Learning (CoNLL)},
+  Year                     = {2017},
+
+  Institution              = {University of Illinois, Urbana-Champaign},
+Url-omit = {http://cogcomp.org/papers/PengChRo17.pdf}
+}
+
+@InProceedings{PengKhRo15,
+  Title                    = {Solving Hard Coreference Problems},
+  Author                   = {Haoruo Peng and Daniel Khashabi and Dan Roth},
+  Booktitle                = {Proc. of the Annual Conference of the North American Chapter of the Association for Computational Linguistics (NAACL)},
+  Year                     = {2015},
+Month-omit = {5},
+
+Url-omit = {http://cogcomp.org/papers/PengKhRo15.pdf}
+}
+
+@InProceedings{PengRo16,
+  Title                    = {Two Discourse Driven Language Models for Semantics},
+  Author                   = {Haoruo Peng and Dan Roth},
+  Booktitle                = {Proc. of the Annual Meeting of the Association for Computational Linguistics (ACL)},
+  Year                     = {2016},
+
+Url-omit = {http://cogcomp.org/papers/PengRo16.pdf}
+}
+
+@InProceedings{PengSoRo16,
+  Title                    = {Event Detection and Co-reference with Minimal Supervision},
+  Author                   = {Haoruo Peng and Yangqiu Song and Dan Roth},
+  Booktitle                = {Proc. of the Conference on Empirical Methods in Natural Language Processing (EMNLP)},
+  Year                     = {2016},
+
+Url-omit = {http://cogcomp.org/papers/PengSoRo16.pdf}
+}
+
+@Other{PRSCR10,
+  Title                    = {Object Search: Supporting Structured Queries in Web Search Engines},
+  Author                   = {K. Pham and N. Rizzolo and K. Small and K. Chang and D. Roth},
+  Booktitle                = {Proc. of the Annual Conference of the North American Chapter of the Association for Computational Linguistics (NAACL) Workshop on Semantic Search},
+  Comment                  = {Searching on the web for objects by their properties without first building a database; uses LBP/LBJ.},
+  Funding                  = {MIAS, NSF-SoD},
+Month-omit = {6},
+  Projects                 = {LBP},
+Url-omit = {http://cogcomp.org/papers/PRSCR10.pdf},
+  Year                     = {2010}
+}
+
+@TechReport{PunyakanokRo05,
+  Title                    = {Inference with Classifiers: The Phrase Identification Problem},
+  Author                   = {V. Punyakanok and D. Roth},
+  Year                     = {2005},
+
+  Comment                  = {Shallow Parsing; Chunking; HMMs, Conditional Models and Constraint Satisfaction Models. Top results on phrase chunking},
+  Funding                  = {CAREER,ITR-MIT,NSF98,KINDLE},
+  Journal                  = {UIUC Technical Report},
+  Projects                 = {LnI,IE,NE,CCM},
+Url-omit = {http://cogcomp.org/papers/Punyakanok-05.pdf}
+}
+
+@InProceedings{PunyakanokRo01,
+  Title                    = {The Use of Classifiers in Sequential Inference},
+  Author                   = {V. Punyakanok and D. Roth},
+  Booktitle                = {Proc. of the Conference on Neural Information Processing Systems (NIPS)},
+  Year                     = {2001},
+Pages-omit = {995--1001},
+Publisher-omit = {MIT Press},
+
+  Acceptance               = {25/514 (4.8\%) Oral Presentations; 152/514 (29\%) overall},
+  Comment                  = {Structured, sequential output; Sequence Prediction: HMM with classifiers, Conditional Models, Constraint Satisfaction},
+  Funding                  = {NSF98 CAREER},
+  Projects                 = {LnI,SI,IE,NE,NLP,CCM},
+Url-omit = {http://cogcomp.org/papers/nips01.pdf}
+}
+
+@TechReport{PunyakanokRo00,
+  Title                    = {The Use of Classifiers in Sequential Inference},
+  Author                   = {V. Punyakanok and D. Roth},
+  Institution              = {UIUC Computer Science Department},
+  Year                     = {2000},
+Month-omit = {7},
+Number-omit = {UIUCDCS-R-2000-2181},
+
+  Invisible                = {true},
+Url-omit = {http://cogcomp.org/papers/PunyakanokRo00a.pdf}
+}
+
+@InProceedings{PunyakanokRo00a,
+  Title                    = {Shallow Parsing by Inferencing with Classifiers},
+  Author                   = {V. Punyakanok and D. Roth},
+  Booktitle                = {Proc. of the Conference on Computational Natural Language Learning (CoNLL)},
+  Year                     = {2000},
+Pages-omit = {107--110},
+
+  Funding                  = {ITR-MIT NSF98},
+Url-omit = {http://cogcomp.org/papers/PunyakanokRo00.pdf}
+}
+
+@Article{PunyakanokRoYi08,
+  Title                    = {The Importance of Syntactic Parsing and Inference in Semantic Role Labeling},
+  Author                   = {V. Punyakanok and D. Roth and W. Yih},
+  Journal                  = {Computational Linguistics},
+  Year                     = {2008},
+Number-omit = {2},
+Volume-omit = {34},
+
+  Funding                  = {KINDLE,REFLEX,MURI,XPRESSMP},
+  Projects                 = {IE,LINL,SP,ILP,SRL},
+Url-omit = {http://cogcomp.org/papers/PunyakanokRoYi07.pdf}
+}
+
+@InProceedings{PunyakanokRoYi05,
+  Title                    = {The Necessity of Syntactic Parsing for Semantic Role Labeling},
+  Author                   = {V. Punyakanok and D. Roth and W. Yih},
+  Booktitle                = {Proc. of the International Joint Conference on Artificial Intelligence (IJCAI)},
+  Year                     = {2005},
+Pages-omit = {1117--1123},
+
+  Acceptance               = {240/1329 (18\%)},
+  Comment                  = {An Analysis of the impact of syntactic parsing on semantic role labeling. Joint inference is used both to guarantee coherent SRL output and to combine several SRL systems.},
+  Funding                  = {KINDLE,REFLEX,MURI,XPRESSMP},
+  Projects                 = {IE,LINL,SP,ILP,SRL},
+Url-omit = {http://cogcomp.org/papers/PunyakanokRoYi05.pdf}
+}
+
+@Article{PunyakanokRoYi04,
+  Title                    = {Mapping Dependencies Trees: An Application to Question Answering},
+  Author                   = {V. Punyakanok and D. Roth and W. Yih},
+  Year                     = {2004},
+
+Month-omit = {1},
+
+  Acceptance               = {30-64 (47\%)},
+  Booktitle                = {Proc. of the International Symposium on Artificial Intelligence and Mathematics (AIM)},
+  Funding                  = {MURI,KINDLE},
+  Projects                 = {QA,KINDLE,TE},
+Url-omit = {http://cogcomp.org/papers/PunyakanokRoYi04a.pdf}
+}
+
+@InProceedings{PRYZ05,
+  Title                    = {Learning and Inference over Constrained Output},
+  Author                   = {V. Punyakanok and D. Roth and W. Yih and D. Zimak},
+  Booktitle                = {Proc. of the International Joint Conference on Artificial Intelligence (IJCAI)},
+  Year                     = {2005},
+Pages-omit = {1124--1129},
+
+  Acceptance               = {240/1329 (18\%)},
+  Comment                  = {Structure Learning; Joint Inference; Learning + Inference vs. Inference based Training Algorithms},
+  Funding                  = {KINDLE,REFLEX,MURI,XPRESSMP,ITR-BI},
+  Projects                 = {LT,CCM},
+Url-omit = {http://cogcomp.org/papers/PRYZ05.pdf}
+}
+
+@InProceedings{PRYZ04,
+  Title                    = {Semantic Role Labeling via Integer Linear Programming Inference},
+  Author                   = {V. Punyakanok and D. Roth and W. Yih and D. Zimak},
+  Booktitle                = {Proc. of the International Conference on Computational Linguistics (COLING)},
+  Year                     = {2004},
+
+Address-omit = {Geneva, Switzerland},
+Month-omit = {8},
+Pages-omit = {1346--1352},
+
+  Comment                  = {Semantic Parsing; Structure Learning with Expressive Constraints; Constraint Optimization; Integer Linear Programming},
+  Funding                  = {ITR-BI,MURI,KINDLE,XPRESSMP},
+  Projects                 = {SP,LnI,CCM,SRL},
+Url-omit = {http://cogcomp.org/papers/PRYZ04.pdf}
+}
+
+@InProceedings{PRYZ04a,
+  Title                    = {Learning via Inference over Structurally Constrained Output},
+  Author                   = {V. Punyakanok and D. Roth and W. Yih and D. Zimak},
+  Booktitle                = {Proc. of the Conference on Neural Information Processing Systems (NIPS) Workshop on Learning Structured Output},
+  Year                     = {2004},
+
+  Comment                  = {Learning + Inference vs. Inference based Training Algorithms},
+  Funding                  = {ITR-BI,ITR-MIT,MURI,KINDLE,XPRESSMP},
+  Invisible                = {true},
+  Projects                 = {LT,CCM},
+Url-omit = {http://cogcomp.org/papers/PRYZ04a.pdf}
+}
+
+@InProceedings{PRYZT04,
+  Title                    = {Semantic Role Labeling via Generalized Inference over Classifiers Shared Task Paper},
+  Author                   = {V. Punyakanok and D. Roth and W. Yih and D. Zimak and Y. Tu},
+  Booktitle                = {Proc. of the Conference on Computational Natural Language Learning (CoNLL)},
+  Year                     = {2004},
+  Editor                   = {Hwee Tou Ng and Ellen Riloff},
+Pages-omit = {130--133},
+
+  Comment                  = {Semantic Parsing; Structure Learning with Expressive Constraints; Constraint Optimization; Integer Linear Programming},
+  Funding                  = {CAREER,MURI,CAREER,KINDLE,CLUSTER,XPRESSMP},
+  Projects                 = {SM,SRL,CCM},
+Url-omit = {http://cogcomp.org/papers/PRYZT04.pdf}
+}
+
+@Other{PKMLDY15,
+  Title                    = {SemEval-2015 Task 8: SpaceEval},
+  Author                   = {James Pustejovsky and Parisa Kordjamshidi and Marie-Francine Moens and Aaron Levine and Seth Dworman and Zachary Yocum},
+  Booktitle                = {Proc. of the Annual Meeting of the Association for Computational Linguistics (ACL)},
+Pages-omit = {884-894},
+Publisher-omit = {ACL},
+Url-omit = {http://cogcomp.org/papers/PustejovskyetalSemEval2015.pdf},
+  Year                     = {2015}
+}
+
+@InProceedings{RahurkarRoHu08,
+  Title                    = {Which Apple are you talking about},
+  Author                   = {M. Rahurkar and D. Roth and T. Huang},
+  Booktitle                = {Proc. of the International World Wide Web Conference (WWW)},
+  Year                     = {2008},
+Pages-omit = {1197-1198},
+
+  Projects                 = {SEARCH},
+Url-omit = {http://cogcomp.org/papers/RahurkarRoHu08.pdf}
+}
+
+@Other{Ratinov12,
+  Title                    = {Exploiting Knowledge in NLP},
+  Author                   = {Lev Ratinov},
+  Booktitle                = {UIUC PhD Thesis},
+Url-omit = {http://cogcomp.org/papers/Ratinov12.pdf},
+  Year                     = {2012}
+}
+
+@InProceedings{RatinovRo12,
+  Title                    = {Learning-based Multi-Sieve Co-Reference Resolution with Knowledge},
+  Author                   = {Lev Ratinov and Dan Roth},
+  Booktitle                = {Proc. of the Conference on Empirical Methods in Natural Language Processing (EMNLP)},
+  Year                     = {2012},
+
+Url-omit = {http://cogcomp.org/papers/RatinovRo12.pdf}
+}
+
+@Other{RatinovRo11,
+  Title                    = {GLOW TAC-KBP 2011 Entity Linking System},
+  Author                   = {L. Ratinov and D. Roth},
+  Booktitle                = {Proc. of the Text Analysis Conference (TAC)},
+  Funding                  = {MR, ARL },
+Month-omit = {11},
+Publisher-omit = {Text Analysis Conference},
+Url-omit = {http://cogcomp.org/papers/RatinovRo11.pdf},
+  Year                     = {2011}
+}
+
+@InProceedings{RatinovRo09,
+  Title                    = {Design Challenges and Misconceptions in Named Entity Recognition},
+  Author                   = {L. Ratinov and D. Roth},
+  Booktitle                = {Proc. of the Conference on Computational Natural Language Learning (CoNLL)},
+  Year                     = {2009},
+Month-omit = {6},
+
+  Comment                  = {Named entity recognition; information extraction; knowledge resources; word class models; gazetteers; non-local features; global features; inference methods; BIO vs. BIOLU; text chunk representation},
+  Funding                  = {MIAS, SoD, Library},
+  Projects                 = {IE},
+Url-omit = {http://cogcomp.org/papers/RatinovRo09.pdf}
+}
+
+@InProceedings{RRDA11,
+  Title                    = {Local and Global Algorithms for Disambiguation to Wikipedia},
+  Author                   = {L. Ratinov and D. Roth and D. Downey and M. Anderson},
+  Booktitle                = {Proc. of the Annual Meeting of the Association for Computational Linguistics (ACL)},
+  Year                     = {2011},
+
+Url-omit = {http://cogcomp.org/papers/RRDA11.pdf}
+}
+
+@TechReport{RedmanSaRo16,
+  Title                    = {Illinois Named Entity Recognizer: Addendum to Ratinov and Roth '09 reporting improved results},
+  Author                   = {Tom Redman and Mark Sammons and Dan Roth},
+  Year                     = {2016},
+
+  Booktitle                = {Tech Reports},
+Url-omit = {http://cogcomp.org/papers/ner-addendum.pdf}
+}
+
+@InProceedings{RiedelCl09,
+  Title                    = {Revisiting Optimal Decoding for Machine Translation IBM Model 4},
+  Author                   = {S. Riedel and J. Clarke},
+  Booktitle                = {Proc. of the Annual Conference of the North American Chapter of the Association for Computational Linguistics (NAACL)},
+  Year                     = {2009},
+
+Address-omit = {Boulder, Colorado},
+
+Url-omit = {http://cogcomp.org/papers/RiedelCl09.pdf}
+}
+
+@Other{Rizzolo11,
+  Title                    = {Learning Based Programming},
+  Author                   = {N. Rizzolo},
+  Booktitle                = {UIUC PhD Thesis},
+Url-omit = {http://cogcomp.org/papers/Rizzolo11.pdf},
+  Year                     = {2011}
+}
+
+@InCollection{RizzoloRo16,
+  Title                    = {Integer Linear Programming for Co-reference Resolution},
+  Author                   = {N. Rizzolo and D. Roth},
+  Booktitle                = {Anaphora Resolution: Algorithms, Resources, and Applications},
+Publisher-omit = {Springer-Verlag},
+  Year                     = {2016},
+  Editor                   = {Massimo Poesio, Roland Stuckardt and Yannick Versley},
+
+  Invisible                = {true}
+}
+
+@InProceedings{RizzoloRo10,
+  Title                    = {Learning Based Java for Rapid Development of NLP Systems},
+  Author                   = {N. Rizzolo and D. Roth},
+  Booktitle                = {Proc. of the International Conference on Language Resources and Evaluation (LREC)},
+  Year                     = {2010},
+
+Address-omit = {Valletta, Malta},
+Month-omit = {5},
+
+  Comment                  = {Learning Based Java: a Modeling language that facilitates development of systems with learning and inference componenets.},
+  Funding                  = {NSF-SoD},
+  Projects                 = {LBP, CCM},
+Url-omit = {http://cogcomp.org/papers/RizzoloRo10.pdf}
+}
+
+@InProceedings{RizzoloRo07,
+  Title                    = {Modeling Discriminative Global Inference},
+  Author                   = {N. Rizzolo and D. Roth},
+  Booktitle                = {Proc. of the IEEE International Conference on Semantic Computing (ICSC)},
+  Year                     = {2007},
+
+Address-omit = {Irvine, California},
+Month-omit = {9},
+Pages-omit = {597-604},
+Publisher-omit = {IEEE},
+
+  Comment                  = {Learning Based Java: a Modeling language that facilitates developing of systems with learning and inference componenets.},
+  Funding                  = {NSF-SoD, LBP},
+  Projects                 = {LBP,CCM},
+Url-omit = {http://cogcomp.org/papers/RizzoloRo07.pdf}
+}
+
+@Article{Roth98a,
+  Title                    = {Learning and Reasoning with Connectionist Representations},
+  Author                   = {D. Roth},
+  Year                     = {1998},
+Pages-omit = {1--40},
+
+  Booktitle                = {Neural Computing Surveys},
+  Comment                  = {A contribution to ``Connectionist Symbol Processing: Dead or Alive''},
+  Editor                   = {A. Jagota, T. Plate, L. Shastri, R. Sun},
+Publisher-omit = {Lawrence Erlbaum Associates},
+Url-omit = {http://cogcomp.org/papers/Roth98a.pdf}
+}
+
+@Article{Roth05,
+  Title                    = {Learning based Programming},
+  Author                   = {D. Roth},
+  Journal                  = {Innovations in Machine Learning: Theory and Applications},
+  Year                     = {2005},
+
+  Comment                  = {Suggests a paradigm and a programming language for the programming of learning intensive computer systems. Springer: http://dx.doi.org/10.1007/3-540-33486-6_3},
+  Editor                   = {L.C. Jain and D. Holmes},
+  Funding                  = {ITR-BI,MURI,TRECC},
+  Projects                 = {LBP},
+Publisher-omit = {Springer-Verlag},
+Url-omit = {http://cogcomp.org/papers/Roth05.pdf}
+}
+
+@InCollection{Roth96b,
+  Title                    = {Learning in Order to Reason: The Approach},
+  Author                   = {D. Roth},
+  Booktitle                = {Proc. of the Conference on Current Trends in Theory and Practice of Informatics (SOFSEM)},
+Publisher-omit = {Springer-verlag},
+  Year                     = {1996},
+  Editor                   = {K. G. Jeffery and J. Kral and M. Bartosek},
+Pages-omit = {113--124},
+
+  Comment                  = {Lecture notes in Computer Science, vol. 1175},
+Url-omit = {http://cogcomp.org/papers/approach.pdf}
+}
+
+@InCollection{Roth97,
+  Title                    = {Learning to perform knowledge intensive inferences Invited Abstract},
+  Author                   = {D. Roth},
+  Booktitle                = {Proc. of the International Symposium on the Mathematical Foundations of Computer Science (MFCS)},
+Publisher-omit = {Springer-verlag},
+  Year                     = {1997},
+  Editor                   = {I. Privara and P. Ruzicka},
+Pages-omit = {108--109},
+
+  Comment                  = {Lecture notes in Computer Science (LNCS) 1295}
+}
+
+@InProceedings{Roth17,
+  Title                    = {Incidental Supervision: Moving beyond Supervised Learning},
+  Author                   = {Dan Roth},
+  Booktitle                = {Proc. of the Conference on Artificial Intelligence (AAAI)},
+  Year                     = {2017},
+Month-omit = {2},
+
+Url-omit = {http://cogcomp.org/papers/Roth-AAAI17-incidental-supervision.pdf}
+}
+
+@InProceedings{Roth01,
+  Title                    = {Reasoning with Classifiers},
+  Author                   = {D. Roth},
+  Booktitle                = {Proc. of the European Conference on Machine Learning (ECML)},
+  Year                     = {2001},
+Pages-omit = {506--510},
+
+  Acceptance               = {197/796 (25\%)},
+  Comment                  = {Paper written to accompany an invited talk at ECML'01. Sequential Inference: Conditional Models, Constraint Satisfaction},
+  Funding                  = {ITR-MIT NSF98 CAREER},
+  Projects                 = {LnI,SI,IE,NE}
+}
+
+@InProceedings{Roth00,
+  Title                    = {Learning in Natural Language: Theory and Algorithmic Approaches},
+  Author                   = {D. Roth},
+  Booktitle                = {Proc. of the Conference on Computational Natural Language Learning (CoNLL)},
+  Year                     = {2000},
+
+Address-omit = {Lisbon, Portugal},
+Pages-omit = {1--6},
+
+  Comment                  = {A paper written to accompany and invited talk at CoNLL.},
+  Funding                  = {ITR-MIT,NSF98,KDI},
+Url-omit = {http://cogcomp.org/papers/lnlp-conll.pdf}
+}
+
+@TechReport{Roth00a,
+  Title                    = {Learning in Natural Language},
+  Author                   = {D. Roth},
+  Institution              = {UIUC Computer Science Department},
+  Year                     = {2000},
+Month-omit = {7},
+Number-omit = {UIUCDCS-R-2000-2180},
+
+  Invisible                = {true},
+Url-omit = {http://cogcomp.org/papers/Roth00a.pdf}
+}
+
+@InProceedings{Roth99,
+  Title                    = {Learning in Natural Language},
+  Author                   = {D. Roth},
+  Booktitle                = {Proc. of the International Joint Conference on Artificial Intelligence (IJCAI)},
+  Year                     = {1999},
+Pages-omit = {898--904},
+
+  Acceptance               = {195/760 (26\%)},
+  Comment                  = {Probabilistic classifiers (Naive Bayes; HMM) as linear models; generative vs. discriminative; Best Paper Award},
+  Funding                  = {NSF98 KDI},
+  Projects                 = {LT,DPL},
+Url-omit = {http://cogcomp.org/papers/ijcai99r.pdf}
+}
+
+@TechReport{Roth99a,
+  Title                    = {Learning Based Programming},
+  Author                   = {D. Roth},
+  Institution              = {UIUC Computer Science Department},
+  Year                     = {1999},
+Month-omit = {10},
+Number-omit = {UIUCDCS-R-99-2127},
+
+Url-omit = {http://cogcomp.org/papers/Roth99c.pdf}
+}
+
+@TechReport{Roth99b,
+  Title                    = {Relational Knowledge Representations that Facilitate Learning},
+  Author                   = {D. Roth},
+  Institution              = {UIUC Computer Science Department},
+  Year                     = {1999},
+Month-omit = {10},
+Number-omit = {UIUCDCS-R-99-2126},
+
+  Invisible                = {true},
+Url-omit = {http://cogcomp.org/papers/Roth99b.pdf}
+}
+
+@TechReport{Roth99c,
+  Title                    = {Memory Based Learning in NLP},
+  Author                   = {D. Roth},
+  Institution              = {UIUC Computer Science Department},
+  Year                     = {1999},
+Month-omit = {3},
+Number-omit = {UIUCDCS-R-99-2125},
+
+Url-omit = {http://cogcomp.org/papers/mbl.pdf}
+}
+
+@InProceedings{Roth98,
+  Title                    = {Learning to Resolve Natural Language Ambiguities: A Unified Approach},
+  Author                   = {D. Roth},
+  Booktitle                = {Proc. of the Conference on Artificial Intelligence (AAAI)},
+  Year                     = {1998},
+Pages-omit = {806--813},
+
+  Acceptance               = {143/475 (30\%)},
+  Comment                  = {Many Natural Language Classifiers are Linear; including probabilistic classifiers; argues for a discriminative approach; SNoW},
+  Funding                  = {NSF98,KDI},
+  Projects                 = {DPL,NLP},
+Url-omit = {http://cogcomp.org/papers/aaai98.pdf}
+}
+
+@Article{Roth96,
+  Title                    = {On the hardness of approximate reasoning},
+  Author                   = {D. Roth},
+  Journal                  = {Artificial Intelligence},
+  Year                     = {1996},
+
+Month-omit = {4},
+Number-omit = {1-2},
+Pages-omit = {273--302},
+Volume-omit = {82},
+
+  Comment                  = {Hardness of Reasoning with Bayesian Networks; Exact inference is #P-Complete; Approximate Reasoning is NP-Hard.},
+Url-omit = {http://cogcomp.org/papers/hardJ.pdf}
+}
+
+@InProceedings{Roth96a,
+  Title                    = {Learning in Order to Reason Invited},
+  Author                   = {D. Roth},
+  Booktitle                = {Proc. of the AAAI Fall Symposium on Learning Complex Behaviors in Adaptive Intelligent Systems},
+  Year                     = {1996},
+Pages-omit = {46--52},
+
+Url-omit = {http://cogcomp.org/papers/approach.pdf}
+}
+
+@InProceedings{Roth96c,
+  Title                    = {On the hardness of approximate reasoning},
+  Author                   = {D. Roth},
+  Booktitle                = {Proc. of the AAAI Fall Symposium on AI and NP Hard Problems},
+  Year                     = {1996},
+Pages-omit = {137-143},
+
+Url-omit = {http://cogcomp.org/papers/hardJ.pdf}
+}
+
+@InProceedings{Roth96d,
+  Title                    = {A Connectionist Framework for Reasoning: Reasoning with Examples},
+  Author                   = {D. Roth},
+  Booktitle                = {Proc. of the Conference on Artificial Intelligence (AAAI)},
+  Year                     = {1996},
+Pages-omit = {1256--1261},
+
+  Acceptance               = {197/640 (31\%)},
+Url-omit = {http://cogcomp.org/papers/nreason.pdf}
+}
+
+@InProceedings{Roth95,
+  Title                    = {Learning to Reason: The Non-Monotonic Case},
+  Author                   = {D. Roth},
+  Booktitle                = {Proc. of the International Joint Conference on Artificial Intelligence (IJCAI)},
+  Year                     = {1995},
+Month-omit = {8},
+Pages-omit = {1178--1184},
+
+  Acceptance               = {249/1112 (22\%)},
+Url-omit = {http://cogcomp.org/papers/nonmon.pdf}
+}
+
+@InProceedings{Roth93,
+  Title                    = {On the hardness of approximate reasoning},
+  Author                   = {D. Roth},
+  Booktitle                = {Proc. of the International Joint Conference on Artificial Intelligence (IJCAI)},
+  Year                     = {1993},
+Month-omit = {8},
+Pages-omit = {613--618},
+
+  Acceptance               = {220/876 (25\%)},
+  Comment                  = {Hardness of Reasoning with Bayesian Networks; Exact inference is #P-Complete; Approximate Reasoning is NP-Hard.}
+}
+
+@InProceedings{RothBo02,
+  Title                    = {Proceedings of CoNLL 2002, the Sixth Workshop on Computational Natural Language Learning},
+  Author                   = {D. Roth and A. van den Bosch Program Chairs},
+  Year                     = {2002},
+  Editor                   = {D. Roth and A. van den Bosch}
+}
+
+@InProceedings{RCLMNPRSY02,
+  Title                    = {Question-Answering via Enhanced Understanding of Questions},
+  Author                   = {D. Roth and C. Cumby and X. Li and P. Morie and R. Nagarajan and V. Punyakanok and N. Rizzolo and K. Small and W. Yih},
+  Booktitle                = {Proc. of the Text Retrieval Conference (TREC)},
+  Year                     = {2002},
+
+  Funding                  = {NSF98,MURI,ITR-MIT},
+  Projects                 = {QA,TE},
+Url-omit = {http://cogcomp.org/papers/trec02.pdf}
+}
+
+@InProceedings{RKLNPRYAM01,
+  Title                    = {Learning Components for a Question Answering System},
+  Author                   = {D. Roth and G. Kao and X. Li and R. Nagarajan and V. Punyakanok and N. Rizzolo and W. Yih and C. Alm and L. G. Moran},
+  Booktitle                = {Proc. of the Text Retrieval Conference (TREC)},
+  Year                     = {2001},
+Pages-omit = {539-548},
+
+  Funding                  = {NSF98,MURI,ITR-MIT},
+  Projects                 = {QA,TE},
+Url-omit = {http://cogcomp.org/papers/trec01.pdf}
+}
+
+@Article{RothSa09,
+  Title                    = {Learning Multi-Linear Representations},
+  Author                   = {D. Roth and R. Samdani},
+  Journal                  = {Machine Learning},
+  Year                     = {2009},
+Number-omit = {2},
+Pages-omit = {195--209},
+Volume-omit = {76},
+
+  Funding                  = {ONR},
+  Projects                 = {CCG},
+Url-omit = {http://cogcomp.org/papers/RothSa09.pdf}
+}
+
+@TechReport{RothSa08,
+  Title                    = {A Unified Representation and Inference Paradigm for Natural Language Processing},
+  Author                   = {D. Roth and M. Sammons},
+  Institution              = {UIUC Computer Science Department},
+  Year                     = {2008},
+Number-omit = {UIUCDCS-R-2008-2969},
+
+  Funding                  = {Boeing},
+  Projects                 = {TE},
+Url-omit = {http://cogcomp.org/papers/RothSa08.pdf}
+}
+
+@Other{RothSa07,
+  Title                    = {Semantic and Logical Inference Model for Textual Entailment},
+Address-omit = {Prague, Czech Republic},
+  Author                   = {D. Roth and M. Sammons},
+  Booktitle                = {Proc. of the Annual Meeting of the Association for Computational Linguistics (ACL)},
+  Comment                  = {Textual Entailment; Compositional semantics; Search-based inference; Modular framework},
+  Funding                  = {Boeing, ARDA, ACQUAINT, Google},
+Month-omit = {6},
+Pages-omit = {107--112},
+  Projects                 = {TE},
+Publisher-omit = {Association for Computational Linguistics},
+Url-omit = {http://cogcomp.org/papers/RothSa07.pdf},
+  Year                     = {2007}
+}
+
+@InProceedings{RothSaVy09,
+  Title                    = {A Framework for Entailed Relation Recognition},
+  Author                   = {D. Roth and M. Sammons and V. Vydiswaran},
+  Booktitle                = {Proc. of the Annual Meeting of the Association for Computational Linguistics (ACL)},
+  Year                     = {2009},
+
+Address-omit = {Singapore},
+Month-omit = {8},
+Publisher-omit = {Association for Computational Linguistics},
+
+  Comment                  = {semantic retrieval, scalable textual entailment, structured query, similarity metrics, exhaustive search, relation recognition, relation extraction},
+  Funding                  = {Boeing, MIAS},
+  Projects                 = {TE,SEARCH},
+Url-omit = {http://cogcomp.org/papers/RothSaVy09.pdf}
+}
+
+@InProceedings{RothSm09,
+  Title                    = {Interactive Feature Space Construction using Semantic Information},
+  Author                   = {D. Roth and K. Small},
+  Booktitle                = {Proc. of the Conference on Computational Natural Language Learning (CoNLL)},
+  Year                     = {2009},
+Month-omit = {6},
+
+  Funding                  = {DARPA},
+  Projects                 = {AL,NER},
+Url-omit = {http://cogcomp.org/papers/RothSm09.pdf}
+}
+
+@InProceedings{RothSm08,
+  Title                    = {Active Learning for Pipeline Models},
+  Author                   = {D. Roth and K. Small},
+  Booktitle                = {Proc. of the Conference on Artificial Intelligence (AAAI)},
+  Year                     = {2008},
+Month-omit = {7},
+
+  Funding                  = {Darpa, DHS},
+  Projects                 = {AL,PL,NER},
+Url-omit = {http://cogcomp.org/papers/RothSm08.pdf}
+}
+
+@InProceedings{RothSm06,
+  Title                    = {Margin-based Active Learning for Structured Output Spaces},
+  Author                   = {D. Roth and K. Small},
+  Booktitle                = {Proc. of the European Conference on Machine Learning (ECML)},
+  Year                     = {2006},
+Month-omit = {9},
+Publisher-omit = {Springer},
+
+  Comment                  = {Active Learning; Structured Output},
+  Funding                  = {MOTOROLA,ITR-EDU},
+  Projects                 = {AL,SRL},
+Url-omit = {http://cogcomp.org/papers/RothSm06a.pdf}
+}
+
+@Other{RothSm06a,
+  Title                    = {Active Learning with Perceptron for Structured Output},
+  Author                   = {D. Roth and K. Small},
+  Booktitle                = {Proc. of the International Conference on Machine Learning (ICML)},
+  Comment                  = {Earlier Version of an ECML'06 paper},
+  Funding                  = {MOTOROLA,ITR-EDU},
+Month-omit = {6},
+  Projects                 = {AL},
+Url-omit = {http://cogcomp.org/papers/RothSm06.pdf},
+  Year                     = {2006}
+}
+
+@InProceedings{RothSmTi09,
+  Title                    = {Sequential Learning of Classifiers for Structured Prediction Problems},
+  Author                   = {D. Roth and K. Small and I. Titov},
+  Booktitle                = {Proc. of the International Workshop on Artificial Intelligence and Statistics (AISTATS)},
+  Year                     = {2009},
+Month-omit = {4},
+Pages-omit = {440--447},
+
+  Acceptance               = {84/210 (40.0 \%)},
+  Comment                  = {Structured prediction; Learning algorithm; Pipelines; An alternative both to joint and to independent learning of classifiers},
+  Funding                  = {BL, SoD},
+Url-omit = {http://cogcomp.org/papers/RothSmTi09.pdf}
+}
+
+@InProceedings{RothTu09,
+  Title                    = {Aspect Guided Text Categorization with Unobserved Labels},
+  Author                   = {D. Roth and Y. Tu},
+  Booktitle                = {Proc. of the IEEE International Conference on Data Mining (ICDM)},
+  Year                     = {2009},
+
+  Comment                  = {multiclass classification; Text classification, short text snippet, structure learning, Constrained optimization; constrained conditional models},
+  Funding                  = {Honda,MIAS},
+  Projects                 = {CCM,Honda},
+Url-omit = {http://cogcomp.org/papers/RothTu09.pdf}
+}
+
+@Article{RothYaAh02,
+  Title                    = {Learning to Recognize 3D Objects},
+  Author                   = {D. Roth and M. Yang and N. Ahuja},
+  Journal                  = {Neural Computation},
+  Year                     = {2002},
+Number-omit = {5},
+Pages-omit = {1071--1104},
+Volume-omit = {14},
+
+  Acceptance               = {NSF98,ITR-MIT},
+  Funding                  = {LT,LV},
+Url-omit = {http://cogcomp.org/papers/objectsJ.pdf}
+}
+
+@InProceedings{RothYaAh00,
+  Title                    = {Learning to Recognize Objects},
+  Author                   = {D. Roth and M. Yang and N. Ahuja},
+  Booktitle                = {Proc. of the IEEE Conference on Computer Vision and Pattern Recognition (CVPR)},
+  Year                     = {2000},
+Pages-omit = {724--731},
+
+  Acceptance               = {200/466 (43\%)},
+  Funding                  = {NSF98},
+Url-omit = {http://cogcomp.org/papers/cvpr00.pdf}
+}
+
+@Article{RothYi07,
+  Title                    = {Global Inference for Entity and Relation Identification via a Linear Programming Formulation},
+  Author                   = {D. Roth and W. Yih},
+  Year                     = {2007},
+
+  Booktitle                = {Introduction to Statistical Relational Learning},
+  Comment                  = {Learning and Inference with Constraints; Integer Linear Programming for Information extraction; Simultaneous recognition of entities and Relations},
+  Editor                   = {Lise Getoor and Ben Taskar},
+  Funding                  = {ITR-BI,ARDA,XPRESSMP},
+  Projects                 = {LT,LINL,ILP,CCM,NER,PL},
+Publisher-omit = {MIT Press},
+Url-omit = {http://cogcomp.org/papers/RothYi07.pdf}
+}
+
+@InProceedings{RothYi04,
+  Title                    = {A Linear Programming Formulation for Global Inference in Natural Language Tasks},
+  Author                   = {D. Roth and W. Yih},
+  Booktitle                = {Proc. of the Conference on Computational Natural Language Learning (CoNLL)},
+  Year                     = {2004},
+  Editor                   = {Hwee Tou Ng and Ellen Riloff},
+Pages-omit = {1--8},
+Publisher-omit = {Association for Computational Linguistics},
+
+  Acceptance               = {11/23 (48\%)},
+  Comment                  = {Simultaneous recognition of Named Entities and Relations between them. Learning and Inference via an Integer Linear Programming framework; Structure Learning; Avoiding Pipeline Processing},
+  Funding                  = {ITR-BI,MURI,XPRESSMP},
+  Projects                 = {IE,LnI,CCM,NER,PL},
+Url-omit = {http://cogcomp.org/papers/RothYi04.pdf}
+}
+
+@InProceedings{RothYi05,
+  Title                    = {Integer Linear Programming Inference for Conditional Random Fields},
+  Author                   = {D. Roth and W. Yih},
+  Booktitle                = {Proc. of the International Conference on Machine Learning (ICML)},
+  Year                     = {2005},
+Pages-omit = {737--744},
+
+  Acceptance               = {143/491 (29\%)},
+  Comment                  = {Extending Conditional Random Fields with expressive, non-sequential, constraints. Comparing multiple joint inference training paradigms for structure learning in the context of SRL.},
+  Funding                  = {MURI,ITR-BI,ITR-MIT,ARDA,XPRESSMP},
+  Projects                 = {LT,LINL,ILP,CCM},
+Url-omit = {http://cogcomp.org/papers/RothYi05.pdf}
+}
+
+@Unpublished{RothYi04a,
+  Title                    = {A Linear Programming Formulation for Global Inference in Natural Language Tasks},
+  Author                   = {D. Roth and W. Yih},
+  Year                     = {2004},
+
+  Booktitle                = {Proc. of the International Symposium on Artificial Intelligence and Mathematics (AIM)},
+  Comment                  = {An early version of the CoNLL paper},
+  Funding                  = {ITR-BI,MURI,CLUSTER,XPRESSMP},
+  Invisible                = {true},
+Pages-omit = {1--8},
+  Projects                 = {IE,LnI,CCM},
+Url-omit = {http://cogcomp.org/papers/RothYi04a.pdf}
+}
+
+@InProceedings{RothYi02,
+  Title                    = {Probabilistic Reasoning for Entity and Relation Recognition},
+  Author                   = {D. Roth and W. Yih},
+  Booktitle                = {Proc. of the International Conference on Computational Linguistics (COLING)},
+  Year                     = {2002},
+Pages-omit = {835--841},
+
+  Acceptance               = {198-435 (45\%)},
+  Comment                  = {Entity And Relation Recognition. Simultaneous Identification of Entities and Relations.},
+  Funding                  = {MURI,ITR-MIT},
+  Projects                 = {IE,NE,LnI,NER},
+Url-omit = {http://cogcomp.org/papers/er-coling02.pdf}
+}
+
+@InProceedings{RothYi01,
+  Title                    = {Relational Learning via Propositional Algorithms: An Information Extraction Case Study},
+  Author                   = {D. Roth and W. Yih},
+  Booktitle                = {Proc. of the International Joint Conference on Artificial Intelligence (IJCAI)},
+  Year                     = {2001},
+Pages-omit = {1257--1263},
+
+  Acceptance               = {197/796 (25\%)},
+  Comment                  = {Expressive, Relational Features for Information Extraction},
+  Funding                  = {ITR-MIT NSF98 MURI},
+  Projects                 = {KR,IE,NE},
+Url-omit = {http://cogcomp.org/papers/ijcai01.pdf}
+}
+
+@TechReport{RothYi01a,
+  Title                    = {Propositionalization of Relational Learning: An Information Extraction Case Study},
+  Author                   = {D. Roth and W. Yih},
+  Institution              = {UIUC Computer Science Department},
+  Year                     = {2001},
+Month-omit = {3},
+Number-omit = {UIUCDCS-R-2001-2206},
+
+  Funding                  = {NSF98,MURI,ITR-MIT},
+  Projects                 = {KR,IE,NE},
+Url-omit = {http://cogcomp.org/papers/RothYi01a.pdf}
+}
+
+@InCollection{RothZe99,
+  Title                    = {Coherent Concepts, Robust Learning Invited},
+  Author                   = {D. Roth and D. Zelenko},
+  Booktitle                = {Proc. of the Conference on Current Trends in Theory and Practice of Informatics (SOFSEM)},
+Publisher-omit = {Springer-verlag},
+  Year                     = {1999},
+  Editor                   = {J. Pavelka and G. Tel and M. Bartosek},
+Pages-omit = {260--272},
+
+  Comment                  = {Lecture notes in Artificial Intelligence, vol. 1725},
+Url-omit = {http://cogcomp.org/papers/RothZe99.pdf}
+}
+
+@InProceedings{RothZe00,
+  Title                    = {Towards a theory of Coherent Concepts},
+  Author                   = {D. Roth and D. Zelenko},
+  Booktitle                = {Proc. of the Conference on Artificial Intelligence (AAAI)},
+  Year                     = {2000},
+Pages-omit = {639--644},
+
+  Acceptance               = {141/430 (33\%)},
+Url-omit = {http://cogcomp.org/papers/aaai00.pdf}
+}
+
+@InProceedings{RothZe98,
+  Title                    = {Part of Speech Tagging Using a Network of Linear Separators},
+  Author                   = {D. Roth and D. Zelenko},
+  Booktitle                = {Coling-Acl, The 17th International Conference on Computational Linguistics},
+  Year                     = {1998},
+Pages-omit = {1136--1142},
+
+  Acceptance               = {137/550 (25\%)},
+  Funding                  = {NSF98,KDI},
+  Projects                 = {SI,NLP},
+Url-omit = {http://cogcomp.org/papers/pos.pdf}
+}
+
+@Other{Roy17,
+  Title                    = {Reasoning about Quantities in Natural Language},
+  Author                   = {Subhro Roy},
+  Booktitle                = {UIUC PhD Thesis},
+Url-omit = {http://cogcomp.org/papers/ROY-DISSERTATION-2017.pdf},
+  Year                     = {2017}
+}
+
+@InProceedings{RoyRo17,
+  Title                    = {Unit Dependency Graph and its Application to Arithmetic Word Problem Solving},
+  Author                   = {Subhro Roy and Dan Roth},
+  Booktitle                = {Proc. of the Conference on Artificial Intelligence (AAAI)},
+  Year                     = {2017},
+
+Url-omit = {http://cogcomp.org/papers/14764-64645-1-SM.pdf}
+}
+
+@InProceedings{RoyRo16,
+  Title                    = {ILLINOIS MATH SOLVER: Math Reasoning on the Web},
+  Author                   = {Subhro Roy and Dan Roth},
+  Booktitle                = {Proc. of the Annual Conference of the North American Chapter of the Association for Computational Linguistics (NAACL) Demonstrations},
+  Year                     = {2016},
+
+Url-omit = {http://cogcomp.org/papers/IMS.pdf}
+}
+
+@InProceedings{RoyRo15,
+  Title                    = {Solving General Arithmetic Word Problems},
+  Author                   = {Subhro Roy and Dan Roth},
+  Booktitle                = {Proc. of the Conference on Empirical Methods in Natural Language Processing (EMNLP)},
+  Year                     = {2015},
+
+Url-omit = {http://cogcomp.org/papers/arithmetic.pdf}
+}
+
+@InProceedings{RoyUpRo16,
+  Title                    = {EQUATION PARSING : Mapping Sentences to Grounded Equations},
+  Author                   = {Subhro Roy and Shyam Upadhyay and Dan Roth},
+  Booktitle                = {Proc. of the Conference on Empirical Methods in Natural Language Processing (EMNLP)},
+  Year                     = {2016},
+
+Url-omit = {http://cogcomp.org/papers/1609.08824v1.pdf}
+}
+
+@Article{RoyViRo15,
+  Title                    = {Reasoning about Quantities in Natural Language},
+  Author                   = {Subhro Roy and Tim Vieira and Dan Roth},
+  Journal                  = {Transactions of the Association for Computational Linguistics (TACL)},
+  Year                     = {2015},
+Volume-omit = {3},
+
+  Booktitle                = {TACL},
+Url-omit = {http://cogcomp.org/papers/RoyViRo15.pdf}
+}
+
+@Other{Rozovskay13,
+  Title                    = {Automated Methods for Text Correction},
+  Author                   = {Alla Rozovskaya},
+  Booktitle                = {UIUC PhD Thesis},
+Url-omit = {http://cogcomp.org/papers/Rozovskaya13.pdf},
+  Year                     = {2013}
+}
+
+@InProceedings{RCSR13,
+  Title                    = {The University of Illinois System in the CoNLL-2013 Shared Task},
+  Author                   = {Alla Rozovskaya and Kai-Wei Chang and Mark Sammons and Dan Roth},
+  Booktitle                = {Proc. of the Conference on Computational Natural Language Learning (CoNLL)},
+  Year                     = {2013},
+
+  Funding                  = {MR, DEFT},
+Url-omit = {http://cogcomp.org/papers/RCSR13.pdf}
+}
+
+@InProceedings{RCSRH14,
+  Title                    = {The Illinois-Columbia System in the CoNLL-2014 Shared Task},
+  Author                   = {Alla Rozovskaya and Kai-Wei Chang and Mark Sammons and Dan Roth and Nizar Habash},
+  Booktitle                = {Proc. of the Conference on Computational Natural Language Learning (CoNLL)},
+  Year                     = {2014},
+
+Url-omit = {http://cogcomp.org/papers/RCSRH14.pdf}
+}
+
+@InProceedings{RozovskayaRo16,
+  Title                    = {Grammatical Error Correction: Machine Translation and Classifiers},
+  Author                   = {Alla Rozovskaya and Dan Roth},
+  Booktitle                = {Proc. of the Annual Meeting of the Association for Computational Linguistics (ACL)},
+  Year                     = {2016},
+Publisher-omit = {ACL},
+
+Url-omit = {http://cogcomp.org/papers/RozovskayaRo16.pdf}
 }
+
+@Article{RozovskayaRo14,
+  Title                    = {Building a State-of-the-Art Grammatical Error Correction System},
+  Author                   = {Alla Rozovskaya and Dan Roth},
+  Year                     = {2014},
+
+  Booktitle                = {TACL},
+Url-omit = {http://cogcomp.org/papers/RozovskayaRo14.pdf}
+}
+
+@InProceedings{RozovskayaRo13,
+  Title                    = {Joint Learning and Inference for Grammatical Error Correction},
+  Author                   = {Alla Rozovskaya and Dan Roth},
+  Booktitle                = {Proc. of the Conference on Empirical Methods in Natural Language Processing (EMNLP)},
+  Year                     = {2013},
+Month-omit = {10},
+
+Url-omit = {http://cogcomp.org/papers/RozovskayaRo13.pdf}
+}
+
+@InProceedings{RozovskayaRo11,
+  Title                    = {Algorithm Selection and Model Adaptation for ESL Correction Tasks},
+  Author                   = {A. Rozovskaya and D. Roth},
+  Booktitle                = {Proc. of the Annual Meeting of the Association for Computational Linguistics (ACL)},
+  Year                     = {2011},
+
+Address-omit = {Portland, Oregon},
+Month-omit = {6},
+Publisher-omit = {Association for Computational Linguistics},
+
+  Funding                  = {EDU},
+Url-omit = {http://cogcomp.org/papers/RozovskayaRo11(1).pdf}
+}
+
+@InProceedings{RozovskayaRo10,
+  Title                    = {Generating Confusion Sets for Context-Sensitive Error Correction},
+  Author                   = {A. Rozovskaya and D. Roth},
+  Booktitle                = {Proc. of the Conference on Empirical Methods in Natural Language Processing (EMNLP)},
+  Year                     = {2010},
+
+  Funding                  = {EDU},
+Url-omit = {http://cogcomp.org/papers/RozovskayaRo10b.pdf}
+}
+
+@InProceedings{RozovskayaRo10a,
+  Title                    = {Training Paradigms for Correcting Errors in Grammar and Usage},
+  Author                   = {A. Rozovskaya and D. Roth},
+  Booktitle                = {Proc. of the Annual Conference of the North American Chapter of the Association for Computational Linguistics (NAACL)},
+  Year                     = {2010},
+Month-omit = {6},
+
+  Comment                  = {Text correction; Error Detection and Correction; ESL Error Detection; ESL Proofing Tools; Errors in Article Usage; training classifiers for detecting and correcting mistakes by selectively introducing mistakes into the training data},
+  Funding                  = {EDU},
+  Projects                 = {CSTC},
+Url-omit = {http://cogcomp.org/papers/RozovskayaRo10.pdf}
+}
+
+@Other{RozovskayaRo10b,
+  Title                    = {Annotating ESL Errors: Challenges and Rewards},
+  Author                   = {A. Rozovskaya and D. Roth},
+  Booktitle                = {Proc. of the Annual Conference of the North American Chapter of the Association for Computational Linguistics (NAACL)},
+  Comment                  = {Text correction; Error Detection and Correction; ESL Error Detection; Annotation of ESL Errors; Annotation Tool; Annotation of Article and Preposition Errors; Learner Corpus; Inter-annotator Agreement; ESL Error Statistics},
+  Funding                  = {EDU},
+Month-omit = {6},
+  Projects                 = {CSTC},
+Url-omit = {http://cogcomp.org/papers/RozovskayaRo10a.pdf},
+  Year                     = {2010}
+}
+
+@Article{RozovskayaRoSa17,
+  Title                    = {Adapting to Learner Errors with Minimal Supervision},
+  Author                   = {Alla Rozovskaya and Dan Roth and Mark Sammons},
+  Journal                  = {Computational Linguistics},
+  Year                     = {2017},
+
+Url-omit = {http://cogcomp.org/papers/CL-adaptation.pdf}
+}
+
+@InProceedings{RozovskayaRoSr14,
+  Title                    = {Correcting Grammatical Verb Errors},
+  Author                   = {Alla Rozovskaya and Dan Roth and Vivek Srikumar},
+  Booktitle                = {EACL},
+  Year                     = {2014},
+Month-omit = {4},
+
+Url-omit = {http://cogcomp.org/papers/RozovskayaRoSr14.pdf}
+}
+
+@Other{RSGR11,
+  Title                    = {University of Illinois System in HOO Text Correction Shared Task},
+  Author                   = {A. Rozovskaya and M. Sammons and J. Gioja and D. Roth},
+  Booktitle                = {Proc. of the European Workshop on Natural Language Generation (ENLG)},
+  Funding                  = {EDU,MR},
+Url-omit = {http://cogcomp.org/papers/RSGR11.pdf},
+  Year                     = {2011}
+}
+
+@Other{RozovskayaSaRo12,
+  Title                    = {The UI System in the HOO 2012 Shared Task on Error Correction},
+  Author                   = {Alla Rozovskaya and Mark Sammons and Dan Roth},
+  Booktitle                = {Proc. of the Annual Conference of the North American Chapter of the Association for Computational Linguistics (NAACL)},
+Month-omit = {6},
+Publisher-omit = {Association for Computational Linguistics},
+Url-omit = {http://cogcomp.org/papers/RozovskayaSaRo12.pdf},
+  Year                     = {2012}
+}
+
+@Other{Salvo07,
+  Title                    = {Lifted First-Order Probabilistic Inference},
+  Author                   = {R. de Salvo Braz},
+  Booktitle                = {UIUC PhD Thesis},
+Url-omit = {http://cogcomp.org/papers/Braz07.pdf},
+  Year                     = {2007}
+}
+
+@InCollection{SalvoAmRo07,
+  Title                    = {Lifted First-Order Probabilistic Inference},
+  Author                   = {R. de Salvo Braz and E. Amir and D. Roth},
+  Booktitle                = {Introduction to Statistical Relational Learning},
+Publisher-omit = {MIT Press},
+  Year                     = {2007},
+  Editor                   = {Lise Getoor and Ben Taskar},
+
+  Comment                  = {Relational Inference; Probabilistic Relational (first order) Models; First-order probabilistic inference without propositionalization; Lifted Probabilistic Inference},
+  Funding                  = {ARDA, ITR-BI, SoD},
+  Projects                 = {FOPI},
+Url-omit = {http://cogcomp.org/papers/BrazAmRo07.pdf}
+}
+
+@InCollection{SalvoAmRo08,
+  Title                    = {A Survey of First-Order Probabilistic Models},
+  Author                   = {R. de Salvo Braz and E. Amir and D. Roth},
+  Booktitle                = {Innovations in Bayesian Networks},
+Publisher-omit = {Springer-Verlag},
+  Year                     = {2008},
+  Editor                   = {D.E. Holmes and L.C. Jain},
+Pages-omit = {289--317},
+
+  Comment                  = {Lifted Probabilistic Inference},
+  Funding                  = {ARDA, ITR-BI, SoD},
+  Projects                 = {FOPI},
+Url-omit = {http://cogcomp.org/papers/BrazAmRo08.pdf}
+}
+
+@Other{SalvoAmRo06,
+  Title                    = {MPE and Partial Inversion in Lifted Probabilistic Variable Elimination},
+  Author                   = {R. de Salvo Braz and E. Amir and D. Roth},
+  Booktitle                = {Proc. of the Conference on Artificial Intelligence (AAAI)},
+  Comment                  = {Relational Inference; Probabilistic Relational (first order) Models; First-order probabilistic inference without propositionalization; Lifted Probabilistic Inference},
+  Funding                  = {ARDA,ITR-BI},
+Month-omit = {7},
+  Projects                 = {FOPI},
+Url-omit = {http://cogcomp.org/papers/BrazAmRo06a.pdf},
+  Year                     = {2006}
+}
+
+@Other{SalvoAmRo06a,
+  Title                    = {MPE and Partial Inversion in Lifted Probabilistic Variable Elimination},
+  Author                   = {R. de Salvo Braz and E. Amir and D. Roth},
+  Booktitle                = {Proc. of the International Conference on Machine Learning (ICML)},
+  Comment                  = {Earlier Version of a AAAI'06 paper.},
+  Funding                  = {ARDA},
+Month-omit = {6},
+  Projects                 = {FOPI},
+Url-omit = {http://cogcomp.org/papers/BrazAmRo06.pdf},
+  Year                     = {2006}
+}
+
+@InProceedings{SalvoAmRo05,
+  Title                    = {Lifted First-order Probabilistic Inference},
+  Author                   = {R. de Salvo Braz and E. Amir and D. Roth},
+  Booktitle                = {Proc. of the International Joint Conference on Artificial Intelligence (IJCAI)},
+  Year                     = {2005},
+Pages-omit = {1319--1125},
+
+  Acceptance               = {240/1329 (18\%)},
+  Comment                  = {Relational Inference; Probabilistic Relational (first order) Models; First-order probabilistic inference without propositionalization},
+  Funding                  = {ITR-BI, CAREER},
+Url-omit = {http://cogcomp.org/papers/BrazAmRo05.pdf}
+}
+
+@InCollection{SGPRS06,
+  Title                    = {An Inference Model for Semantic Entailment in Natural Language},
+  Author                   = {R. de Salvo Braz and R. Girju and V. Punyakanok and D. Roth and M. Sammons},
+Publisher-omit = {Springer},
+  Year                     = {2006},
+  Editor                   = {J. Quinonero Candela and I. Dagan and B. Magnini and F. d'Alche-Buc},
+Pages-omit = {261--286},
+Volume-omit = {3944},
+
+  Comment                  = {Revised version of PASCAL RTE Challenge. Textual Entailment, integrating NLP text analyis, shallow semantic inference},
+  Funding                  = {ARDA,ITR-BI,TRECC,CLUSTER,XPRESSMP},
+  Journal                  = {Machine Learning Challenges, Evaluating Predictive Uncertainty, Visual Object Classification and Recognizing Textual Entailment, First PASCAL Machine Learning Challenges Workshop, Revised Selected Papers},
+  Projects                 = {KINDLE,TE,KRNLP},
+Url-omit = {http://cogcomp.org/papers/BGPRS06.pdf}
+}
+
+@InProceedings{SGPRS05,
+  Title                    = {An Inference Model for Semantic Entailment in Natural Language},
+  Author                   = {R. de Salvo Braz and R. Girju and V. Punyakanok and D. Roth and M. Sammons},
+  Booktitle                = {Proc. of the Conference on Artificial Intelligence (AAAI)},
+  Year                     = {2005},
+Pages-omit = {1678--1679},
+
+  Acceptance               = {223/803 (28\%)},
+  Comment                  = {Textual Entailment; Mapping sentences to a description logic based representation, Pascal Entailment Task},
+  Funding                  = {ARDA,ITR-BI,TRECC,CLUSTER,XPRESSMP},
+  Projects                 = {KINDLE,TE,KRNLP},
+Url-omit = {http://cogcomp.org/papers/BGPRS05.pdf}
+}
+
+@Other{SGPRS05a,
+  Title                    = {Knowledge Representation for Semantic Entailment and Question-Answering},
+  Author                   = {R. de Salvo Braz and R. Girju and V. Punyakanok and D. Roth and M. Sammons},
+  Booktitle                = {Proc. of the International Joint Conference on Artificial Intelligence (IJCAI)},
+  Comment                  = {Analysis of our Textual Entailment system},
+  Funding                  = {ARDA,ITR-BI,TRECC,CLUSTER,XPRESSMP,TE},
+  Projects                 = {KINDLE},
+Url-omit = {http://cogcomp.org/papers/BGPRS05a.pdf},
+  Year                     = {2005}
+}
+
+@InProceedings{SGPRS05b,
+  Title                    = {An Inference Model for Semantic Entailment in Natural Language},
+  Author                   = {R. de Salvo Braz and R. Girju and V. Punyakanok and D. Roth and M. Sammons},
+  Booktitle                = {Proc. of the International Joint Conference on Artificial Intelligence (IJCAI)},
+  Year                     = {2005},
+
+  Acceptance               = {112/450 (25\%)},
+  Comment                  = {Textual Entailment; Mapping sentences to a description logic based representation},
+  Funding                  = {ARDA,ITR-BI,TRECC,CLUSTER,XPRESSMP},
+  Projects                 = {KINDLE,TE},
+Url-omit = {http://cogcomp.org/papers/BGPRS05b.pdf}
+}
+
+@TechReport{SalvoRo04,
+  Title                    = {Functional Subsumption in Feature Description Logic},
+  Author                   = {R. de Salvo Braz and D. Roth},
+  Institution              = {UIUC Computer Science Department},
+  Year                     = {2004},
+Number-omit = {UIUCDCS-R-2004-2423},
+
+  Funding                  = {ITR-BI,CAREER},
+  Invisible                = {true},
+  Projects                 = {KINDLE,KR}
+}
+
+@InProceedings{SalvoRo03,
+  Title                    = {Functional subsumption in Description Logics},
+  Author                   = {R. de Salvo Braz and D. Roth},
+  Booktitle                = {Proc. of the Conference on Neural Information Processing Systems (NIPS) Workshop on Feature Extraction and Selection},
+  Year                     = {2003},
+
+  Comment                  = {Relational Feature Extraction; Feature Description Logic},
+  Funding                  = {ITR-BI,CAREER},
+  Projects                 = {KR,KINDLE}
+}
+
+@TechReport{SalvoRoAm04,
+  Title                    = {First-order probabilistic inference revisited},
+  Author                   = {R. de Salvo Braz and D. Roth and E. Amir},
+  Institution              = {UIUC Computer Science Department},
+  Year                     = {2004},
+Month-omit = {6},
+Number-omit = {UIUCDCS-R-2004-2443},
+
+  Comment                  = {First order Probabilistic Inference without grounding.},
+  Funding                  = {ITR-BI},
+  Invisible                = {true},
+  Projects                 = {KR,FOPI}
+}
+
+@Other{Samdani13,
+  Title                    = {Algorithms for Structural Learning with Decompositions},
+  Author                   = {Rajhans Samdani},
+  Booktitle                = {UIUC PhD Thesis},
+Url-omit = {http://cogcomp.org/papers/Samdani13.pdf},
+  Year                     = {2013}
+}
+
+@InProceedings{SamdaniChRo14,
+  Title                    = {A Discriminative Latent Variable Model for Online Clustering},
+  Author                   = {Rajhans Samdani and Kai-Wei Chang and Dan Roth},
+  Booktitle                = {Proc. of the International Conference on Machine Learning (ICML)},
+  Year                     = {2014},
+
+  Acceptance               = {14.7\%},
+Url-omit = {http://cogcomp.org/papers/l3m.icml.pdf}
+}
+
+@Other{SamdaniChRo12,
+  Title                    = {A Framework for Tuning Posterior Entropy in Unsupervised Learning},
+  Author                   = {Rajhans Samdani and Ming-Wei Chang and Dan Roth},
+  Booktitle                = {Proc. of the International Conference on Machine Learning (ICML)},
+  Funding                  = {ONR, ARL, AFRL},
+Month-omit = {6},
+Url-omit = {http://cogcomp.org/papers/SamdaniChRo12b.pdf},
+  Year                     = {2012}
+}
+
+@InProceedings{SamdaniChRo12a,
+  Title                    = {Unified Expectation Maximization},
+  Author                   = {Rajhans Samdani and Ming-Wei Chang and Dan Roth},
+  Booktitle                = {Proc. of the Annual Conference of the North American Chapter of the Association for Computational Linguistics (NAACL)},
+  Year                     = {2012},
+Month-omit = {6},
+
+Url-omit = {http://cogcomp.org/papers/SamdaniChRo12.pdf}
+}
+
+@InProceedings{SamdaniRo12,
+  Title                    = {Efficient Decomposed Learning for Structured Prediction},
+  Author                   = {Rajhans Samdani and Dan Roth},
+  Booktitle                = {Proc. of the International Conference on Machine Learning (ICML)},
+  Year                     = {2012},
+Month-omit = {6},
+
+  Acceptance               = {27\%},
+  Funding                  = {ONR, AFRL, ARL},
+Url-omit = {http://cogcomp.org/papers/SamdaniRo12.pdf}
+}
+
+@InProceedings{SCKKSVBWR16,
+  Title                    = {EDISON: Feature Extraction for NLP, Simplified},
+  Author                   = {Mark Sammons and Christos Christodoulopoulos and Parisa Kordjamshidi and Daniel Khashabi and Vivek Srikumar and Paul Vijayakumar and Mazin Bokhari and Xinbo Wu and Dan Roth},
+  Booktitle                = {Proc. of the International Conference on Language Resources and Evaluation (LREC) },
+  Year                     = {2016},
+  Editor                   = {Nicoletta Calzolari (Conference Chair) and Khalid Choukri and Thierry Declerck and Marko Grobelnik and Bente Maegaard and Joseph Mariani and Asuncion Moreno and Jan Odijk and Stelios Piperidis},
+Publisher-omit = {European Language Resources Association (ELRA)},
+
+Url-omit = {http://cogcomp.org/papers/SCKKSVBWR16.pdf}
+}
+
+@Other{SPSUTRRR15,
+  Title                    = {Illinois CCG TAC 2015 Event Nugget, Entity Discovery and Linking, and Slot Filler Validation Systems},
+  Author                   = {Mark Sammons and Haoruo Peng and Yangqiu Song and Shyam Upadhyay and Chen-Tse Tsai and Pavankumar Reddy and Subhro Roy and Dan Roth},
+  Booktitle                = {Text Analysis Conference},
+  Institution              = {National Institute of Standards and Technology},
+Url-omit = {http://cogcomp.org/papers/SPSUTRRR15.pdf},
+  Year                     = {2015}
+}
+
+@InProceedings{SPSUTRRR15a,
+  Title                    = {Illinois CCG TAC 2015 Event Nugget, Entity Discovery and Linking, and Slot Filler Validation Systems},
+  Author                   = {Mark Sammons and Haoruo Peng and Yangqiu Song and Shyam Upadhyay and Chen-Tse Tsai and Pavankumar Reddy and Subhro Roy and Dan Roth},
+  Booktitle                = {Proc. of the Text Analysis Conference (TAC)},
+  Year                     = {2015},
+
+Url-omit = {http://cogcomp.org/papers/TAC15.pdf}
+}
+
+@InProceedings{SSWKTUAM14,
+  Title                    = {Overview of UI-CCG Systems for Event Argument Extraction, Entity Discovery and Linking, and Slot Filler Validation},
+  Author                   = {Mark Sammons and Yangqiu Song and Ruichen Wang and Gourab Kundu and Chen-Tse Tsai and Shyam Upadhyay and Siddarth Ancha and Stephen Mayhew},
+  Booktitle                = {Proc. of the Text Analysis Conference (TAC)},
+  Year                     = {2014},
+
+  Institution              = {NIST},
+Url-omit = {http://cogcomp.org/papers/SSWKTUMRA14.pdf}
+}
+
+@InCollection{SammonsVyRo12,
+  Title                    = {Recognizing Textual Entailment },
+  Author                   = {Mark Sammons and V.G.Vinod Vydiswaran and Dan Roth},
+  Booktitle                = {Multilingual Natural Language Applications: From Theory to Practice},
+Publisher-omit = {Prentice Hall},
+  Year                     = {2012},
+  Editor                   = {Daniel M. Bikel and Imed Zitouni},
+Month-omit = {5},
+Pages-omit = {209-258}
+}
+
+@InProceedings{SammonsVyRo10,
+  Title                    = {Ask not what Textual Entailment can do for You...},
+  Author                   = {M. Sammons and V. Vydiswaran and D. Roth},
+  Booktitle                = {Proc. of the Annual Meeting of the Association for Computational Linguistics (ACL)},
+  Year                     = {2010},
+
+Address-omit = {Uppsala, Sweden},
+Month-omit = {7},
+Publisher-omit = {Association for Computational Linguistics},
+
+  Comment                  = {Annotation, explanation, Recognizing Textual Entailment, evaluating textual entailment, data ablation},
+  Funding                  = {DARPA,Boeing, DHS},
+  Projects                 = {TE},
+Url-omit = {http://cogcomp.org/papers/SammonsVyRo10.pdf}
+}
+
+@InProceedings{SVVJCGSKTSRDR09,
+  Title                    = {Relation Alignment for Textual Entailment Recognition},
+  Author                   = {M. Sammons and V. Vydiswaran and T. Vieira and N. Johri and M. Chang and D. Goldwasser and V. Srikumar and G. Kundu and Y. Tu and K. Small and J. Rule and Q. Do and D. Roth},
+  Booktitle                = {Proc. of the Text Analysis Conference (TAC)},
+  Year                     = {2009},
+
+  Comment                  = {Recognizing Textual Entailment, textual entailment system, alignment, multi-view representation},
+  Funding                  = {DARPA,Boeing},
+  Projects                 = {TE,KRNLP},
+Url-omit = {http://cogcomp.org/papers/SVVJCGSKTSRDR09(1).pdf}
+}
+
+@InProceedings{ShenLiDo05,
+  Title                    = {Constraint-Based Entity Matching},
+  Author                   = {W. Shen and X. Li and A. Doan},
+  Booktitle                = {Proc. of the Conference on Artificial Intelligence (AAAI)},
+  Year                     = {2005},
+
+  Acceptance               = {223/803 (28\%)},
+  Comment                  = {Entity Identification, Generative Model, Record Linkage, Constraint, Relaxation Labeling},
+  Funding                  = {MURI,ITR-MIT},
+  Projects                 = {MIRROR,NER,COREF},
+Url-omit = {http://cogcomp.org/papers/ShenLiDn05.pdf}
+}
+
+@Other{Small09,
+  Title                    = {Interactive Learning Protocols for Natural Language Applications},
+  Author                   = {K. Small},
+  Booktitle                = {UIUC PhD Thesis},
+Url-omit = {http://cogcomp.org/papers/Small09.pdf},
+  Year                     = {2009}
+}
+
+@Article{SmallRo10,
+  Title                    = {Margin-based Active Learning for Structured Predictions},
+  Author                   = {K. Small and D. Roth},
+  Year                     = {2010},
+Pages-omit = {3-25},
+Volume-omit = {1},
+
+  Booktitle                = {IJMLC},
+Url-omit = {http://cogcomp.org/papers/SmallRo10.pdf}
+}
+
+@InProceedings{SondhiVyZh12,
+  Title                    = {Reliability Prediction of Webpages in the Medical Domain},
+  Author                   = {Parikshit Sondhi and V.G. Vinod Vydiswaran and ChengXiang Zhai},
+  Booktitle                = {Proc. of the European Conference on Information Retrieval},
+  Year                     = {2012},
+Month-omit = {4},
+Pages-omit = {219--231},
+Volume-omit = {7224},
+
+Url-omit = {http://cogcomp.org/papers/SondhiVyZh12.pdf}
+}
+
+@InCollection{SongMaRo16,
+  Title                    = {Cross-lingual Dataless Classification for Languages with Small Wikipedia Presence},
+  Author                   = {Yangqiu Song and Stephen Mayhew and Dan Roth},
+  Booktitle                = {arXiv},
+  Year                     = {2016},
+Month-omit = {11},
+Number-omit = {arXiv:1611.04122},
+Pages-omit = {17},
+
+Url-omit = {http://cogcomp.org/papers/SongMR16.pdf}
+}
+
+@InProceedings{SPKSR15,
+  Title                    = {Improving a Pipeline Architecture for Shallow Discourse Parsing},
+  Author                   = {Yangqiu Song and Haoruo Peng and Parisa Kordjamshidi and Mark Sammons and Dan Roth},
+  Booktitle                = {Proc. of the Conference on Computational Natural Language Learning (CoNLL)},
+  Year                     = {2015},
+
+Url-omit = {http://cogcomp.org/papers/SPKSR15.pdf}
+}
+
+@InProceedings{SongRo15,
+  Title                    = {Unsupervised Sparse Vector Densification for Short Text Similarity},
+  Author                   = {Yangqiu Song and Dan Roth},
+  Booktitle                = {Proc. of the Annual Conference of the North American Chapter of the Association for Computational Linguistics (NAACL)},
+  Year                     = {2015},
+Month-omit = {5},
+
+Url-omit = {http://cogcomp.org/papers/SongRo15.pdf}
+}
+
+@InProceedings{SongRo14,
+  Title                    = {On Dataless Hierarchical Text Classification},
+  Author                   = {Yangqiu Song and Dan Roth},
+  Booktitle                = {Proc. of the Conference on Artificial Intelligence (AAAI)},
+  Year                     = {2014},
+Month-omit = {7},
+
+Url-omit = {http://cogcomp.org/papers/SongRo14.pdf}
+}
+
+@InProceedings{SUPR16,
+  Title                    = {Cross-lingual Dataless Classification for Many Languages},
+  Author                   = {Yangqiu Song and Shyam Upadhyay and Haoruo Peng and Dan Roth},
+  Booktitle                = {Proc. of the International Joint Conference on Artificial Intelligence (IJCAI)},
+  Year                     = {2016},
+
+Url-omit = {http://cogcomp.org/papers/SUPR16.pdf}
+}
+
+@Other{Srikumar13,
+  Title                    = {The Semantics of Role Labeling},
+  Author                   = {Vivek Srikumar},
+  Booktitle                = {UIUC PhD Thesis},
+Url-omit = {http://cogcomp.org/papers/Srikumar13.pdf},
+  Year                     = {2013}
+}
+
+@InProceedings{SrikumarKuRo12,
+  Title                    = {On Amortizing Inference Cost for Structured Prediction},
+  Author                   = {Vivek Srikumar and Gourab Kundu and Dan Roth},
+  Booktitle                = {Proc. of the Conference on Empirical Methods in Natural Language Processing (EMNLP)},
+  Year                     = {2012},
+Month-omit = {7},
+
+Url-omit = {http://cogcomp.org/papers/SrikumarKuRo12.pdf}
+}
+
+@InProceedings{SRSRR08,
+  Title                    = {Extraction of Entailed Semantic Relations Through Syntax-based Comma Resolution},
+  Author                   = {V. Srikumar and R. Reichart and M. Sammons and A. Rappoport and D. Roth},
+  Booktitle                = {Proc. of the Annual Meeting of the Association for Computational Linguistics (ACL)},
+  Year                     = {2008},
+
+Address-omit = {Columbus, OH, USA},
+Month-omit = {6},
+Publisher-omit = {Association for Computational Linguistics},
+
+  Funding                  = {SoD,Boeing},
+  Projects                 = {TE},
+Url-omit = {http://cogcomp.org/papers/SRSRR08.pdf}
+}
+
+@Article{SrikumarRo13,
+  Title                    = {Modeling Semantic Relations Expressed by Prepositions},
+  Author                   = {Vivek Srikumar and Dan Roth},
+  Year                     = {2013},
+Pages-omit = {231-242},
+Volume-omit = {1},
+
+  Booktitle                = {TACL},
+Url-omit = {http://cogcomp.org/papers/SrikumarRo13.pdf}
+}
+
+@InProceedings{SrikumarRo11,
+  Title                    = {A Joint Model for Extended Semantic Role Labeling},
+  Author                   = {V. Srikumar and D. Roth},
+  Booktitle                = {Proc. of the Conference on Empirical Methods in Natural Language Processing (EMNLP)},
+  Year                     = {2011},
+
+Address-omit = {Edinburgh, Scotland},
+
+Url-omit = {http://cogcomp.org/papers/SrikumarRo11.pdf}
+}
+
+@InProceedings{TKSR10,
+  Title                    = {Unsupervised Aggregation for Classification Problems with Large Numbers of Categories},
+  Author                   = {I. Titov and A. Klementiev and K. Small and D. Roth},
+  Booktitle                = {Proc. of the International Workshop on Artificial Intelligence and Statistics (AISTATS)},
+  Year                     = {2010},
+Month-omit = {5},
+
+  Comment                  = {Structured prediction; Unsupervised Learning; Aggregation},
+  Funding                  = {BL, DHS},
+Url-omit = {http://cogcomp.org/papers/TKSR10.pdf}
+}
+
+@Other{Tsai17,
+  Title                    = {Concept and Entity Grounding Using Indirect Supervision},
+  Author                   = {Chen-Tse Tsai},
+  Booktitle                = {UIUC PhD Thesis},
+Url-omit = {http://cogcomp.org/papers/Tsai17.pdf},
+  Year                     = {2017}
+}
+
+@InProceedings{TsaiKuRo13,
+  Title                    = {Concept-Based Analysis of Scientific Literature},
+  Author                   = {Chen-Tse Tsai and Gourab Kundu and Dan Roth},
+  Booktitle                = {Proc. of the ACM Conference on Information and Knowledge Management (CIKM)},
+  Year                     = {2013},
+
+Url-omit = {http://cogcomp.org/papers/TsaiKuRo13.pdf}
+}
+
+@Other{TMPSMRR16,
+  Title                    = {Illinois CCG Entity Discovery and Linking, Event Nugget Detection and Co-reference, and Slot Filler Validation Systems for TAC 2016},
+  Author                   = {Chen-Tse Tsai and Stephen Mayhew and Haoruo Peng and Mark Sammons and Bhargav Mangipundi and Pavankumar Reddy and Dan Roth},
+  Booktitle                = {Text Analysis Conference (Proc. of the Text Analysis Conference (TAC) 2016)},
+  Institution              = {National Institute of Standards and Technology},
+  Year                     = {2016}
+}
+
+@InProceedings{TsaiMaRo16,
+  Title                    = {Cross-Lingual Named Entity Recognition via Wikification},
+  Author                   = {Chen-Tse Tsai and Stephen Mayhew and Dan Roth},
+  Booktitle                = {Proc. of the Conference on Computational Natural Language Learning (CoNLL)},
+  Year                     = {2016},
+
+Url-omit = {http://cogcomp.org/papers/TsaiMaRo16.pdf}
+}
+
+@InProceedings{TsaiRo16,
+  Title                    = {Illinois Cross-Lingual Wikifier: Grounding Entities in Many Languages to the English Wikipedia},
+  Author                   = {Chen-Tse Tsai and Dan Roth},
+  Booktitle                = {Proc. of the International Conference on Computational Linguistics (COLING) Demonstrations},
+  Year                     = {2016},
+Month-omit = {12},
+
+Url-omit = {http://cogcomp.org/papers/TsaiRo16c.pdf}
+}
+
+@InProceedings{TsaiRo16a,
+  Title                    = {Cross-lingual Wikification Using Multilingual Embeddings},
+  Author                   = {Chen-Tse Tsai and Dan Roth},
+  Booktitle                = {Proc. of the Annual Conference of the North American Chapter of the Association for Computational Linguistics (NAACL)},
+  Year                     = {2016},
+Month-omit = {6},
+
+Url-omit = {http://cogcomp.org/papers/TsaiRo16b.pdf}
+}
+
+@Article{TsaiRo16b,
+  Title                    = {Concept Grounding to Multiple Knowledge Bases via Indirect Supervision},
+  Author                   = {Chen-Tse Tsai and Dan Roth},
+  Year                     = {2016},
+
+Month-omit = {2},
+
+  Booktitle                = {TACL},
+Url-omit = {http://cogcomp.org/papers/TsaiRo16.pdf}
+}
+
+@InProceedings{TSMSR16,
+  Title                    = {Illinois CCG LoReHLT 2016 Named Entity Recognition and Situation Frame Systems},
+  Author                   = {Chen-Tse Tsai and Yangqiu Song and Stephen Mayhew and Mark Sammons and Dan Roth},
+  Booktitle                = {Low Resource Human Language Technologies (LoReHLT)},
+  Year                     = {2016},
+
+Url-omit = {http://cogcomp.org/papers/CYSMD16.pdf}
+}
+
+@Other{Tu12,
+  Title                    = {English Complex Verb Constructions: Identification and Inference},
+  Author                   = {Yuancheng Tu},
+  Booktitle                = {UIUC PhD Thesis},
+Url-omit = {http://cogcomp.org/papers/Tu12.pdf},
+  Year                     = {2012}
+}
+
+@InProceedings{TJRH10,
+  Title                    = {Citation Author Topic Model in Expert Search},
+  Author                   = {Y. Tu and N. Johri and D. Roth and J. Hockenmaier},
+  Booktitle                = {Proc. of the International Conference on Computational Linguistics (COLING)},
+  Year                     = {2010},
+
+  Comment                  = {author topic model, expert search, semantic search, information retrieval},
+  Funding                  = {MIAS},
+  Projects                 = {search},
+Url-omit = {http://cogcomp.org/papers/TJRH10(2).pdf}
+}
+
+@InProceedings{TuRo12,
+  Title                    = {Sorting out the Most Confusing English Phrasal Verbs},
+  Author                   = {Yuancheng Tu and Dan Roth},
+  Booktitle                = {Proc. of the Joint Conference on Lexical and Computational Sematics},
+  Year                     = {2012},
+
+Address-omit = {Montreal, Canada},
+Publisher-omit = {Association for Computational Linguistics},
+
+  Funding                  = {DHS},
+  Projects                 = {LS},
+Url-omit = {http://cogcomp.org/papers/TuRoth12.pdf}
+}
+
+@Other{TuRo11,
+  Title                    = {Learning English Light Verb Constructions: Contextual or Statistical},
+  Author                   = {Y. Tu and D. Roth},
+  Booktitle                = {Proc. of the Annual Meeting of the Association for Computational Linguistics (ACL)},
+  Funding                  = {MIAS},
+  Projects                 = {LS},
+Url-omit = {http://cogcomp.org/papers/TuRo11.pdf},
+  Year                     = {2011}
+}
+
+@InProceedings{TurianRaBe10,
+  Title                    = {Word representations: A simple and general method for semi-supervised learning},
+  Author                   = {J. Turian and L. Ratinov and Y. Bengio},
+  Booktitle                = {Proc. of the Annual Meeting of the Association for Computational Linguistics (ACL)},
+  Year                     = {2010},
+
+Url-omit = {http://cogcomp.org/papers/TurianRaBe2010.pdf}
+}
+
+@Other{UpadhyayChRo16,
+  Title                    = {Making the News - Identifying Noteworthy Events in News Articles},
+  Author                   = {Shyam Upadhyay and Christos Christodoulopoulos and Dan Roth},
+  Booktitle                = {The 4th Workshop on EVENTS, Proc. of the Annual Conference of the North American Chapter of the Association for Computational Linguistics (NAACL)},
+Url-omit = {http://cogcomp.org/papers/W16-1001.pdf},
+  Year                     = {2016}
+}
+
+@InProceedings{UFDR16,
+  Title                    = {Cross-lingual Models of Word Embeddings: An Empirical Comparison},
+  Author                   = {Shyam Upadhyay and Manaal Faruqui and Chris Dyer and Dan Roth},
+  Booktitle                = {Proc. of the Annual Meeting of the Association for Computational Linguistics (ACL)},
+  Year                     = {2016},
+
+Url-omit = {http://cogcomp.org/papers/acl2016.pdf}
+}
+
+@InProceedings{UGCR16,
+  Title                    = {Revisiting the Evaluation for Cross Document Event Coreference},
+  Author                   = {Shyam Upadhyay and Nitish Gupta and Christos Christodoulopoulos and Dan Roth},
+  Booktitle                = {Proc. of the International Conference on Computational Linguistics (COLING)},
+  Year                     = {2016},
+
+Url-omit = {http://cogcomp.org/papers/revisiting-evaluation-cross.pdf}
+}
+
+@Other{Vydiswar13,
+  Title                    = {Modeling and Predicting Trustworthiness of Online Textual Information},
+  Author                   = {V.G.Vinod Vydiswaran},
+  Booktitle                = {UIUC PhD Thesis},
+Url-omit = {http://cogcomp.org/papers/Vydiswaran13.pdf},
+  Year                     = {2013}
+}
+
+@Other{VydiswaranZhRo11,
+  Title                    = {Gauging the Internet Doctor: Ranking Medical Claims based on Community Knowledge},
+  Author                   = {V. Vydiswaran and C. Zhai and D. Roth},
+  Booktitle                = {Proc. of the ACM SIGKDD Conference on Knowledge Discovery and Data Mining (KDD) Workshop on Data Mining for Medicine and HealthCare},
+  Funding                  = {MIAS, CCICADA, ARL},
+Month-omit = {8},
+  Projects                 = {Trustworthiness},
+Url-omit = {http://cogcomp.org/papers/VydiswaranZhRo11b.pdf},
+  Year                     = {2011}
+}
+
+@InProceedings{VydiswaranZhRo11a,
+  Title                    = {Content-driven Trust Propagation Framework},
+  Author                   = {V. Vydiswaran and C. Zhai and D. Roth},
+  Booktitle                = {Proc. of the ACM SIGKDD Conference on Knowledge Discovery and Data Mining (KDD)},
+  Year                     = {2011},
+Month-omit = {8},
+Pages-omit = {974--982},
+
+  Acceptance               = {17.5\%},
+  Funding                  = {MIAS, CCICADA, ARL},
+  Projects                 = {Trustworthiness},
+Url-omit = {http://cogcomp.org/papers/VydiswaranZhRo11.pdf}
+}
+
+@Article{VZRP14,
+  Title                    = {Overcoming bias to learn about controversial topics},
+  Author                   = {V.G.Vinod Vydiswaran and Chengxiang Zhai and Dan Roth and Peter Pirolli},
+  Journal                  = {Journal of the American Society for Information Science and Technology (JASIST)},
+  Year                     = {2014},
+
+  Projects                 = {Trustworthiness},
+Publisher-omit = {Wiley},
+Url-omit = {http://cogcomp.org/papers/VZRP14.pdf}
+}
+
+@InProceedings{VZRP12,
+  Title                    = {BiasTrust: Teaching biased users about controversial topics},
+  Author                   = {V.G.Vinod Vydiswaran and ChengXiang Zhai and Dan Roth and Peter Pirolli},
+  Booktitle                = {Proc. of the ACM Conference on Information and Knowledge Management (CIKM)},
+  Year                     = {2012},
+Month-omit = {10},
+Pages-omit = {1205--1209},
+
+  Funding                  = {MIAS, ITI, ARL},
+  Projects                 = {Trustworthiness},
+Url-omit = {http://cogcomp.org/papers/VZRP12b.pdf}
+}
+
+@InProceedings{VZRP12a,
+  Title                    = {Unbiased Learning of Controversial Topics},
+  Author                   = {V.G.Vinod Vydiswaran and ChengXiang Zhai and Dan Roth and Peter Pirolli},
+  Booktitle                = {Proc. of the Annual Meeting of the American Society for Information Science and Technology},
+  Year                     = {2012},
+Month-omit = {10},
+
+  Funding                  = {MIAS, ITI, ARL},
+  Projects                 = {Trustworthiness},
+Url-omit = {http://cogcomp.org/papers/VZRP12.pdf}
+}
+
+@InProceedings{WSERZH15,
+  Title                    = {Incorporating World Knowledge to Document Clustering via Heterogeneous Information Networks},
+  Author                   = {Chenguang Wang and Yangqiu Song and Ahmed El-Kishky and Dan Roth and Ming Zhang and Jiawei Han},
+  Booktitle                = {Proc. of the ACM SIGKDD Conference on Knowledge Discovery and Data Mining (KDD)},
+  Year                     = {2015},
+
+Url-omit = {http://cogcomp.org/papers/WSERZH15.pdf}
+}
+
+@InProceedings{WSRWHJZ15,
+  Title                    = {Constrained Information-Theoretic Tripartite Graph Clustering to Identify Semantically Similar Relations},
+  Author                   = {Chenguang Wang and Yangqiu Song and Dan Roth and Chi Wang and Jiawei Han and Heng Ji and Ming Zhang},
+  Booktitle                = {Proc. of the International Joint Conference on Artificial Intelligence (IJCAI)},
+  Year                     = {2015},
+
+Url-omit = {http://cogcomp.org/papers/WSRWHJZ15.pdf}
+}
+
+@Article{WSRZH16,
+  Title                    = {World Knowledge as Indirect Supervision for Document Clustering},
+  Author                   = {Chenguang Wang and Yangqiu Song and Dan Roth and Ming Zhang and Jiawei Han},
+  Year                     = {2016},
+
+  Booktitle                = {ACM TKDD},
+Url-omit = {http://cogcomp.org/papers/WSRZH16.pdf}
+}
+
+@Other{WAAPRGHFLA11,
+  Title                    = {On Bayesian Interpretation of Fact-finding in Information Networks},
+  Author                   = {D. Wang and T. Abdelzaher and H. Ahmadi and J. Pasternack and D. Roth and M. Gupta and J. Han and O. Fatemieh and H. Le and C. Aggarwal},
+  Booktitle                = {Proc. of the International Conference on Information Fusion},
+Url-omit = {http://cogcomp.org/papers/WAAPRGHFLA11.pdf},
+  Year                     = {2011}
+}
+
+@Article{WBGLR15,
+  Title                    = {From Paraphrase Database to Compositional Paraphrase Model and Back},
+  Author                   = {John Wieting and Mohit Bansal and Kevin Gimpel and Karen Livescu and Dan Roth},
+  Year                     = {2015},
+
+  Booktitle                = {TACL},
+Url-omit = {http://cogcomp.org/papers/WietingBaGiLiRo15.pdf}
+}
+
+@InProceedings{WSSASURCGD17,
+  Title                    = {A Consolidated Open Knowledge Representation for Multiple Texts},
+  Author                   = {Rachel Wities and Vered Shwartz and Gabriel Stanovsky and Meni Adler and Ori Shapira and Shyam Upadhyay and Dan Roth and Eugenio Martinez Camara and Iryna Gurevych and Ido Dagan},
+  Booktitle                = {Proceedings of the 2nd LSDSem Workshop, in EACL},
+  Year                     = {2017},
+
+Url-omit = {http://cogcomp.org/papers/paper.pdf}
+}
+
+@InProceedings{WFDMSR14,
+  Title                    = {IllinoisCloudNLP: Text Analytics Services in the Cloud},
+  Author                   = {Hao Wu and Zhiye Fei and Aaron Dai and Stephen Mayhew and Mark Sammons and Dan Roth},
+  Booktitle                = {Proc. of the International Conference on Language Resources and Evaluation (LREC)},
+  Year                     = {2014},
+Month-omit = {5},
+
+  Funding                  = {MIAS, ARL, DARPA, NSF},
+Url-omit = {http://cogcomp.org/papers/WFDMSR14.pdf}
+}
+
+@InProceedings{YangRoAh02,
+  Title                    = {A Tale of Two Classifiers: SNoW vs. SVM in Visual Recognition},
+  Author                   = {M. Yang and D. Roth and N. Ahuja},
+  Booktitle                = {Proc. of the European Conference on Computer Vision (ECCV)},
+  Year                     = {2002},
+Pages-omit = {685--700},
+
+  Acceptance               = {45/600 (7.5\%) Oral Presentations; 225/600 (37\%) overall},
+  Funding                  = {NSF98,ITR-MIT},
+  Projects                 = {LT,LV},
+Url-omit = {http://cogcomp.org/papers/YangRoAh02.pdf}
+}
+
+@InProceedings{YangRoAh01,
+  Title                    = {Face Detection Using Large Margin Classifiers},
+  Author                   = {M. Yang and D. Roth and N. Ahuja},
+  Booktitle                = {Proc. of the IEEE International Conference on Image Processing (ICIP)},
+  Year                     = {2001},
+Pages-omit = {665--668},
+
+  Funding                  = {NSF98,ITR-MIT,CAREER},
+  Projects                 = {LV,LT},
+Url-omit = {http://cogcomp.org/papers/YangRoAh01.pdf}
+}
+
+@InProceedings{YangRoAh00,
+  Title                    = {A SNoW-based Face Detector},
+  Author                   = {M. Yang and D. Roth and N. Ahuja},
+  Booktitle                = {Proc. of the Conference on Neural Information Processing Systems (NIPS)},
+  Year                     = {2000},
+Pages-omit = {855--861},
+Publisher-omit = {MIT Press},
+
+  Acceptance               = {151/467 (32\%)},
+  Funding                  = {NSF98},
+Url-omit = {http://cogcomp.org/papers/nips00.pdf}
+}
+
+@InProceedings{YangRoAh00a,
+  Title                    = {Learning To Recognize 3D Objects With SNoW},
+  Author                   = {M. Yang and D. Roth and N. Ahuja},
+  Booktitle                = {Proc. of the European Conference on Computer Vision (ECCV)},
+  Year                     = {2000},
+Month-omit = {6},
+
+  Acceptance               = {43/266 (16\%) Oral Presentations; 115/266 (43\%) overall},
+Url-omit = {http://cogcomp.org/papers/YangRoAh00a.pdf}
+}
+
+@InProceedings{YangRoAh00b,
+  Title                    = {View-Based 3D Object Recognition Using SNoW},
+  Author                   = {M. Yang and D. Roth and N. Ahuja},
+  Booktitle                = {Proc. of the Asian Conference on Computer Vision (ACCV)},
+  Year                     = {2000},
+Month-omit = {1},
+Pages-omit = {830--835},
+Volume-omit = {2},
+
+  Acceptance               = {172/268 (64\%)},
+Url-omit = {http://cogcomp.org/papers/accv00.pdf}
+}
+
+@Other{Yih05,
+  Title                    = {Learning and Inference for Information Extraction},
+  Author                   = {W. Yih},
+  Booktitle                = {UIUC PhD thesis},
+Url-omit = {http://cogcomp.org/papers/Yih05.pdf},
+  Year                     = {2005}
+}
+
+@InProceedings{YihChKi04,
+  Title                    = {Mining Online Deal Forums for Hot Deals},
+  Author                   = {W. Yih and P. Chang and W. Kim},
+  Booktitle                = {Proc. of the IEEE/WIC/ACM International Conference on Web Intelligence (WI)},
+  Year                     = {2004},
+Pages-omit = {384--390},
+Publisher-omit = {IEEE Computer Society},
+
+  Comment                  = {Applying topic and sentiment text classification to online web forums},
+  Funding                  = {ITR-BI,MURI},
+  Projects                 = {IIA},
+Url-omit = {http://scottyih.org/YihChKi-wi04.pdf}
+}
+
+@Article{ZTLHPRL07,
+  Title                    = {Audio-Visual Affect Recognition},
+  Author                   = {Z. Zeng and J. Tu and M. Liu and T. Huang and B. Pianfetti and D. Roth and S. Levinson},
+  Journal                  = {IEEE Transactions on Multimedia},
+  Year                     = {2007},
+Number-omit = {2},
+Pages-omit = {424-428},
+Volume-omit = {9},
+
+  Funding                  = {ITR-BI},
+Url-omit = {http://cogcomp.org/papers/ZTLHPRL07.pdf}
+}
+
+@InProceedings{ZTLZRZHRL04,
+  Title                    = {Bimodal HCI-related Affect Recognition},
+  Author                   = {Z. Zeng and J. Tu and M. Liu and T. Zhang and N. Rizzolo and Z. Zhang and T. Huang and D. Roth and S. Levinson},
+  Booktitle                = {Proc. of the International Conference on Multimodal Interfaces (ICMI)},
+  Year                     = {2004},
+Month-omit = {10},
+Pages-omit = {137--143},
+
+  Acceptance               = {56/257 (28\%)},
+  Funding                  = {TRECC,ITR-BI},
+Url-omit = {http://cogcomp.org/papers/ZTKZRZHRL04.pdf}
+}
+
+@InProceedings{ZhaoDoRo12,
+  Title                    = {A Robust Shallow Temporal Reasoning System},
+  Author                   = {Ran Zhao and Quang Do and Dan Roth},
+  Booktitle                = {Proc. of the Annual Conference of the North American Chapter of the Association for Computational Linguistics (NAACL)},
+  Year                     = {2012},
+Month-omit = {6},
+
+Url-omit = {http://cogcomp.org/papers/ZhaoDoRo12.pdf}
+}
+
+@InProceedings{ZDCR05,
+  Title                    = {Learning Automation Policies for Pervasive Computing Environments},
+  Author                   = {B. Ziebart and A. Dey and R. Campbell and D. Roth},
+  Booktitle                = {Proc. of the International Conference on Autonomic Computing (ICAC)},
+  Year                     = {2005},
+Pages-omit = {204-215},
+
+  Acceptance               = {64/150 (43\%)},
+  Funding                  = {ITR-BI},
+  Projects                 = {LBP},
+Url-omit = {http://cogcomp.org/papers/ZDRC05.pdf}
+}
+
+@Other{Zimak06,
+  Title                    = {Algorithms and Analysis for Multi-Category Classification},
+  Author                   = {D. Zimak},
+  Booktitle                = {UIUC PhD Thesis},
+Url-omit = {http://cogcomp.org/papers/Zimak06.pdf},
+  Year                     = {2006}
+}
+
+@comment{jabref-meta: keypatterndefault:[authRoth][shortyear];}
 

--- a/ccg-long.bib
+++ b/ccg-long.bib
@@ -246,4259 +246,4513 @@ Automatic Acquisition of Spoken Language by an Autonomous Robot}}
 
 @string{Cambridge = {Cambridge University Press}}
 @string{Benjamin = {Benjamin/Cummings Publishing Company, Inc.}}
-@string{MIT = {MIT Press}}%%%%%%%%%%%%%%
-%%%  2017  %%%
-%%%%%%%%%%%%%%
-@workshop{NGDIDNDHPR17,
-  author = {Anjali Narayan-Chen  and Colin Graber  and Mayukh Das  and Md Rakibul Islam  and Soham Dan  and Sriraam Natarajan  and Janardhan Rao Doppa  and Julia Hockenmaier  and Martha Palmer and Dan Roth},
-  title = {Towards Problem Solving Agents that Communicate and Learn},
-  year = {2017},
-  url = "http://cogcomp.org/papers/ngdidndhpr17.pdf",
-}
-
-@inproceedings{NingFeRo17,
-  author = {Qiang Ning and Zhili Feng and Dan Roth},
-  title = {A Structured Learning Approach to Temporal Relation Extraction},
-  booktitle = {Proc. of the Conference on Empirical Methods in Natural Language Processing (EMNLP)},
-  pages = {1038--1048},
-  month = {9},
-  year = {2017},
-  address = {Copenhagen, Denmark},
-  publisher = {Association for Computational Linguistics},
-  url = "http://cogcomp.org/papers/NingFeRo17.pdf",
-  funding = {AI2, IBM-ILLINOIS C3SR, DARPA, ARL},
-}
-
-@inproceedings{ChaturvediPeRo17,
-  author = {Snigdha Chaturvedi and Haoruo Peng and Dan Roth},
-  title = {Story Comprehension for Predicting What Happens Next},
-  booktitle = {In proceedings of the Conference on Empirical Methods in Natural Language Processing},
-  year = {2017},
-  url = "http://cogcomp.org/papers/ChaturvediPeRo17.pdf",
-  funding = { IBM-ILLINOIS Center for Cognitive Computing Systems Research (C3SR), US Defense Advanced Research Projects Agency (DARPA) under contract FA8750-13-2-0008, Army Research Laboratory (ARL) under agreement W911NF-09-2-0053},
-}
-
-@thesis{Roy17,
-  author = {Subhro Roy},
-  title = {Reasoning about Quantities in Natural Language},
-  booktitle = {UIUC PhD Thesis},
-  year = {2017},
-  url = "http://cogcomp.org/papers/ROY-DISSERTATION-2017.pdf",
-}
-
-@inproceedings{KSKCSSR17,
-  author = {Parisa Kordjamshidi and Sameer Singh and Daniel Khashabi and Christos Christodoulopoulos and Mark Summons and Saurabh Sinha and Dan Roth },
-  title = {Relational Learning and Feature Extraction by Querying over Heterogeneous Information Networks},
-  booktitle = {Seventh International Workshop on Statistical Relational AI (StarAI)},
-  year = {2017},
-  url = "http://cogcomp.org/papers/2017_saul_relational_learning_starai.pdf",
-}
-
-@inproceedings{MayhewTsRo17,
-  author = {Stephen Mayhew and Chen-Tse Tsai and Dan Roth},
-  title = {Cheap Translation for Cross-Lingual Named Entity Recognition},
-  booktitle = {Proc. of the Conference on Empirical Methods in Natural Language Processing (EMNLP)},
-  year = {2017},
-  url = "http://cogcomp.org/papers/MayhewTsRo17.pdf",
-  funding = {LORELEI, DEFT},
-}
-
-@inproceedings{GuptaSiRo17,
-  author = {Nitish Gupta and Sameer Singh and Dan Roth},
-  title = {Entity Linking via Joint Encoding of Types, Descriptions, and Context},
-  booktitle = {Proc. of the Conference on Empirical Methods in Natural Language Processing (EMNLP)},
-  year = {2017},
-  url = "http://cogcomp.org/papers/GuptaSiRo17.pdf",
-}
-
-@article{RozovskayaRoSa17,
-  author = {Alla Rozovskaya and Dan Roth and Mark Sammons},
-  title = {Adapting to Learner Errors with Minimal Supervision},
-  year = {2017},
-  journal = {Computational Linguistics},
-  url = "http://cogcomp.org/papers/CL-adaptation.pdf",
-}
-
-@thesis{Tsai17,
-  author = {Chen-Tse Tsai},
-  title = {Concept and Entity Grounding Using Indirect Supervision},
-  booktitle = {UIUC PhD Thesis},
-  year = {2017},
-  url = "http://cogcomp.org/papers/Tsai17.pdf",
-}
-
-@inproceedings{PengChRo17,
-  author = {Haoruo Peng and Snigdha Chaturvedi and Dan Roth},
-  title = {A Joint Model for Semantic Sequences: Frames, Entities, Sentiments},
-  booktitle = {Proc. of the Conference on Computational Natural Language Learning (CoNLL)},
-  year = {2017},
-  institution = {University of Illinois, Urbana-Champaign},
-  url = "http://cogcomp.org/papers/PengChRo17.pdf",
-}
-
-@inproceedings{KhTuSaRo17,
-  author = {Daniel Khashabi and Tushar Khot and Ashish Sabharwal and Dan Roth },
-  title = {Learning What is Essential in Questions},
-  booktitle = {The Conference on Computational Natural Language Learning (Proc. of the Conference on Computational Natural Language Learning (CoNLL))},
-  year = {2017},
-  url = "http://cogcomp.org/papers/2017_conll_essential_terms.pdf",
-}
-
-@inproceedings{WSSASURMEGD17,
-  author = {Rachel Wities and Vered Shwartz and Gabriel Stanovsky and Meni Adler and Ori Shapira and Shyam Upadhyay and Dan Roth and Eugenio Martinez Camara and Iryna Gurevych and Ido Dagan},
-  title = {A Consolidated Open Knowledge Representation for Multiple Texts},
-  booktitle = {Proceedings of the 2nd LSDSem Workshop, in EACL},
-  year = {2017},
-  url = "http://cogcomp.org/papers/paper.pdf",
-}
-
-@inproceedings{Roth17,
-  author = {Dan Roth},
-  title = {Incidental Supervision: Moving beyond Supervised Learning},
-  booktitle = {Proc. of the Conference on Artificial Intelligence (AAAI)},
-  month = {2},
-  year = {2017},
-  url = "http://cogcomp.org/papers/Roth-AAAI17-incidental-supervision.pdf",
-}
-
-@inproceedings{RoyRo17,
-  author = {Subhro Roy and Dan Roth},
-  title = {Unit Dependency Graph and its Application to Arithmetic Word Problem Solving},
-  booktitle = {Proc. of the Conference on Artificial Intelligence (AAAI)},
-  year = {2017},
-  url = "http://cogcomp.org/papers/14764-64645-1-SM.pdf",
-}
-
-%%%%%%%%%%%%%%
-%%%  2016  %%%
-%%%%%%%%%%%%%%
-@workshop{TMPSMRR16,
-  author = {Chen-Tse Tsai and Stephen Mayhew and Haoruo Peng and Mark Sammons and Bhargav Mangipundi and Pavankumar Reddy and Dan Roth},
-  title = {Illinois CCG Entity Discovery and Linking, Event Nugget Detection and Co-reference, and Slot Filler Validation Systems for TAC 2016},
-  booktitle = {Text Analysis Conference (Proc. of the Text Analysis Conference (TAC) 2016)},
-  year = {2016},
-  institution = {National Institute of Standards and Technology},
-  url = {},
-}
-
-@inproceedings{GuptaSaRo16,
-  author = {Narender Gupta and Aman Sawhney and Dan Roth},
-  title = {Will I Get in? - Modeling the Graduate Admission  Process for American Universities},
-  booktitle = {2016 IEEE 16th International Conference on Data Mining Workshops (ICDMW)},
-  pages = {631--638},
-  year = {2016},
-  url = "http://cogcomp.org/papers/Will_I_Get_In.pdf",
-}
-
-@inproceedings{TsaiRo16c,
-  author = {Chen-Tse Tsai and Dan Roth},
-  title = {Illinois Cross-Lingual Wikifier: Grounding Entities in Many Languages to the English Wikipedia},
-  booktitle = {Proc. of the International Conference on Computational Linguistics (COLING) Demonstrations},
-  month = {12},
-  year = {2016},
-  url = "http://cogcomp.org/papers/TsaiRo16c.pdf",
-}
-
-@article{WSRZH16,
-  author = {Chenguang Wang and Yangqiu Song and Dan Roth and Ming Zhang and Jiawei Han},
-  title = {World Knowledge as Indirect Supervision for Document Clustering},
-  booktitle = {ACM TKDD},
-  year = {2016},
-  url = "http://cogcomp.org/papers/WSRZH16.pdf",
-}
-
-@incollection{SongMaRo16,
-  author = {Yangqiu Song and Stephen Mayhew and Dan Roth},
-  title = {Cross-lingual Dataless Classification for Languages with Small Wikipedia Presence},
-  booktitle = {arXiv},
-  pages = {17},
-  month = {11},
-  year = {2016},
-  number = {arXiv:1611.04122},
-  url = "http://cogcomp.org/papers/SongMR16.pdf",
-}
-
-@inproceedings{CYSMD16,
-  author = {Chen-Tse Tsai and Yangqiu Song and Stephen Mayhew and Mark Sammons and Dan Roth},
-  title = {Illinois CCG LoReHLT 2016 Named Entity Recognition and Situation Frame Systems},
-  booktitle = {Low Resource Human Language Technologies (LoReHLT)},
-  year = {2016},
-  url = "http://cogcomp.org/papers/CYSMD16.pdf",
-}
-
-@inproceedings{KKCMSR16,
-  author = {Parisa Kordjamshidi and Daniel Khashabi and Christos Christodoulopoulos and Bhargav Mangipudi and Sameer Singh and Dan Roth },
-  title = {Better call Saul: Flexible Programming for Learning and Inference in NLP},
-  booktitle = {Proc. of the International Conference on Computational Linguistics (COLING)},
-  year = {2016},
-  url = "http://cogcomp.org/papers/KKCMSR16.pdf",
-}
-
-@inproceedings{RoyRo16,
-  author = {Subhro Roy and Dan Roth},
-  title = {ILLINOIS MATH SOLVER: Math Reasoning on the Web},
-  booktitle = {Proc. of the Annual Conference of the North American Chapter of the Association for Computational Linguistics (NAACL) Demonstrations},
-  year = {2016},
-  url = "http://cogcomp.org/papers/IMS.pdf",
-}
-
-@inproceedings{UGCR16,
-  author = {Shyam Upadhyay and Nitish Gupta and Christos Christodoulopoulos and Dan Roth},
-  title = {Revisiting the Evaluation for Cross Document Event Coreference},
-  booktitle = {Proc. of the International Conference on Computational Linguistics (COLING)},
-  year = {2016},
-  url = "http://cogcomp.org/papers/revisiting-evaluation-cross.pdf",
-}
-
-@inproceedings{RoyUpRo16,
-  author = {Subhro Roy and Shyam Upadhyay and Dan Roth},
-  title = {EQUATION PARSING : Mapping Sentences to Grounded Equations},
-  booktitle = {Proc. of the Conference on Empirical Methods in Natural Language Processing (EMNLP)},
-  year = {2016},
-  url = "http://cogcomp.org/papers/1609.08824v1.pdf",
-}
-
-@inproceedings{PengSoRo16,
-  author = {Haoruo Peng and Yangqiu Song and Dan Roth},
-  title = {Event Detection and Co-reference with Minimal Supervision},
-  booktitle = {Proc. of the Conference on Empirical Methods in Natural Language Processing (EMNLP)},
-  year = {2016},
-  url = "http://cogcomp.org/papers/PengSoRo16.pdf",
-}
-
-@workshop{UpChRo16,
-  author = {Shyam Upadhyay and Christos Christodoulopoulos and Dan Roth},
-  title = {Making the News - Identifying Noteworthy Events in News Articles},
-  booktitle = {The 4th Workshop on EVENTS, Proc. of the Annual Conference of the North American Chapter of the Association for Computational Linguistics (NAACL)},
-  year = {2016},
-  url = "http://cogcomp.org/papers/W16-1001.pdf",
-}
-
-@workshop{ChristodoulopoulosRoFi16,
-  author = { Christos Christodoulopoulos and Dan Roth and Cynthia Fisher},
-  title = {An incremental model of syntactic bootstrapping},
-  booktitle = {7th Workshop on Cognitive Aspects of Computational Language Learning, Proc. of the Annual Meeting of the Association for Computational Linguistics (ACL)},
-  month = {8},
-  year = {2016},
-  url = "http://cogcomp.org/papers/christodoulopoulos_16_incremental.pdf",
-}
-
-@inproceedings{TsaiMaRo16,
-  author = {Chen-Tse Tsai and Stephen Mayhew and Dan Roth},
-  title = {Cross-Lingual Named Entity Recognition via Wikification},
-  booktitle = {Proc. of the Conference on Computational Natural Language Learning (CoNLL)},
-  year = {2016},
-  url = "http://cogcomp.org/papers/TsaiMaRo16.pdf",
-}
-
-@inproceedings{PengRo16,
-  author = {Haoruo Peng and Dan Roth},
-  title = {Two Discourse Driven Language Models for Semantics},
-  booktitle = {Proc. of the Annual Meeting of the Association for Computational Linguistics (ACL)},
-  year = {2016},
-  url = "http://cogcomp.org/papers/PengRo16.pdf",
-}
-
-@inproceedings{UFDR16,
-  author = {Shyam Upadhyay and Manaal Faruqui and Chris Dyer and Dan Roth},
-  title = {Cross-lingual Models of Word Embeddings: An Empirical Comparison},
-  booktitle = {Proc. of the Annual Meeting of the Association for Computational Linguistics (ACL)},
-  year = {2016},
-  url = "http://cogcomp.org/papers/acl2016.pdf",
-}
-
-@inproceedings{RozovskayaRo16,
-  author = {Alla Rozovskaya and Dan Roth},
-  title = {Grammatical Error Correction: Machine Translation and Classifiers},
-  booktitle = {Proc. of the Annual Meeting of the Association for Computational Linguistics (ACL)},
-  year = {2016},
-  publisher = {ACL},
-  url = "http://cogcomp.org/papers/RozovskayaRo16.pdf",
-}
-
-@inproceedings{SCKKSVBWR16,
-  author = {Mark Sammons and Christos Christodoulopoulos and Parisa Kordjamshidi and Daniel Khashabi and Vivek Srikumar and Paul Vijayakumar and Mazin Bokhari and Xinbo Wu and Dan Roth},
-  title = {EDISON: Feature Extraction for NLP, Simplified},
-  booktitle = {Proc. of the International Conference on Language Resources and Evaluation (LREC) },
-  year = {2016},
-  publisher = {European Language Resources Association (ELRA)},
-  editor = {Nicoletta Calzolari (Conference Chair) and Khalid Choukri and Thierry Declerck and Marko Grobelnik and Bente Maegaard and Joseph Mariani and Asuncion Moreno and Jan Odijk and Stelios Piperidis},
-  url = "http://cogcomp.org/papers/SCKKSVBWR16.pdf",
-}
-
-@inproceedings{LingSoRo16,
-  author = {Shaoshi Ling and Yangqiu Song and Dan Roth},
-  title = {Word Embeddings with Limited Memory},
-  booktitle = {Proc. of the Annual Meeting of the Association for Computational Linguistics (ACL)},
-  year = {2016},
-  url = "http://cogcomp.org/papers/LingSoRo16.pdf",
-}
-
-@techreport{RedmanSaRo17,
-  author = {Tom Redman and Mark Sammons and Dan Roth},
-  title = {Illinois Named Entity Recognizer: Addendum to Ratinov and Roth '09 reporting improved results},
-  booktitle = {Tech Reports},
-  year = {2016},
-  url = "http://cogcomp.org/papers/ner-addendum.pdf",
-}
-
-@inproceedings{SUPR16,
-  author = {Yangqiu Song and Shyam Upadhyay and Haoruo Peng and Dan Roth},
-  title = {Cross-lingual Dataless Classification for Many Languages},
-  booktitle = {Proc. of the International Joint Conference on Artificial Intelligence (IJCAI)},
-  year = {2016},
-  url = "http://cogcomp.org/papers/SUPR16.pdf",
-}
-
-@inproceedings{KKSCER16,
-  author = {Daniel Khashabi and Tushar Khot and Ashish Sabharwal and Peter Clark and Oren Etzioni and Dan Roth },
-  title = {Question Answering via Integer Programming over Semi-Structured Knowledge},
-  booktitle = {Proc. of the International Joint Conference on Artificial Intelligence (IJCAI)},
-  year = {2016},
-  url = "http://cogcomp.org/papers/KKSCER16.pdf",
-}
-
-@inproceedings{TsaiRo16b,
-  author = {Chen-Tse Tsai and Dan Roth},
-  title = {Cross-lingual Wikification Using Multilingual Embeddings},
-  booktitle = {Proc. of the Annual Conference of the North American Chapter of the Association for Computational Linguistics (NAACL)},
-  month = {6},
-  year = {2016},
-  url = "http://cogcomp.org/papers/TsaiRo16b.pdf",
-}
-
-@incollection{RizzoloRo16,
-  author = {N. Rizzolo and D. Roth},
-  title = {Integer Linear Programming for Co-reference Resolution},
-  booktitle = {Anaphora Resolution: Algorithms, Resources, and Applications},
-  year = {2016},
-  publisher = {Springer-Verlag},
-  editor = {Massimo Poesio, Roland Stuckardt and Yannick Versley},
-  url = {},
-  invisible = {true},
-}
-
-@article{TsaiRo16,
-  author = {Chen-Tse Tsai and Dan Roth},
-  title = {Concept Grounding to Multiple Knowledge Bases via Indirect Supervision},
-  booktitle = {TACL},
-  month = {2},
-  year = {2016},
-  url = "http://cogcomp.org/papers/TsaiRo16.pdf",
-}
-
-@inproceedings{ArivazhaganChRo16,
-  author = {Naveen Arivazhagan and Christos Christodoulopoulos and Dan Roth},
-  title = {Labeling the Semantic Roles of Commas},
-  booktitle = {Proc. of the Conference on Artificial Intelligence (AAAI)},
-  month = {2},
-  year = {2016},
-  url = "http://cogcomp.org/papers/ArivazhaganChRo16.pdf",
-  projects = {DEFT},
-}
-
-%%%%%%%%%%%%%%
-%%%  2015  %%%
-%%%%%%%%%%%%%%
-@workshop{SPSUTRRR15,
-  author = {Mark Sammons and Haoruo Peng and Yangqiu Song and Shyam Upadhyay and Chen-Tse Tsai and Pavankumar Reddy and Subhro Roy and Dan Roth},
-  title = {Illinois CCG TAC 2015 Event Nugget, Entity Discovery and Linking, and Slot Filler Validation Systems},
-  booktitle = {Text Analysis Conference},
-  year = {2015},
-  institution = {National Institute of Standards and Technology},
-  url = "http://cogcomp.org/papers/SPSUTRRR15.pdf",
-}
-
-@inproceedings{SPSUTRRR15,
-  author = {Mark Sammons and Haoruo Peng and Yangqiu Song and Shyam Upadhyay and Chen-Tse Tsai and Pavankumar Reddy and Subhro Roy and Dan Roth},
-  title = {Illinois CCG TAC 2015 Event Nugget, Entity Discovery and Linking, and Slot Filler Validation Systems},
-  booktitle = {Proc. of the Text Analysis Conference (TAC)},
-  year = {2015},
-  url = "http://cogcomp.org/papers/TAC15.pdf",
-}
-
-@workshop{LCUR15,
-  author = {Ching-pei Lee and Kai-Wei Chang and Shyam Upadhyay and Dan Roth},
-  title = {Distributed Training of Structured SVM},
-  booktitle = {OPT Workshop, Proc. of the Conference on Neural Information Processing Systems (NIPS)},
-  year = {2015},
-  url = "http://cogcomp.org/papers/OPT2015_paper_1.pdf",
-}
-
-@workshop{PKMLDY15,
-  author = {James Pustejovsky and Parisa Kordjamshidi and Marie-Francine Moens and Aaron Levine and Seth Dworman and Zachary Yocum},
-  title = {SemEval-2015 Task 8: SpaceEval},
-  booktitle = {Proc. of the Annual Meeting of the Association for Computational Linguistics (ACL)},
-  pages = {884-894},
-  year = {2015},
-  publisher = {ACL},
-  url = "http://cogcomp.org/papers/PustejovskyetalSemEval2015.pdf",
-}
-
-@inproceedings{MKPM15,
-  author = {Wouter Massa and Parisa Kordjamshidi and Thomas Provoost and Marie-Francine Moens},
-  title = {Machine Reading of Biological Texts: Bacteria-Biotope Extraction},
-  booktitle = {Proc. of the International Conference on Bioinformatics Models, Methods and Algorithms},
-  pages = {55-64},
-  year = {2015},
-  publisher = {SCITEPRESS},
-  url = "http://cogcomp.org/papers/MassaetalBIOSTEC2015.pdf",
-}
-
-@article{WBGLR15,
-  author = {John Wieting and Mohit Bansal and Kevin Gimpel and Karen Livescu and Dan Roth},
-  title = {From Paraphrase Database to Compositional Paraphrase Model and Back},
-  booktitle = {TACL},
-  year = {2015},
-  url = "http://cogcomp.org/papers/WietingBaGiLiRo15.pdf",
-}
-
-@inproceedings{SPKSR15,
-  author = {Yangqiu Song and Haoruo Peng and Parisa Kordjamshidi and Mark Sammons and Dan Roth},
-  title = {Improving a Pipeline Architecture for Shallow Discourse Parsing},
-  booktitle = {Proc. of the Conference on Computational Natural Language Learning (CoNLL)},
-  year = {2015},
-  url = "http://cogcomp.org/papers/SPKSR15.pdf",
-}
-
-@inproceedings{RoyRo15,
-  author = {Subhro Roy and Dan Roth},
-  title = {Solving General Arithmetic Word Problems},
-  booktitle = {Proc. of the Conference on Empirical Methods in Natural Language Processing (EMNLP)},
-  year = {2015},
-  url = "http://cogcomp.org/papers/arithmetic.pdf",
-}
-
-@inproceedings{PengChRo15,
-  author = {Haoruo Peng and Kai-Wei Chang and Dan Roth},
-  title = {A Joint Framework for Coreference Resolution and Mention Head Detection},
-  booktitle = {Proc. of the Conference on Computational Natural Language Learning (CoNLL)},
-  pages = {10},
-  month = {7},
-  year = {2015},
-  address = {University of Illinois, Urbana-Champaign, Urbana, IL, 61801},
-  publisher = {ACL},
-  institution = {University of Illinois at Urbana-Champaign},
-  url = "http://cogcomp.org/papers/MentionDetection.pdf",
-}
-
-@workshop{FKPWR15,
-  author = {Zhiye Fei and Daniel Khashabi and Haoruo Peng and Hao Wu and Dan Roth},
-  title = {ILLINOIS-PROFILER: Knowledge Schemas at Scale},
-  booktitle = {Workshop on Cognitive Knowledge Acquisition and Applications, Proc. of the International Joint Conference on Artificial Intelligence (IJCAI)},
-  year = {2015},
-  url = "http://cogcomp.org/papers/profiler_ijcai.pdf",
-}
-
-@inproceedings{LeeRo15,
-  author = {Ching-pei Lee and Dan Roth},
-  title = {Distributed Box-Constrained Quadratic Optimization for Dual Linear SVM},
-  booktitle = {Proc. of the International Conference on Machine Learning (ICML)},
-  month = {7},
-  year = {2015},
-  acceptance = {26\%},
-  url = "http://cogcomp.org/papers/distcd.pdf",
-  funding = {DEFT},
-}
-
-@article{KordjamshidiRoMo15,
-  author = {Parisa Kordjamshidi and Dan Roth and Marie-Francine Moens},
-  title = {Structured Learning for Spatial Information Extraction from Biomedical Text: Bacteria Biotopes},
-  booktitle = {BMC Proc. of the International Conference on Bioinformatics Models, Methods and Algorithms},
-  month = {4},
-  year = {2015},
-  volume = {16},
-  number = {126},
-  url = "http://cogcomp.org/papers/BMC_Bacteria_Biotope.pdf",
-}
-
-@inproceedings{KordjamshidiRoWu15,
-  author = {Parisa Kordjamshidi and Hao Wu and Dan Roth},
-  title = {Saul: Towards Declarative Learning Based Programming},
-  booktitle = {Proc. of the International Joint Conference on Artificial Intelligence (IJCAI)},
-  month = {7},
-  year = {2015},
-  url = "http://cogcomp.org/papers/KordjamshidiRoWu15.pdf",
-}
-
-@inproceedings{WSERZH15,
-  author = {Chenguang Wang and Yangqiu Song and Ahmed El-Kishky and Dan Roth and Ming Zhang and Jiawei Han},
-  title = {Incorporating World Knowledge to Document Clustering via Heterogeneous Information Networks},
-  booktitle = {Proc. of the ACM SIGKDD Conference on Knowledge Discovery and Data Mining (KDD)},
-  year = {2015},
-  url = "http://cogcomp.org/papers/WSERZH15.pdf",
-}
-
-@inproceedings{WSRWHJZ15,
-  author = {Chenguang Wang and Yangqiu Song and Dan Roth and Chi Wang and Jiawei Han and Heng Ji and Ming Zhang},
-  title = {Constrained Information-Theoretic Tripartite Graph Clustering to Identify Semantically Similar Relations},
-  booktitle = {Proc. of the International Joint Conference on Artificial Intelligence (IJCAI)},
-  year = {2015},
-  url = "http://cogcomp.org/papers/WSRWHJZ15.pdf",
-}
-
-@thesis{Chang15,
-  author = {Kai-Wei Chang},
-  title = {Selective Algorithms for Large-Scale Classification and Structured Learning},
-  booktitle = {UIUC PhD Thesis},
-  year = {2015},
-  url = "http://cogcomp.org/papers/Chang15.pdf",
-}
-
-@inproceedings{SongRo15,
-  author = {Yangqiu Song and Dan Roth},
-  title = {Unsupervised Sparse Vector Densification for Short Text Similarity},
-  booktitle = {Proc. of the Annual Conference of the North American Chapter of the Association for Computational Linguistics (NAACL)},
-  month = {5},
-  year = {2015},
-  url = "http://cogcomp.org/papers/SongRo15.pdf",
-}
-
-@inproceedings{PengKhRo15,
-  author = {Haoruo Peng and Daniel Khashabi and Dan Roth},
-  title = {Solving Hard Coreference Problems},
-  booktitle = {Proc. of the Annual Conference of the North American Chapter of the Association for Computational Linguistics (NAACL)},
-  month = {5},
-  year = {2015},
-  url = "http://cogcomp.org/papers/PengKhRo15.pdf",
-}
-
-@article{RoyViRo15,
-  author = {Subhro Roy and Tim Vieira and Dan Roth},
-  title = {Reasoning about Quantities in Natural Language},
-  booktitle = {TACL},
-  year = {2015},
-  journal = {Transactions of the Association for Computational Linguistics (TACL)},
-  volume = {3},
-  url = "http://cogcomp.org/papers/RoyViRo15.pdf",
-}
-
-@inproceedings{CUKR15,
-  author = {Kai-Wei Chang and Shyam Upadhyay and Gourab Kundu and Dan Roth},
-  title = {Structural Learning with Amortized Inference},
-  booktitle = {Proc. of the Conference on Artificial Intelligence (AAAI)},
-  year = {2015},
-  url = "http://cogcomp.org/papers/CUKR15.pdf",
-  funding = {ONR,ARL,DEFT},
-}
-
-%%%%%%%%%%%%%%
-%%%  2014  %%%
-%%%%%%%%%%%%%%
-@incollection{PasternackRo14,
-  author = {Jeff Pasternack and Dan Roth},
-  title = {Judging the Veracity of Claims and Reliability of Sources With Fact-Finders},
-  booktitle = {Computational Trust Models and Machine Learning},
-  pages = {39-72},
-  year = {2014},
-  publisher = {Chapman and Hall/CRC},
-  editor = {Xin Liu, Anwitaman Datta, and Ee-Peng Lim},
-  url = "http://cogcomp.org/papers/fact_finder_chapter_clean.pdf",
-}
-
-@inproceedings{JindalGuRo14,
-  author = {Prateek Jindal and Carl A. Gunter and Dan Roth},
-  title = {Detecting Privacy-Sensitive Events in Medical Text},
-  booktitle = {Proc. of the ACM Conference on Proc. of the International Conference on Bioinformatics Models, Methods and Algorithms, Computational Biology, and Health Informatics},
-  month = {9},
-  year = {2014},
-  url = "http://cogcomp.org/papers/JindalGR14.pdf",
-}
-
-@inproceedings{JindalRoGu14,
-  author = {Prateek Jindal and Dan Roth and  Carl A. Gunter},
-  title = {Joint Inference for End-to-End Coreference Resolution for Clinical Notes},
-  booktitle = {Proc. of the ACM Conference on Proc. of the International Conference on Bioinformatics Models, Methods and Algorithms, Computational Biology, and Health Informatics},
-  month = {9},
-  year = {2014},
-  url = "http://cogcomp.org/papers/p192-jindal.pdf",
-}
-
-@inproceedings{SSWKTUMRA14,
-  author = {Mark Sammons and Yangqiu Song and Ruichen Wang and Gourab Kundu and Chen-Tse Tsai and Shyam Upadhyay and Siddarth Ancha and Stephen Mayhew},
-  title = {Overview of UI-CCG Systems for Event Argument Extraction, Entity Discovery and Linking, and Slot Filler Validation},
-  booktitle = {Proc. of the Text Analysis Conference (TAC)},
-  year = {2014},
-  institution = {NIST},
-  url = "http://cogcomp.org/papers/SSWKTUMRA14.pdf",
-}
-
-@article{RozovskayaRo14,
-  author = {Alla Rozovskaya and Dan Roth},
-  title = {Building a State-of-the-Art Grammatical Error Correction System},
-  booktitle = {TACL},
-  year = {2014},
-  url = "http://cogcomp.org/papers/RozovskayaRo14.pdf",
-}
-
-@inproceedings{SongRo14,
-  author = {Yangqiu Song and Dan Roth},
-  title = {On Dataless Hierarchical Text Classification},
-  booktitle = {Proc. of the Conference on Artificial Intelligence (AAAI)},
-  month = {7},
-  year = {2014},
-  url = "http://cogcomp.org/papers/SongRo14.pdf",
-}
-
-@inproceedings{RCSRH14,
-  author = {Alla Rozovskaya and Kai-Wei Chang and Mark Sammons and Dan Roth and Nizar Habash},
-  title = {The Illinois-Columbia System in the CoNLL-2014 Shared Task},
-  booktitle = {Proc. of the Conference on Computational Natural Language Learning (CoNLL)},
-  year = {2014},
-  url = "http://cogcomp.org/papers/RCSRH14.pdf",
-}
-
-@inproceedings{WFDMSR14,
-  author = {Hao Wu and Zhiye Fei and Aaron Dai and Stephen Mayhew and Mark Sammons and Dan Roth},
-  title = {IllinoisCloudNLP: Text Analytics Services in the Cloud},
-  booktitle = {Proc. of the International Conference on Language Resources and Evaluation (LREC)},
-  month = {5},
-  year = {2014},
-  url = "http://cogcomp.org/papers/WFDMSR14.pdf",
-  funding = {MIAS, ARL, DARPA, NSF},
-}
-
-@article{VZRP14,
-  author = {V.G.Vinod Vydiswaran and Chengxiang Zhai and Dan Roth and Peter Pirolli},
-  title = {Overcoming bias to learn about controversial topics},
-  year = {2014},
-  publisher = {Wiley},
-  journal = {Journal of the American Society for Information Science and Technology (JASIST)},
-  url = "http://cogcomp.org/papers/VZRP14.pdf",
-  projects = {Trustworthiness},
-}
-
-@inproceedings{RozovskayaRoSr14,
-  author = {Alla Rozovskaya and Dan Roth and Vivek Srikumar},
-  title = {Correcting Grammatical Verb Errors},
-  booktitle = {EACL},
-  month = {4},
-  year = {2014},
-  url = "http://cogcomp.org/papers/RozovskayaRoSr14.pdf",
-}
-
-@article{GoldwasserRo14,
-  author = {Dan Goldwasser and Dan Roth},
-  title = {Learning from Natural Instructions},
-  pages = {205-232},
-  month = {2},
-  year = {2014},
-  publisher = {Springer},
-  journal = {Machine Learning},
-  volume = {94},
-  number = {2},
-  url = "http://cogcomp.org/papers/GoldwasserRo14.pdf",
-}
-
-@article{BBCRWZ14,
-  author = {Antoine Bordes and L�on Bottou and Ronan Collobert and Dan Roth and Jason Weston and Luke Zettlemoyer},
-  title = {Introduction to the special issue on learning semantics},
-  pages = {127-131},
-  month = {2},
-  year = {2014},
-  publisher = {Springer},
-  journal = {Machine Learning},
-  volume = {94},
-  number = {2},
-  url = "http://cogcomp.org/papers/BBCRWZ14.pdf",
-}
-
-@inproceedings{SamdaniChRo14,
-  author = {Rajhans Samdani and Kai-Wei Chang and Dan Roth},
-  title = {A Discriminative Latent Variable Model for Online Clustering},
-  booktitle = {Proc. of the International Conference on Machine Learning (ICML)},
-  year = {2014},
-  acceptance = {14.7\%},
-  url = "http://cogcomp.org/papers/l3m.icml.pdf",
-}
-
-%%%%%%%%%%%%%%
-%%%  2013  %%%
-%%%%%%%%%%%%%%
-@inproceedings{CCSCFSWRWR13,
-  author = {Xiao Cheng and Bingling Chen and Rajhans Samdani and Kai-Wei Chang and Zhiye Fei and Mark Sammons and John Wieting and Subhro Roy and Chizheng Wang and Dan Roth},
-  title = {Illinois Cognitive Computation Group UI-CCG TAC 2013 Entity Linking and Slot Filler Validation Systems},
-  booktitle = {Proc. of the Text Analysis Conference (TAC)},
-  year = {2013},
-  url = "http://cogcomp.org/papers/UI_CCG.TAC2013.proceedings.pdf",
-}
-
-@thesis{Srikumar13,
-  author = {Vivek Srikumar},
-  title = {The Semantics of Role Labeling},
-  booktitle = {UIUC PhD Thesis},
-  year = {2013},
-  url = "http://cogcomp.org/papers/Srikumar13.pdf",
-}
-
-@thesis{Vydiswaran13,
-  author = {V.G.Vinod Vydiswaran},
-  title = {Modeling and Predicting Trustworthiness of Online Textual Information},
-  booktitle = {UIUC PhD Thesis},
-  year = {2013},
-  url = "http://cogcomp.org/papers/Vydiswaran13.pdf",
-}
-
-@thesis{Samdani13,
-  author = {Rajhans Samdani},
-  title = {Algorithms for Structural Learning with Decompositions},
-  booktitle = {UIUC PhD Thesis},
-  year = {2013},
-  url = "http://cogcomp.org/papers/Samdani13.pdf",
-}
-
-@thesis{Jindal13,
-  author = {Prateek Jindal},
-  title = {Information Extraction for Clinical Narratives},
-  booktitle = {UIUC PhD Thesis},
-  year = {2013},
-  url = "http://cogcomp.org/papers/Jindal13.pdf",
-}
-
-@thesis{Rozovskaya13,
-  author = {Alla Rozovskaya},
-  title = {Automated Methods for Text Correction},
-  booktitle = {UIUC PhD Thesis},
-  year = {2013},
-  url = "http://cogcomp.org/papers/Rozovskaya13.pdf",
-}
-
-@inproceedings{TsaiKuRo13,
-  author = {Chen-Tse Tsai and Gourab Kundu and Dan Roth},
-  title = {Concept-Based Analysis of Scientific Literature},
-  booktitle = {Proc. of the ACM Conference on Information and Knowledge Management (CIKM)},
-  year = {2013},
-  url = "http://cogcomp.org/papers/TsaiKuRo13.pdf",
-}
-
-@inproceedings{ChengRo13,
-  author = {Xiao Cheng and Dan Roth},
-  title = {Relational Inference for Wikification},
-  booktitle = {Proc. of the Conference on Empirical Methods in Natural Language Processing (EMNLP)},
-  year = {2013},
-  url = "http://cogcomp.org/papers/ChengRo13.pdf",
-  funding = {DEFT,ARL,MIAS},
-}
-
-@inproceedings{RozovskayaRo13,
-  author = {Alla Rozovskaya and Dan Roth},
-  title = {Joint Learning and Inference for Grammatical Error Correction},
-  booktitle = {Proc. of the Conference on Empirical Methods in Natural Language Processing (EMNLP)},
-  month = {10},
-  year = {2013},
-  url = "http://cogcomp.org/papers/RozovskayaRo13.pdf",
-}
-
-@article{JindalRo13d,
-  author = {P. Jindal and D. Roth},
-  title = {Extraction of Events and Temporal Expressions from Clinical Narratives},
-  month = {10},
-  year = {2013},
-  editor = {E.H. Shortliffe},
-  journal = {Journal of Biomedical Informatics (JBI)},
-  url = "http://cogcomp.org/papers/JindalRo13d.pdf",
-}
-
-@inproceedings{JindalRo13c,
-  author = {Prateek Jindal and Dan Roth},
-  title = {Using Soft Constraints in Joint Inference for Clinical Concept Recognition},
-  booktitle = {Proc. of the Conference on Empirical Methods in Natural Language Processing (EMNLP)},
-  month = {10},
-  year = {2013},
-  url = "http://cogcomp.org/papers/JindalRo13c.pdf",
-}
-
-@inproceedings{ChangSaRo13,
-  author = {Kai-Wei Chang and Rajhans Samdani and Dan Roth},
-  title = {A Constrained Latent Variable Model for Coreference Resolution},
-  booktitle = {Proc. of the Conference on Empirical Methods in Natural Language Processing (EMNLP)},
-  year = {2013},
-  url = "http://cogcomp.org/papers/ChangSaRo13.pdf",
-}
-
-@inproceedings{RCSR13,
-  author = {Alla Rozovskaya and Kai-Wei Chang and Mark Sammons and Dan Roth},
-  title = {The University of Illinois System in the CoNLL-2013 Shared Task},
-  booktitle = {Proc. of the Conference on Computational Natural Language Learning (CoNLL)},
-  year = {2013},
-  url = "http://cogcomp.org/papers/RCSR13.pdf",
-  funding = {MR, DEFT},
-}
-
-@unpublished{DRSZ13,
-  author = {Ido Dagan and Dan Roth and Mark Sammons and Fabio Massimo Zanzoto},
-  title = {Recognizing Textual Entailment: Models and Applications},
-  booktitle = {Recognizing Textual Entailment: Models and Applications},
-  month = {7},
-  year = {2013},
-  publisher = {Morgan and Claypool},
-  url = {},
-}
-
-@inproceedings{KunduSrRo13,
-  author = {Gourab Kundu and Vivek Srikumar and Dan Roth},
-  title = {Margin-based Decomposed Amortized Inference},
-  booktitle = {Proc. of the Annual Meeting of the Association for Computational Linguistics (ACL)},
-  month = {8},
-  year = {2013},
-  url = "http://cogcomp.org/papers/KunduSrRo13.pdf",
-}
-
-@inproceedings{ChangSrRo13,
-  author = {K.-W. Chang and V. Srikumar and D. Roth},
-  title = {Multi-core Structural SVM Training},
-  booktitle = {Proc. of the European Conference on Machine Learning and Principles and Practice of Knowledge Discovery in Databases (ECML PKDD)},
-  year = {2013},
-  acceptance = {25\%},
-  url = "http://cogcomp.org/papers/ChangSrRo13.pdf",
-  funding = {ONR, DEFT},
-}
-
-@article{SrikumarRo13,
-  author = {Vivek Srikumar and Dan Roth},
-  title = {Modeling Semantic Relations Expressed by Prepositions},
-  booktitle = {TACL},
-  pages = {231-242},
-  year = {2013},
-  volume = {1},
-  url = "http://cogcomp.org/papers/SrikumarRo13.pdf",
-}
-
-@inproceedings{GoldwasserRoth13,
-  author = {Dan Goldwasser and Dan Roth},
-  title = {Leveraging Domain-Independent Information in Semantic Parsing},
-  booktitle = {Proc. of the Annual Meeting of the Association for Computational Linguistics (ACL)},
-  year = {2013},
-  url = "http://cogcomp.org/papers/GoldwasserRoth13.pdf",
-}
-
-@inproceedings{JindalRo13b,
-  author = {Prateek Jindal and Dan Roth},
-  title = {End-to-End Coreference Resolution for Clinical Narratives},
-  booktitle = {Proc. of the International Joint Conference on Artificial Intelligence (IJCAI)},
-  pages = {2106-2112},
-  month = {8},
-  year = {2013},
-  acceptance = {19\%},
-  url = "http://cogcomp.org/papers/JindalRo13.pdf",
-  funding = {HHS 90TR003/01},
-}
-
-@inproceedings{PasternackRo13,
-  author = {Jeff Pasternack and Dan Roth},
-  title = {Latent Credibility Analysis},
-  booktitle = {Proc. of the International World Wide Web Conference (WWW)},
-  year = {2013},
-  url = "http://cogcomp.org/papers/PasternackRo13.pdf",
-}
-
-@article{JindalRo13,
-  author = {Prateek Jindal and Dan Roth},
-  title = {Using Domain Knowledge and Domain-Inspired Discourse Model for Coreference Resolution for Clinical Narratives},
-  booktitle = {Journal of the American Medical Informatics Association (JAMIA)},
-  pages = {356-362},
-  month = {3},
-  year = {2013},
-  publisher = {BMJ Publishing Group Ltd},
-  editor = {Professor Lucila Ohno-Machado},
-  volume = {20},
-  number = {2},
-  acceptance = {19\%},
-  url = "http://cogcomp.org/papers/JindalRo12.pdf",
-}
-
-%%%%%%%%%%%%%%
-%%%  2012  %%%
-%%%%%%%%%%%%%%
-@thesis{Goldwasser12,
-  author = {Dan Goldwasser },
-  title = {Learning from Natural Instructions},
-  booktitle = {UIUC PhD Thesis},
-  year = {2012},
-  url = "http://cogcomp.org/papers/Goldwasser12.pdf",
-}
-
-@inproceedings{JindalRo12,
-  author = {Prateek Jindal and Dan Roth},
-  title = {Using Knowledge and Constraints to Find the Best Antecedent},
-  booktitle = {Proc. of the International Conference on Computational Linguistics (COLING)},
-  pages = {1327-1342},
-  month = {12},
-  year = {2012},
-  acceptance = {20\%},
-  url = "http://cogcomp.org/papers/JindalRo12b.pdf",
-  funding = {Grant HHS 90TR0003/01},
-}
-
-@incollection{ConnorFiRo12,
-  author = {Michael Connor and Cynthia Fisher and Dan Roth},
-  title = {Starting from Scratch in Semantic Role Labeling: Early Indirect Supervision},
-  month = {11},
-  year = {2012},
-  publisher = {Springer},
-  editor = {A. Alishahi and T. Poibeau and A. Korhonen},
-  journal = {Cognitive Aspects of Computational Language Acquisition},
-  url = "http://cogcomp.org/papers/ConnorFiRo12.pdf",
-}
-
-@inproceedings{LWZR12,
-  author = {Yue Lu and Hongning Wang and ChengXiang Zhai and Dan Roth},
-  title = {Unsupervised Discovery of Opposing Opinion Networks From Forum Discussions},
-  booktitle = {Proc. of the ACM Conference on Information and Knowledge Management (CIKM)},
-  month = {10},
-  year = {2012},
-  url = "http://cogcomp.org/papers/LWZR12.pdf",
-}
-
-@inproceedings{CDHR12,
-  author = {Kai-Wei Chang and Biplab Deka and Wen-Mei W. Hwu and Dan Roth},
-  title = {Efficient Pattern-Based Time Series Classification on GPU },
-  booktitle = {Proc. of the IEEE International Conference on Data Mining (ICDM)},
-  year = {2012},
-  acceptance = {10.7\%},
-  url = "http://cogcomp.org/papers/undefined.pdf",
-  funding = {MR, BL},
-}
-
-@thesis{Tu12,
-  author = {Yuancheng Tu},
-  title = {English Complex Verb Constructions: Identification and Inference},
-  booktitle = {UIUC PhD Thesis},
-  year = {2012},
-  url = "http://cogcomp.org/papers/Tu12.pdf",
-}
-
-@thesis{Ratinov12,
-  author = {Lev Ratinov},
-  title = {Exploiting Knowledge in NLP},
-  booktitle = {UIUC PhD Thesis},
-  year = {2012},
-  url = "http://cogcomp.org/papers/Ratinov12.pdf",
-}
-
-@thesis{Do12,
-  author = {Quang Do},
-  title = {Background Knowledge in Learning-Based Relation Extraction},
-  booktitle = {UIUC PhD Thesis},
-  year = {2012},
-  url = "http://cogcomp.org/papers/Do12.pdf",
-}
-
-@inproceedings{SondhiVyZh12,
-  author = {Parikshit Sondhi and V.G. Vinod Vydiswaran and ChengXiang Zhai},
-  title = {Reliability Prediction of Webpages in the Medical Domain},
-  booktitle = {Proc. of the European Conference on Information Retrieval},
-  pages = {219--231},
-  month = {4},
-  year = {2012},
-  volume = {7224},
-  url = "http://cogcomp.org/papers/SondhiVyZh12.pdf",
-}
-
-@inproceedings{VZRP12b,
-  author = {V.G.Vinod Vydiswaran and ChengXiang Zhai and Dan Roth and Peter Pirolli},
-  title = {BiasTrust: Teaching biased users about controversial topics},
-  booktitle = {Proc. of the ACM Conference on Information and Knowledge Management (CIKM)},
-  pages = {1205--1209},
-  month = {10},
-  year = {2012},
-  url = "http://cogcomp.org/papers/VZRP12b.pdf",
-  funding = {MIAS, ITI, ARL},
-  projects = {Trustworthiness},
-}
-
-@inproceedings{VZRP12,
-  author = {V.G.Vinod Vydiswaran  and ChengXiang Zhai and Dan Roth and Peter Pirolli},
-  title = {Unbiased Learning of Controversial Topics},
-  booktitle = {Proc. of the Annual Meeting of the American Society for Information Science and Technology},
-  month = {10},
-  year = {2012},
-  url = "http://cogcomp.org/papers/VZRP12.pdf",
-  funding = {MIAS, ITI, ARL},
-  projects = {Trustworthiness},
-}
-
-@inproceedings{ClarkeSrSaRo2012,
-  author = {James Clarke and Vivek Srikumar and Mark Sammons and Dan Roth},
-  title = {An NLP Curator (or: How I Learned to Stop Worrying and Love NLP Pipelines)},
-  booktitle = {Proc. of the International Conference on Language Resources and Evaluation (LREC)},
-  month = {5},
-  year = {2012},
-  url = "http://cogcomp.org/papers/ClarkeSrSaRo2012.pdf",
-}
-
-@workshop{RozovskayaSaRo12,
-  author = {Alla Rozovskaya and Mark Sammons and Dan Roth},
-  title = {The UI System in the HOO 2012 Shared Task on Error Correction},
-  booktitle = {Proc. of the Annual Conference of the North American Chapter of the Association for Computational Linguistics (NAACL)},
-  month = {6},
-  year = {2012},
-  publisher = {Association for Computational Linguistics},
-  url = "http://cogcomp.org/papers/RozovskayaSaRo12.pdf",
-}
-
-@inproceedings{CSRSR12,
-  author = {Kai-Wei Chang and Rajhans Samdani and Alla Rozovskaya and Mark Sammons and Dan Roth},
-  title = {Illinois-Coref: The UI System in the CoNLL-2012 Shared Task},
-  booktitle = {Proc. of the Conference on Computational Natural Language Learning (CoNLL)},
-  year = {2012},
-  url = "http://cogcomp.org/papers/CSRSR12.pdf",
-  funding = {Machine Reading, ARL},
-  projects = {Coreference Within and Across Documents},
-}
-
-@workshop{SamdaniChRo12b,
-  author = {Rajhans Samdani and Ming-Wei Chang and Dan Roth},
-  title = {A Framework for Tuning Posterior Entropy in Unsupervised Learning},
-  booktitle = {Proc. of the International Conference on Machine Learning (ICML)},
-  month = {6},
-  year = {2012},
-  url = "http://cogcomp.org/papers/SamdaniChRo12b.pdf",
-  funding = {ONR, ARL, AFRL},
-}
-
-@inproceedings{SamdaniRo12,
-  author = {Rajhans Samdani and Dan Roth},
-  title = {Efficient Decomposed Learning for Structured Prediction},
-  booktitle = {Proc. of the International Conference on Machine Learning (ICML)},
-  month = {6},
-  year = {2012},
-  acceptance = {27\%},
-  url = "http://cogcomp.org/papers/SamdaniRo12.pdf",
-  funding = {ONR, AFRL, ARL},
-}
-
-@article{ChangRaRo12,
-  author = {Ming-Wei Chang and Lev Ratinov and Dan Roth},
-  title = {Structured Learning with Constrained Conditional Models},
-  pages = {399-431},
-  month = {6},
-  year = {2012},
-  publisher = {Springer},
-  editor = {Hal Daume III},
-  journal = {Machine Learning},
-  volume = {88},
-  number = {3},
-  url = "http://cogcomp.org/papers/ChangRaRo12.pdf",
-}
-
-@inproceedings{LuRo12,
-  author = {Wei Lu and Dan Roth},
-  title = {Automatic Event Extraction with Structured Preference Modeling},
-  booktitle = {Proc. of the Annual Meeting of the Association for Computational Linguistics (ACL)},
-  pages = {10},
-  month = {7},
-  year = {2012},
-  acceptance = {19\%},
-  url = "http://cogcomp.org/papers/LuRo12.pdf",
-  funding = {Machine Reading},
-  projects = {Machine Reading},
-}
-
-@inproceedings{RatinovRo12,
-  author = {Lev Ratinov and Dan Roth},
-  title = {Learning-based Multi-Sieve Co-Reference Resolution with Knowledge},
-  booktitle = {Proc. of the Conference on Empirical Methods in Natural Language Processing (EMNLP)},
-  year = {2012},
-  url = "http://cogcomp.org/papers/RatinovRo12.pdf",
-}
-
-@inproceedings{SrikumarKuRo12,
-  author = {Vivek Srikumar and Gourab Kundu and Dan Roth},
-  title = {On Amortizing Inference Cost for Structured Prediction},
-  booktitle = {Proc. of the Conference on Empirical Methods in Natural Language Processing (EMNLP)},
-  month = {7},
-  year = {2012},
-  url = "http://cogcomp.org/papers/SrikumarKuRo12.pdf",
-}
-
-@inproceedings{SamdaniChRo12,
-  author = {Rajhans Samdani and Ming-Wei Chang and Dan Roth},
-  title = {Unified Expectation Maximization},
-  booktitle = {Proc. of the Annual Conference of the North American Chapter of the Association for Computational Linguistics (NAACL)},
-  month = {6},
-  year = {2012},
-  url = "http://cogcomp.org/papers/SamdaniChRo12.pdf",
-}
-
-@inproceedings{DoLuRo12,
-  author = {Quang Do and Wei Lu and Dan Roth},
-  title = {Joint Inference for Event Timeline Construction},
-  booktitle = {Proc. of the Conference on Empirical Methods in Natural Language Processing (EMNLP)},
-  year = {2012},
-  url = "http://cogcomp.org/papers/DoLuRo12.pdf",
-}
-
-@inproceedings{ZhaoDoRo12,
-  author = {Ran Zhao and Quang Do and Dan Roth},
-  title = {A Robust Shallow Temporal Reasoning System},
-  booktitle = {Proc. of the Annual Conference of the North American Chapter of the Association for Computational Linguistics (NAACL)},
-  month = {6},
-  year = {2012},
-  url = "http://cogcomp.org/papers/ZhaoDoRo12.pdf",
-}
-
-@article{DoRo12,
-  author = {Quang Do and Dan Roth},
-  title = {Exploiting the Wikipedia Structure in Local and Global Classification of Taxonomic Relations},
-  pages = {235-262},
-  month = {4},
-  year = {2012},
-  publisher = {Cambridge University Press},
-  journal = {Journal of Natural Language Engineering (JNLE)},
-  volume = {18},
-  number = {2},
-  url = "http://cogcomp.org/papers/DoRo12.pdf",
-  comment = {http://journals.cambridge.org/action/displayAbstract?fromPage=online&aid=8511905&fulltextType=RA&fileId=S1351324912000046},
-}
-
-@inproceedings{TuRo12,
-  author = {Yuancheng Tu and Dan Roth},
-  title = {Sorting out the Most Confusing English Phrasal Verbs},
-  booktitle = {Proc. of the Joint Conference on Lexical and Computational Sematics},
-  year = {2012},
-  address = {Montreal, Canada},
-  publisher = {Association for Computational Linguistics},
-  url = "http://cogcomp.org/papers/TuRoth12.pdf",
-  funding = {DHS},
-  projects = {LS},
-}
-
-@incollection{SammonsVyRo12,
-  author = {Mark Sammons and V.G.Vinod Vydiswaran and Dan Roth},
-  title = {Recognizing Textual Entailment },
-  booktitle = {Multilingual Natural Language Applications: From Theory to Practice},
-  pages = {209-258},
-  month = {5},
-  year = {2012},
-  publisher = {Prentice Hall},
-  editor = {Daniel M. Bikel and Imed Zitouni},
-  url = {},
-}
-
-%%%%%%%%%%%%%%
-%%%  2011  %%%
-%%%%%%%%%%%%%%
-@thesis{Connor11,
-  author = {M. Connor},
-  title = {Minimal Supervision for Language Learning: Bootstrapping Global Patterns from Local Knowledge},
-  booktitle = {UIUC PhD Thesis},
-  year = {2011},
-  url = "http://cogcomp.org/papers/Connor11.pdf",
-}
-
-@thesis{Rizzolo11,
-  author = {N. Rizzolo},
-  title = {Learning Based Programming},
-  booktitle = {UIUC PhD Thesis},
-  year = {2011},
-  url = "http://cogcomp.org/papers/Rizzolo11.pdf",
-}
-
-@thesis{Pasternack11,
-  author = {J. Pasternack},
-  title = {Knowing Who to Trust and What to Believe in the Presence of Conflicting Information},
-  booktitle = {UIUC PhD Thesis},
-  year = {2011},
-  url = "http://cogcomp.org/papers/Pasternack11.pdf",
-  invisible = {true},
-}
-
-@thesis{Chang11,
-  author = {M. Chang},
-  title = {Structured Prediction with Indirect Supervision},
-  booktitle = {UIUC PhD Thesis},
-  year = {2011},
-  url = "http://cogcomp.org/papers/Chang11.pdf",
-}
-
-@inproceedings{BurgardRo11,
-  author = {W. Burgard and D. Roth Program Chairs},
-  title = {Proceedings of the 25th AAAI Conference on Artificial Intelligence},
-  booktitle = {Proc. of the Conference on Artificial Intelligence (AAAI)},
-  year = {2011},
-  editor = {W. Burgard and D. Roth},
-  url = {},
-}
-
-@article{MengshoelRoWi11,
-  author = {O. J. Mengshoel and D. Roth and D. C. Wilkins},
-  title = {Portfolios in Stochastic Local Search: Efficiently Computing Most Probable Explanations in Bayesian Networks},
-  pages = {103-160},
-  year = {2011},
-  journal = {Journal of Automated Reasoning},
-  volume = {46},
-  number = {2},
-  url = "http://cogcomp.org/papers/MengshoelRoWi11.pdf",
-}
-
-@article{MengshoelWiRo11,
-  author = {O. J. Mengshoel and D. C. Wilkins and D. Roth},
-  title = {Initialization and Restart in Stochastic Local Search: Computing a Most Probable Explanation in Bayesian Networks},
-  pages = {235-247},
-  year = {2011},
-  journal = {IEEE Transactions on Knowledge and Data Engineering},
-  volume = {23},
-  number = {2},
-  url = "http://cogcomp.org/papers/MengshoelWiRo11.pdf",
-}
-
-@inproceedings{JindalRo11,
-  author = {P. Jindal and D. Roth},
-  title = {Learning from Negative Examples in Set-Expansion},
-  booktitle = {Proc. of the IEEE International Conference on Data Mining (ICDM)},
-  pages = {1110-1115},
-  month = {12},
-  year = {2011},
-  acceptance = {18\%},
-  url = "http://cogcomp.org/papers/JindalRo11.pdf",
-}
-
-@inproceedings{ConnorFiRo11b,
-  author = {M. Connor and C. Fisher and D. Roth},
-  title = {The Origin of Syntactic Bootstrapping: A computational Model},
-  booktitle = {Proc. of the Boston University Conference on Language Development},
-  year = {2011},
-  url = {},
-}
-
-@workshop{RatinovRo11,
-  author = {L. Ratinov and D. Roth},
-  title = {GLOW TAC-KBP 2011 Entity Linking System},
-  booktitle = {Proc. of the Text Analysis Conference (TAC)},
-  month = {11},
-  year = {2011},
-  publisher = {Text Analysis Conference},
-  url = "http://cogcomp.org/papers/RatinovRo11.pdf",
-  funding = {MR, ARL },
-}
-
-@workshop{VydiswaranZhRo11b,
-  author = {V. Vydiswaran and C. Zhai and D. Roth},
-  title = {Gauging the Internet Doctor: Ranking Medical Claims based on Community Knowledge},
-  booktitle = {Proc. of the ACM SIGKDD Conference on Knowledge Discovery and Data Mining (KDD) Workshop on Data Mining for Medicine and HealthCare},
-  month = {8},
-  year = {2011},
-  url = "http://cogcomp.org/papers/VydiswaranZhRo11b.pdf",
-  funding = {MIAS, CCICADA, ARL},
-  projects = {Trustworthiness},
-}
-
-@workshop{RSGR11,
-  author = {A. Rozovskaya and M. Sammons and J. Gioja and D. Roth},
-  title = {University of Illinois System in HOO Text Correction Shared Task},
-  booktitle = {Proc. of the European Workshop on Natural Language Generation (ENLG)},
-  year = {2011},
-  url = "http://cogcomp.org/papers/RSGR11.pdf",
-  funding = {EDU,MR},
-}
-
-@workshop{KunduChRo11,
-  author = {G. Kundu and M. Chang and D. Roth},
-  title = {Prior Knowledge Driven Domain Adaptation},
-  booktitle = {Proc. of the International Conference on Machine Learning (ICML)},
-  month = {7},
-  year = {2011},
-  url = "http://cogcomp.org/papers/KunduChRo11(3).pdf",
-  funding = {ARL and DARPA Machine Reading},
-}
-
-@workshop{KunduRoSa11,
-  author = {G. Kundu and D. Roth and R. Samdani},
-  title = {Constrained Conditional Models For Information Fusion},
-  booktitle = {Proc. of the International Conference on Information Fusion},
-  year = {2011},
-  url = "http://cogcomp.org/papers/SamdaniRothKunduFusion2011.pdf",
-}
-
-@inproceedings{CSRRSR11,
-  author = {K.-W. Chang and R. Samdani and A. Rozovskaya and N. Rizzolo and M. Sammons and D. Roth},
-  title = {Inference Protocols for Coreference Resolution},
-  booktitle = {Proc. of the Conference on Computational Natural Language Learning (CoNLL)},
-  pages = {40--44},
-  year = {2011},
-  address = {Portland, Oregon, USA},
-  publisher = {Association for Computational Linguistics},
-  url = "http://cogcomp.org/papers/CSRRSR11.pdf",
-  funding = {MR},
-}
-
-@workshop{WAAPRGHFLA11,
-  author = {D. Wang and T. Abdelzaher and H. Ahmadi and J. Pasternack and D. Roth and M. Gupta and J. Han and O. Fatemieh and H. Le and C. Aggarwal},
-  title = {On Bayesian Interpretation of Fact-finding in Information Networks},
-  booktitle = {Proc. of the International Conference on Information Fusion},
-  year = {2011},
-  url = "http://cogcomp.org/papers/WAAPRGHFLA11.pdf",
-}
-
-@workshop{KPAGSAHRSA11,
-  author = {H. Khac Le and J. Pasternack and H. Ahmadi and M. Gupta and Y. Sun and T. Abdelzaher and J. Han and D. Roth and B. Szymanski and S. Adali},
-  title = {Apollo: Towards Factfinding in Participatory Sensing},
-  booktitle = {Proc. of the International Conference on Information Processing in Sensor Networks (IPSN)},
-  year = {2011},
-  url = "http://cogcomp.org/papers/LePa11.pdf",
-}
-
-@inproceedings{SrikumarRo11,
-  author = {V. Srikumar and D. Roth},
-  title = {A Joint Model for Extended Semantic Role Labeling},
-  booktitle = {Proc. of the Conference on Empirical Methods in Natural Language Processing (EMNLP)},
-  year = {2011},
-  address = {Edinburgh, Scotland},
-  url = "http://cogcomp.org/papers/SrikumarRo11.pdf",
-}
-
-@inproceedings{DoChRo11,
-  author = {Q. Do and Y. Chan and D. Roth},
-  title = {Minimally Supervised Event Causality Identification},
-  booktitle = {Proc. of the Conference on Empirical Methods in Natural Language Processing (EMNLP)},
-  month = {7},
-  year = {2011},
-  address = {Edinburgh, Scotland},
-  url = "http://cogcomp.org/papers/DoChaRo11.pdf",
-  funding = {MR},
-}
-
-@workshop{TuRo11,
-  author = {Y. Tu and D. Roth},
-  title = {Learning English Light Verb Constructions: Contextual or Statistical},
-  booktitle = {Proc. of the Annual Meeting of the Association for Computational Linguistics (ACL)},
-  year = {2011},
-  url = "http://cogcomp.org/papers/TuRo11.pdf",
-  funding = {MIAS},
-  projects = {LS},
-}
-
-@inproceedings{KunduRo11,
-  author = {G. Kundu and D. Roth},
-  title = {Adapting Text Instead of the Model: An Open Domain Approach},
-  booktitle = {Proc. of the Conference on Computational Natural Language Learning (CoNLL)},
-  month = {6},
-  year = {2011},
-  url = "http://cogcomp.org/papers/KunduRo11.pdf",
-  funding = {Darpa MR and ARL},
-}
-
-@inproceedings{ChangRo11,
-  author = {K.-W. Chang and D. Roth},
-  title = {Selective Block Minimization for Faster Convergence of Limited Memory Large-scale Linear Models},
-  booktitle = {Proc. of the ACM SIGKDD Conference on Knowledge Discovery and Data Mining (KDD)},
-  year = {2011},
-  acceptance = {17.5\%},
-  url = "http://cogcomp.org/papers/ChangRo11(4).pdf",
-  funding = {BL, MR},
-}
-
-@inproceedings{VydiswaranZhRo11,
-  author = {V. Vydiswaran and C. Zhai and D. Roth},
-  title = {Content-driven Trust Propagation Framework},
-  booktitle = {Proc. of the ACM SIGKDD Conference on Knowledge Discovery and Data Mining (KDD)},
-  pages = {974--982},
-  month = {8},
-  year = {2011},
-  acceptance = {17.5\%},
-  url = "http://cogcomp.org/papers/VydiswaranZhRo11.pdf",
-  funding = {MIAS, CCICADA, ARL},
-  projects = {Trustworthiness},
-}
-
-@inproceedings{PasternackRo11b,
-  author = {J. Pasternack and D. Roth},
-  title = {Making Better Informed Trust Decisions with Generalized Fact-Finding},
-  booktitle = {Proc. of the International Joint Conference on Artificial Intelligence (IJCAI)},
-  year = {2011},
-  url = "http://cogcomp.org/papers/PasternackRo11b.pdf",
-  funding = {ARL, DHS},
-}
-
-@inproceedings{GoldwasserRo11,
-  author = {D. Goldwasser and D. Roth},
-  title = {Learning from Natural Instructions},
-  booktitle = {Proc. of the International Joint Conference on Artificial Intelligence (IJCAI)},
-  year = {2011},
-  url = "http://cogcomp.org/papers/GoldwasserRo11(2).pdf",
-}
-
-@inproceedings{ConnorFiRo11,
-  author = {M. Connor and C. Fisher and D. Roth},
-  title = {Online Latent Structure Training for Language Acquisition},
-  booktitle = {Proc. of the International Joint Conference on Artificial Intelligence (IJCAI)},
-  month = {7},
-  year = {2011},
-  url = "http://cogcomp.org/papers/ConnorFiRo11.pdf",
-  funding = {Psych},
-  projects = {PSYCHO},
-  comment = {Indirect supervision; language acquisition; BabySRL; psycholinguistically plausible features; },
-}
-
-@inproceedings{PasternackRo11,
-  author = {J. Pasternack and D. Roth},
-  title = {Generalized Fact-Finding},
-  booktitle = {Proc. of the International World Wide Web Conference (WWW)},
-  year = {2011},
-  url = "http://cogcomp.org/papers/PasternackRo11.pdf",
-}
-
-@inproceedings{RRDA11,
-  author = {L. Ratinov and D. Roth and D. Downey and M. Anderson},
-  title = {Local and Global Algorithms for Disambiguation to Wikipedia},
-  booktitle = {Proc. of the Annual Meeting of the Association for Computational Linguistics (ACL)},
-  year = {2011},
-  url = "http://cogcomp.org/papers/RRDA11.pdf",
-}
-
-@inproceedings{ChanRo11,
-  author = {Y. Chan and D. Roth},
-  title = {Exploiting Syntactico-Semantic Structures for Relation Extraction},
-  booktitle = {Proc. of the Annual Meeting of the Association for Computational Linguistics (ACL)},
-  year = {2011},
-  address = {Portland, Oregon},
-  url = "http://cogcomp.org/papers/ChanRo11.pdf",
-  funding = {MR},
-  projects = {NLP, IE},
-}
-
-@inproceedings{GRCR11,
-  author = {D. Goldwasser and R. Reichart and J. Clarke and D. Roth },
-  title = {Confidence Driven Unsupervised Semantic Parsing },
-  booktitle = {Proc. of the Annual Meeting of the Association for Computational Linguistics (ACL)},
-  year = {2011},
-  url = "http://cogcomp.org/papers/main(2).pdf",
-}
-
-@inproceedings{RozovskayaRo11,
-  author = {A. Rozovskaya and D. Roth},
-  title = {Algorithm Selection and Model Adaptation for ESL Correction Tasks},
-  booktitle = {Proc. of the Annual Meeting of the Association for Computational Linguistics (ACL)},
-  month = {6},
-  year = {2011},
-  address = {Portland, Oregon},
-  publisher = {Association for Computational Linguistics},
-  url = "http://cogcomp.org/papers/RozovskayaRo11(1).pdf",
-  funding = {EDU},
-}
-
-%%%%%%%%%%%%%%
-%%%  2010  %%%
-%%%%%%%%%%%%%%
-@article{SmallRo10,
-  author = {K. Small and D. Roth},
-  title = {Margin-based Active Learning for Structured Predictions},
-  booktitle = {IJMLC},
-  pages = {3-25},
-  year = {2010},
-  volume = {1},
-  url = "http://cogcomp.org/papers/SmallRo10.pdf",
-}
-
-@inproceedings{TurianRaBe2010,
-  author = {J. Turian and L. Ratinov and Y. Bengio},
-  title = {Word representations: A simple and general method for semi-supervised learning},
-  booktitle = {Proc. of the Annual Meeting of the Association for Computational Linguistics (ACL)},
-  year = {2010},
-  url = "http://cogcomp.org/papers/TurianRaBe2010.pdf",
-}
-
-@inproceedings{PasternackRo10b,
-  author = {J. Pasternack and D. Roth},
-  title = {Comprehensive Trust Metrics for Information Networks},
-  booktitle = {Proc. of the Army Science Conference (ASC)},
-  month = {12},
-  year = {2010},
-  address = {Orlando, Florida},
-  url = "http://cogcomp.org/papers/PasternackRo10b.pdf",
-}
-
-@inproceedings{ChangCoRo10,
-  author = {M. Chang and M. Connor and D. Roth},
-  title = {The Necessity of Combining Adaptation Methods},
-  booktitle = {Proc. of the Conference on Empirical Methods in Natural Language Processing (EMNLP)},
-  month = {10},
-  year = {2010},
-  address = {Massachusetts, USA},
-  url = "http://cogcomp.org/papers/ChangCoRo10.pdf",
-  funding = {DARPA},
-  projects = {Adaptation},
-}
-
-@inproceedings{DoRo10,
-  author = {Q. Do and D. Roth},
-  title = {Relational Constraints based Taxonomic Relation Classification},
-  booktitle = {Proc. of the Conference on Empirical Methods in Natural Language Processing (EMNLP)},
-  pages = {1099-1109},
-  month = {10},
-  year = {2010},
-  address = {Massachusetts, USA},
-  url = "http://cogcomp.org/papers/DoRo10.pdf",
-  funding = {DARPA},
-  projects = {Machine Reading},
-}
-
-@inproceedings{LDWSVR10,
-  author = {G. Levine and G. DeJong and L. Wang and R. Samdani and S. Vembu and D. Roth},
-  title = {Automatic Model Adaptation for Complex Structured Domains},
-  booktitle = {Proc. of the European Conference on Machine Learning and Principles and Practice of Knowledge Discovery in Databases (ECML PKDD)},
-  year = {2010},
-  url = {},
-}
-
-@inproceedings{RozovskayaRo10b,
-  author = {A. Rozovskaya and D. Roth},
-  title = {Generating Confusion Sets for Context-Sensitive Error Correction},
-  booktitle = {Proc. of the Conference on Empirical Methods in Natural Language Processing (EMNLP)},
-  year = {2010},
-  url = "http://cogcomp.org/papers/RozovskayaRo10b.pdf",
-  funding = {EDU},
-}
-
-@inproceedings{PasternackRo10,
-  author = {J. Pasternack and D. Roth},
-  title = {Knowing What to Believe (when you already know something)},
-  booktitle = {Proc. of the International Conference on Computational Linguistics (COLING)},
-  month = {8},
-  year = {2010},
-  address = {Beijing, China},
-  url = "http://cogcomp.org/papers/PasternackRo10.pdf",
-  funding = {ARL},
-  projects = {TRUST, IE, USS},
-  comment = {Trustworthiness. Truth Finders. Using prior knowledge to both improve the accuracy of trust and belief decisions  and permit such decisions to be made subjectively relative to the user},
-}
-
-@inproceedings{TJRH10,
-  author = {Y. Tu and N. Johri and D. Roth and J. Hockenmaier},
-  title = {Citation Author Topic Model in Expert Search},
-  booktitle = {Proc. of the International Conference on Computational Linguistics (COLING)},
-  year = {2010},
-  url = "http://cogcomp.org/papers/TJRH10(2).pdf",
-  funding = {MIAS},
-  projects = {search},
-  comment = {author topic model, expert search,  semantic search, information retrieval},
-}
-
-@inproceedings{ChanRo10,
-  author = {Y. Chan and D. Roth},
-  title = {Exploiting Background Knowledge for Relation Extraction},
-  booktitle = {Proc. of the International Conference on Computational Linguistics (COLING)},
-  month = {8},
-  year = {2010},
-  address = {Beijing, China},
-  url = "http://cogcomp.org/papers/ChanRo10.pdf",
-  funding = {MR},
-  projects = {NLP, IE},
-  comment = {Relation extraction, background knowledge, constraints, information extraction},
-}
-
-@inproceedings{CGFR10,
-  author = {M. Connor and Y. Gertner and C. Fisher and D. Roth},
-  title = {Starting from Scratch in Semantic Role Labeling},
-  booktitle = {Proc. of the Annual Meeting of the Association for Computational Linguistics (ACL)},
-  month = {7},
-  year = {2010},
-  address = {Uppsala, Sweden},
-  publisher = {Association for Computational Linguistics},
-  url = "http://cogcomp.org/papers/CGFR10.pdf",
-  funding = {Psych},
-  projects = {PSYCHO},
-  comment = {Minimal supervision; language acquisition; BabySRL; psycholinguistically plausible features; unsupervised HMM; background knowledge and linguistic constraints},
-}
-
-@inproceedings{SammonsVyRo10,
-  author = {M. Sammons and V. Vydiswaran and D. Roth},
-  title = {Ask not what Textual Entailment can do for You...},
-  booktitle = {Proc. of the Annual Meeting of the Association for Computational Linguistics (ACL)},
-  month = {7},
-  year = {2010},
-  address = {Uppsala, Sweden},
-  publisher = {Association for Computational Linguistics},
-  url = "http://cogcomp.org/papers/SammonsVyRo10.pdf",
-  funding = {DARPA,Boeing, DHS},
-  projects = {TE},
-  comment = {Annotation, explanation, Recognizing Textual Entailment, evaluating textual entailment, data ablation},
-}
-
-@inproceedings{CGCR10,
-  author = {J. Clarke and D. Goldwasser and M. Chang and D. Roth},
-  title = {Driving Semantic Parsing from the World's Response},
-  booktitle = {Proc. of the Conference on Computational Natural Language Learning (CoNLL)},
-  month = {7},
-  year = {2010},
-  url = "http://cogcomp.org/papers/CGCR10.pdf",
-  funding = {BL,MR},
-  projects = {NLP, SP, COMP, USS},
-  comment = {Learning semantic parsers without complex logical form annotations. Supervision provided in the form of a binary feedback signal recieved from an external world.},
-}
-
-@inproceedings{CSGR10,
-  author = {M. Chang and V. Srikumar and D. Goldwasser and D. Roth},
-  title = {Structured Output Learning with Indirect Supervision},
-  booktitle = {Proc. of the International Conference on Machine Learning (ICML)},
-  year = {2010},
-  url = "http://cogcomp.org/papers/CSGR10.pdf",
-  funding = {DARPA,SoD,MIAS,MR},
-  projects = {CCM,TL},
-  comment = {indirect supervision, structured learning, joint learning of binary and structured learning tasks},
-}
-
-@inproceedings{CGRS10,
-  author = {M. Chang and D. Goldwasser and D. Roth and V. Srikumar},
-  title = {Discriminative Learning over Constrained Latent Representations},
-  booktitle = {Proc. of the Annual Conference of the North American Chapter of the Association for Computational Linguistics (NAACL)},
-  month = {6},
-  year = {2010},
-  url = "http://cogcomp.org/papers/CGRS10.pdf",
-  funding = {DARPA,SoD,MIAS,MR},
-  projects = {CCM,TL},
-  comment = {learning over latent representation, learning feature representation, intermediate representation, generalized alignment for various NLP tasks},
-}
-
-@inproceedings{RozovskayaRo10,
-  author = {A. Rozovskaya and D. Roth},
-  title = {Training Paradigms for Correcting Errors in Grammar and Usage},
-  booktitle = {Proc. of the Annual Conference of the North American Chapter of the Association for Computational Linguistics (NAACL)},
-  month = {6},
-  year = {2010},
-  url = "http://cogcomp.org/papers/RozovskayaRo10.pdf",
-  funding = {EDU},
-  projects = {CSTC},
-  comment = {Text correction; Error Detection and Correction; ESL Error Detection; ESL Proofing Tools;     Errors in Article Usage; training classifiers for detecting and correcting mistakes by selectively introducing mistakes into the training data},
-}
-
-@workshop{RozovskayaRo10a,
-  author = {A. Rozovskaya and D. Roth},
-  title = {Annotating ESL Errors: Challenges and Rewards},
-  booktitle = {Proc. of the Annual Conference of the North American Chapter of the Association for Computational Linguistics (NAACL)},
-  month = {6},
-  year = {2010},
-  url = "http://cogcomp.org/papers/RozovskayaRo10a.pdf",
-  funding = {EDU},
-  projects = {CSTC},
-  comment = {Text correction; Error Detection and Correction; ESL Error Detection; Annotation of ESL Errors; Annotation Tool;     Annotation of Article and Preposition Errors; Learner Corpus; Inter-annotator Agreement; ESL Error Statistics},
-}
-
-@workshop{PRSCR10,
-  author = {K. Pham and N. Rizzolo and K. Small and K. Chang and D. Roth},
-  title = {Object Search: Supporting Structured Queries in Web Search Engines},
-  booktitle = {Proc. of the Annual Conference of the North American Chapter of the Association for Computational Linguistics (NAACL) Workshop on Semantic Search},
-  month = {6},
-  year = {2010},
-  url = "http://cogcomp.org/papers/PRSCR10.pdf",
-  funding = {MIAS, NSF-SoD},
-  projects = {LBP},
-  comment = {Searching on the web for objects by their properties without first building a database; uses LBP/LBJ.},
-}
-
-@workshop{JohriRoTu10,
-  author = {N. Johri and D. Roth and Y. Tu},
-  title = {Experts' Retrieval with Multiword-Enhanced Author Topic Model},
-  booktitle = {Proc. of the Annual Conference of the North American Chapter of the Association for Computational Linguistics (NAACL)},
-  year = {2010},
-  url = "http://cogcomp.org/papers/JohriRoTu10(1).pdf",
-  funding = {MIAS},
-  projects = {SEARCH},
-  comment = {author topic model; multiword expression;  expert search; information retrieval},
-}
-
-@inproceedings{TKSR10,
-  author = {I. Titov and A. Klementiev and K. Small and D. Roth},
-  title = {Unsupervised Aggregation for Classification Problems with Large Numbers of Categories},
-  booktitle = {Proc. of the International Workshop on Artificial Intelligence and Statistics (AISTATS)},
-  month = {5},
-  year = {2010},
-  url = "http://cogcomp.org/papers/TKSR10.pdf",
-  funding = {BL, DHS},
-  comment = {Structured prediction; Unsupervised Learning; Aggregation},
-}
-
-@inproceedings{RizzoloRo10,
-  author = {N. Rizzolo and D. Roth},
-  title = {Learning Based Java for Rapid Development of NLP Systems},
-  booktitle = {Proc. of the International Conference on Language Resources and Evaluation (LREC)},
-  month = {5},
-  year = {2010},
-  address = {Valletta, Malta},
-  url = "http://cogcomp.org/papers/RizzoloRo10.pdf",
-  funding = {NSF-SoD},
-  projects = {LBP, CCM},
-  comment = {Learning Based Java: a Modeling language that facilitates development of systems with learning and inference componenets.},
-}
-
-%%%%%%%%%%%%%%
-%%%  2009  %%%
-%%%%%%%%%%%%%%
-@thesis{Small09,
-  author = {K. Small},
-  title = {Interactive Learning Protocols for Natural Language Applications},
-  booktitle = {UIUC PhD Thesis},
-  year = {2009},
-  url = "http://cogcomp.org/papers/Small09.pdf",
-}
-
-@thesis{Klementiev09,
-  author = {A. Klementiev},
-  title = {Learning with Incidental Supervision},
-  booktitle = {UIUC PhD Thesis },
-  year = {2009},
-  url = "http://cogcomp.org/papers/Klementiev09.pdf",
-}
-
-@techreport{DRSTV09,
-  author = {Q. Do and D. Roth and M. Sammons and Y. Tu and V. Vydiswaran},
-  title = {Robust, Light-weight Approaches to compute Lexical Similarity},
-  booktitle = {Computer Science Research and Technical Reports, University of Illinois},
-  year = {2009},
-  url = "http://cogcomp.org/papers/DRSTV09.pdf",
-}
-
-@inproceedings{RothTu09,
-  author = {D. Roth and Y. Tu},
-  title = {Aspect Guided Text Categorization with Unobserved Labels},
-  booktitle = {Proc. of the IEEE International Conference on Data Mining (ICDM)},
-  year = {2009},
-  url = "http://cogcomp.org/papers/RothTu09.pdf",
-  funding = {Honda,MIAS},
-  projects = {CCM,Honda},
-  comment = {multiclass classification; Text classification, short text snippet, structure learning, Constrained optimization; constrained conditional models},
-}
-
-@article{RothSa09,
-  author = {D. Roth and R. Samdani},
-  title = {Learning Multi-Linear Representations},
-  pages = {195--209},
-  year = {2009},
-  journal = {Machine Learning},
-  volume = {76},
-  number = {2},
-  url = "http://cogcomp.org/papers/RothSa09.pdf",
-  funding = {ONR},
-  projects = {CCG},
-}
-
-@inproceedings{PasternackRo09a,
-  author = {J. Pasternack and D. Roth},
-  title = {Learning Better Transliterations},
-  booktitle = {Proc. of the ACM Conference on Information and Knowledge Management (CIKM)},
-  month = {11},
-  year = {2009},
-  url = "http://cogcomp.org/papers/PasternackRo09a.pdf",
-  funding = {MIAS},
-  projects = {TL},
-  comment = {State-of-the-art transliteration with unbounded substring-to-substring productions and capable of both discovery and generation.},
-}
-
-@inproceedings{RothSaVy09,
-  author = {D. Roth and M. Sammons and V. Vydiswaran},
-  title = {A Framework for Entailed Relation Recognition},
-  booktitle = {Proc. of the Annual Meeting of the Association for Computational Linguistics (ACL)},
-  month = {8},
-  year = {2009},
-  address = {Singapore},
-  publisher = {Association for Computational Linguistics},
-  url = "http://cogcomp.org/papers/RothSaVy09.pdf",
-  funding = {Boeing, MIAS},
-  projects = {TE,SEARCH},
-  comment = {semantic retrieval, scalable textual entailment, structured query, similarity metrics, exhaustive search, relation recognition, relation extraction},
-}
-
-@inproceedings{ECGR09,
-  author = {J. Eisenstein and J. Clarke and D. Goldwasser and D. Roth},
-  title = {Reading to Learn: Constructing Features from Semantic Abstracts},
-  booktitle = {Proc. of the Conference on Empirical Methods in Natural Language Processing (EMNLP)},
-  year = {2009},
-  address = {Singapore},
-  url = "http://cogcomp.org/papers/ECGR09.pdf",
-  funding = {SoD, BL},
-  projects = {COMP, USS},
-  comment = {Proposes a novel form of semantic analysis where the goal is to obtain a high-level semantic abstract of documents in a representation that facilitates learning. The abstract is obtained through a generative model that requires no labeled data. The semantic abstract is converted into a transformed feature space for relational learning.},
-}
-
-@inproceedings{KRST09,
-  author = {A. Klementiev and D. Roth and K. Small and I. Titov},
-  title = {Unsupervised Rank Aggregation with Domain-Specific Expertise},
-  booktitle = {Proc. of the International Joint Conference on Artificial Intelligence (IJCAI)},
-  month = {7},
-  year = {2009},
-  acceptance = {331/1290 (25.7 \%)},
-  url = "http://cogcomp.org/papers/KRST09.pdf",
-  funding = {ITR-EDU, BL, MIAS},
-  projects = {USS, RANK},
-  comment = {Proposes a framework for learning to aggregate votes of rankers with domain specific expertise without supervision. Applies the learning framework to the settings of aggregating full rankings and aggregating top-k lists, demonstrating significant improvements over a domain-agnostic baseline in both cases.},
-}
-
-@inproceedings{CGFR09,
-  author = {M. Connor and Y. Gertner and C. Fisher and D. Roth},
-  title = {Minimally Supervised Model of Early Language Acquisition},
-  booktitle = {Proc. of the Conference on Computational Natural Language Learning (CoNLL)},
-  month = {6},
-  year = {2009},
-  url = "http://cogcomp.org/papers/CGFR09.pdf",
-  funding = {Psych},
-  projects = {PSYCHO},
-  comment = {Minimal supervision; language acquisition; BabySRL; a semantic role labeling system with simple, psycholinguistically plausible features; trained using background knowledge plus linguistic constraints},
-}
-
-@inproceedings{RothSm09,
-  author = {D. Roth and K. Small},
-  title = {Interactive Feature Space Construction using Semantic Information},
-  booktitle = {Proc. of the Conference on Computational Natural Language Learning (CoNLL)},
-  month = {6},
-  year = {2009},
-  url = "http://cogcomp.org/papers/RothSm09.pdf",
-  funding = {DARPA},
-  projects = {AL,NER},
-}
-
-@inproceedings{RatinovRo09,
-  author = {L. Ratinov and D. Roth},
-  title = {Design Challenges and Misconceptions in Named Entity Recognition},
-  booktitle = {Proc. of the Conference on Computational Natural Language Learning (CoNLL)},
-  month = {6},
-  year = {2009},
-  url = "http://cogcomp.org/papers/RatinovRo09.pdf",
-  funding = {MIAS, SoD, Library},
-  projects = {IE},
-  comment = {Named entity recognition; information extraction; knowledge resources; word class models; gazetteers; non-local features; global features; inference methods; BIO vs. BIOLU; text chunk representation},
-}
-
-@inproceedings{CGRT09,
-  author = {M. Chang and D. Goldwasser and D. Roth and Y. Tu},
-  title = {Unsupervised Constraint Driven Learning For Transliteration Discovery},
-  booktitle = {Proc. of the Annual Conference of the North American Chapter of the Association for Computational Linguistics (NAACL)},
-  month = {5},
-  year = {2009},
-  url = "http://cogcomp.org/papers/CGRT09.pdf",
-  funding = {DARPA,SoD,MIAS},
-  projects = {CCM,TL},
-  comment = {Transliteration; Constrained optimization; constrained conditional models, unsupervised learning; named entity discovery; multilingual corpora; bootstrapping, romanization table, feature selection for transliteration; Discriminative training of Objective function; Dynamic Programming},
-}
-
-@inproceedings{PasternackRo09,
-  author = {J. Pasternack and D. Roth},
-  title = {Extracting Article Text from the Web with Maximum Subsequence Segmentation},
-  booktitle = {Proc. of the International World Wide Web Conference (WWW)},
-  month = {4},
-  year = {2009},
-  url = "http://cogcomp.org/papers/PasternackRo09.pdf",
-  projects = {IE},
-  comment = {A new global optimization technique, maximum subsequence, is used to accurately identify and extract article text from HTML documents in linear time},
-}
-
-@inproceedings{RothSmTi09,
-  author = {D. Roth and K. Small and I. Titov},
-  title = {Sequential Learning of Classifiers for Structured Prediction Problems},
-  booktitle = {Proc. of the International Workshop on Artificial Intelligence and Statistics (AISTATS)},
-  pages = {440--447},
-  month = {4},
-  year = {2009},
-  acceptance = {84/210 (40.0 \%)},
-  url = "http://cogcomp.org/papers/RothSmTi09.pdf",
-  funding = {BL, SoD},
-  comment = {Structured prediction; Learning algorithm; Pipelines; An alternative both to joint and to independent learning of classifiers},
-}
-
-@inproceedings{RiedelCl09,
-  author = {S. Riedel and J. Clarke},
-  title = {Revisiting Optimal Decoding for Machine Translation IBM Model 4},
-  booktitle = {Proc. of the Annual Conference of the North American Chapter of the Association for Computational Linguistics (NAACL)},
-  year = {2009},
-  address = {Boulder, Colorado},
-  url = "http://cogcomp.org/papers/RiedelCl09.pdf",
-}
-
-@inproceedings{GCTR09,
-  author = {D. Goldwasser and M. Chang and Y. Tu and D. Roth},
-  title = {Constraint Driven Transliteration Discovery},
-  booktitle = {Proc. of the Conference on Recent Advances in Natural Language Processing},
-  year = {2009},
-  publisher = {John Benjamins},
-  editor = {Nicolas Nicolov},
-  url = "http://cogcomp.org/papers/GCTR09.pdf",
-  funding = {BL,SoD},
-  projects = {CCG,TL},
-  comment = {Extending Constrained Conditional Model based transliteration; Combines EMNLP'08 and NAACL'09},
-}
-
-@article{DDMR09,
-  author = {I.  Dagan and B. Dolan and B. Magnini and D. Roth},
-  title = {Guest Editors Introduction: Recognizing Textual Entailment: Rational, Evaluation and Approaches},
-  pages = {459--476},
-  year = {2009},
-  publisher = {Cambridge University Press},
-  journal = {Journal of Natural Language Engineering},
-  volume = {15},
-  url = {},
-  projects = {TE},
-}
-
-@inproceedings{SVVJCGSKTSRDR09,
-  author = {M. Sammons and V. Vydiswaran and T. Vieira and N. Johri and M. Chang and D. Goldwasser and V. Srikumar and G. Kundu and Y. Tu and K. Small and J. Rule and Q. Do and D. Roth},
-  title = {Relation Alignment for Textual Entailment Recognition},
-  booktitle = {Proc. of the Text Analysis Conference (TAC)},
-  year = {2009},
-  url = "http://cogcomp.org/papers/SVVJCGSKTSRDR09(1).pdf",
-  funding = {DARPA,Boeing},
-  projects = {TE,KRNLP},
-  comment = {Recognizing Textual Entailment, textual entailment system, alignment, multi-view representation},
-}
-
-@article{GHJKRRC09,
-  author = {C. Godby and P. Hswe and L. Jackson and J. Klavans and L. Ratinov and D. Roth and H. Cho},
-  title = {Who's Who in Your Digital Collection: Developing a Tool for Name Disambiguation and Identity Resolution},
-  booktitle = {Journal of the Chicago Colloquium on Digital Humanities and Computer Science (Proc. of the Chicago Colloquium on Digital Humanities and Computer Science (DHCS))},
-  year = {2009},
-  url = "http://cogcomp.org/papers/GHJKRRC09.pdf",
-  funding = {DARPA,LIBRARY},
-  projects = {IR,LBJ},
-  comment = {Named Entity Recognition (NER) and Wikification; Applications to Digital Libraries},
-}
-
-%%%%%%%%%%%%%%
-%%%  2008  %%%
-%%%%%%%%%%%%%%
-@thesis{Alm08,
-  author = {C. Alm},
-  title = {Affect in Text and Speech},
-  booktitle = {UIUC PhD Thesis},
-  year = {2008},
-  url = "http://cogcomp.org/papers/Alm thesis(1).pdf",
-}
-
-@techreport{PasternackRo08,
-  author = {J. Pasternack and D. Roth},
-  title = {The Wikipedia Corpus},
-  year = {2008},
-  journal = {University of Illinois Technical Report},
-  url = "http://cogcomp.org/papers/PasternackRo08.pdf",
-}
-
-@incollection{KlementievRo08,
-  author = {A. Klementiev and D. Roth},
-  title = {Named Entity Transliteration and Discovery in Multilingual Corpora},
-  booktitle = {Learning Machine Translation},
-  year = {2008},
-  publisher = {MIT Press},
-  editor = {Cyril Goutte and Nicola Cancedda and Marc Dymetman and George Foster},
-  url = "http://cogcomp.org/papers/KlementievRo08.pdf",
-  funding = {KINDLE,REFLEX},
-  projects = {REFLEX,USS,TL,ADAPT},
-}
-
-@inproceedings{GoldwasserRo08a,
-  author = {D. Goldwasser and D. Roth},
-  title = {Transliteration as Constrained Optimization},
-  booktitle = {Proc. of the Conference on Empirical Methods in Natural Language Processing (EMNLP)},
-  month = {10},
-  year = {2008},
-  url = "http://cogcomp.org/papers/GoldwasserRo08a.pdf",
-  funding = {DARPA,SoD},
-  projects = {CCM,TL},
-  comment = {Transliteration; Constrained optimization; Named entity discovery; bilingual corpora; feature selection for transliteration; Discriminative training of Objective function; Integer Linear Programming;ILP; Hebrew transliteration},
-}
-
-@inproceedings{BengtsonRo08,
-  author = {E. Bengtson and D. Roth},
-  title = {Understanding the Value of Features for Coreference Resolution},
-  booktitle = {Proc. of the Conference on Empirical Methods in Natural Language Processing (EMNLP)},
-  month = {10},
-  year = {2008},
-  url = "http://cogcomp.org/papers/BengtsonRo08.pdf",
-  funding = {Boeing,SoD},
-  projects = {COREF,TE},
-  comment = {The importance of good features for coreference resolution},
-}
-
-@workshop{KlementievRoSm08a,
-  author = {A. Klementiev and D. Roth and K. Small},
-  title = {A Framework for Unsupervised Rank Aggregation},
-  booktitle = {Proc. of the ACM SIGIR Conference (SIGIR)},
-  pages = {32-39},
-  month = {7},
-  year = {2008},
-  url = "http://cogcomp.org/papers/KlementievRoSm08a.pdf",
-  funding = {ITR-EDU, BL, MIAS},
-  projects = {USS,RANK},
-}
-
-@workshop{ChangRaRo08,
-  author = {M. Chang and L. Ratinov and D. Roth},
-  title = {Constraints as Prior Knowledge},
-  booktitle = {Proc. of the International Conference on Machine Learning (ICML)},
-  pages = {32-39},
-  month = {7},
-  year = {2008},
-  url = "http://cogcomp.org/papers/ChangRaRo08.pdf",
-  funding = {SoD, LIBRARY, MIAS},
-  projects = {USS,IE,CCM},
-}
-
-@techreport{RothSa08,
-  author = {D. Roth and M. Sammons},
-  title = {A Unified Representation and Inference Paradigm for Natural Language Processing},
-  year = {2008},
-  institution = {UIUC Computer Science Department},
-  number = {UIUCDCS-R-2008-2969},
-  url = "http://cogcomp.org/papers/RothSa08.pdf",
-  funding = {Boeing},
-  projects = {TE},
-}
-
-@inproceedings{CGFR08,
-  author = {M. Connor and Y. Gertner and C. Fisher and D. Roth},
-  title = {Baby SRL: Modeling Early Language Acquisition},
-  booktitle = {Proc. of the Conference on Computational Natural Language Learning (CoNLL)},
-  month = {8},
-  year = {2008},
-  url = "http://cogcomp.org/papers/CGFR08.pdf",
-  funding = {Psych},
-  projects = {PSYCHO},
-  comment = {Evaluating the psycholinguistics structure-mapping assumption; a semantic role labeling system with simple, psycholinguistically plausible features; language acquisition},
-}
-
-@article{PunyakanokRoYi08,
-  author = {V. Punyakanok and D. Roth and W. Yih},
-  title = {The Importance of Syntactic Parsing and Inference in Semantic Role Labeling},
-  year = {2008},
-  journal = {Computational Linguistics},
-  volume = {34},
-  number = {2},
-  url = "http://cogcomp.org/papers/PunyakanokRoYi07.pdf",
-  funding = {KINDLE,REFLEX,MURI,XPRESSMP},
-  projects = {IE,LINL,SP,ILP,SRL},
-}
-
-@article{DayaRoWi08,
-  author = {E. Daya and D. Roth and S. Wintner},
-  title = {Learning Hebrew Roots: Machine Learning with Linguistic Constraints},
-  year = {2008},
-  journal = {Computational Linguistics},
-  volume = {34},
-  number = {3},
-  url = "http://cogcomp.org/papers/DayaRoWi08.pdf",
-  funding = {CAREER,MURI, REFLEX},
-  projects = {LnI,SI,NLP},
-}
-
-@inproceedings{SRSRR08,
-  author = {V. Srikumar and R. Reichart and M. Sammons and A. Rappoport and D. Roth},
-  title = {Extraction of Entailed Semantic Relations Through Syntax-based Comma Resolution},
-  booktitle = {Proc. of the Annual Meeting of the Association for Computational Linguistics (ACL)},
-  month = {6},
-  year = {2008},
-  address = {Columbus, OH, USA},
-  publisher = {Association for Computational Linguistics},
-  url = "http://cogcomp.org/papers/SRSRR08.pdf",
-  funding = {SoD,Boeing},
-  projects = {TE},
-}
-
-@inproceedings{GoldwasserRo08,
-  author = {D. Goldwasser and D. Roth},
-  title = {Active Sample Selection for Named Entity Transliteration},
-  booktitle = {Proc. of the Annual Conference of the North American Chapter of the Association for Computational Linguistics (NAACL)},
-  month = {6},
-  year = {2008},
-  address = {Columbus, OH, USA},
-  publisher = {Association for Computational Linguistics},
-  url = "http://cogcomp.org/papers/GoldwasserRo08.pdf",
-  funding = {Darpa},
-  projects = {AL,TL},
-  comment = {Named entity discovery; bilingual corpora; active sampling; data selection; domain adaptation; Russian transliteration; Hebrew transliteration},
-}
-
-@inproceedings{LRSS08,
-  author = {B. Liebald and D. Roth and N. Shah and V. Srikumar},
-  title = {Proactive Intrusion Detection},
-  booktitle = {Proc. of the Conference on Artificial Intelligence (AAAI)},
-  month = {7},
-  year = {2008},
-  url = "http://cogcomp.org/papers/LRSS08.pdf",
-  funding = {DARPA,Boeing},
-}
-
-@inproceedings{CRRS08,
-  author = {M. Chang and L. Ratinov and D. Roth and V. Srikumar},
-  title = {Importance of Semantic Representation: Dataless Classification},
-  booktitle = {Proc. of the Conference on Artificial Intelligence (AAAI)},
-  month = {7},
-  year = {2008},
-  url = "http://cogcomp.org/papers/CRRS08.pdf",
-  funding = {SoD,MIAS,Library,Boeing},
-  projects = {DC},
-}
-
-@inproceedings{RothSm08,
-  author = {D. Roth and K. Small},
-  title = {Active Learning for Pipeline Models},
-  booktitle = {Proc. of the Conference on Artificial Intelligence (AAAI)},
-  month = {7},
-  year = {2008},
-  url = "http://cogcomp.org/papers/RothSm08.pdf",
-  funding = {Darpa, DHS},
-  projects = {AL,PL,NER},
-}
-
-@inproceedings{CRRR08,
-  author = {M. Chang and L. Ratinov and N. Rizzolo and D. Roth},
-  title = {Learning and Inference with Constraints},
-  booktitle = {Proc. of the Conference on Artificial Intelligence (AAAI)},
-  month = {7},
-  year = {2008},
-  url = "http://cogcomp.org/papers/CRRR08.pdf",
-  funding = {SoD,MIAS,Library,Boeing},
-  projects = {CCM,LBP},
-}
-
-@inproceedings{KlementievRoSm08,
-  author = {A. Klementiev and D. Roth and K. Small},
-  title = {Unsupervised Rank Aggregation with Distance-Based Models},
-  booktitle = {Proc. of the International Conference on Machine Learning (ICML)},
-  month = {7},
-  year = {2008},
-  acceptance = {158/583 (27\%) (regular papers)},
-  url = "http://cogcomp.org/papers/KlementievRoSm08.pdf",
-  funding = {ITR-EDU, BL, MIAS},
-  projects = {USS,RANK},
-  comment = {We propose a mathematical and algorithmic framework for learning to aggregate (partial) rankings without supervision. We instantiate the framework for the cases of combining permutations and combining top-k lists, and propose a novel metric for the latter.},
-}
-
-@inproceedings{RahurkarRoHu08,
-  author = {M. Rahurkar and D. Roth and T. Huang},
-  title = {Which Apple are you talking about},
-  booktitle = {Proc. of the International World Wide Web Conference (WWW)},
-  pages = {1197-1198},
-  year = {2008},
-  url = "http://cogcomp.org/papers/RahurkarRoHu08.pdf",
-  projects = {SEARCH},
-}
-
-@incollection{BrazAmRo08,
-  author = {R. de Salvo Braz and E. Amir and D. Roth},
-  title = {A Survey of First-Order Probabilistic Models},
-  booktitle = {Innovations in Bayesian Networks},
-  pages = {289--317},
-  year = {2008},
-  publisher = {Springer-Verlag},
-  editor = {D.E. Holmes and L.C. Jain},
-  url = "http://cogcomp.org/papers/BrazAmRo08.pdf",
-  funding = {ARDA, ITR-BI, SoD},
-  projects = {FOPI},
-  comment = {Lifted Probabilistic Inference},
-}
-
-%%%%%%%%%%%%%%
-%%%  2007  %%%
-%%%%%%%%%%%%%%
-@thesis{Braz07,
-  author = {R. de Salvo Braz},
-  title = {Lifted First-Order Probabilistic Inference},
-  booktitle = {UIUC PhD Thesis},
-  year = {2007},
-  url = "http://cogcomp.org/papers/Braz07.pdf",
-}
-
-@workshop{RothSa07,
-  author = {D. Roth and M. Sammons},
-  title = {Semantic and Logical Inference Model for Textual Entailment},
-  booktitle = {Proc. of the Annual Meeting of the Association for Computational Linguistics (ACL)},
-  pages = {107--112},
-  month = {6},
-  year = {2007},
-  address = {Prague, Czech Republic},
-  publisher = {Association for Computational Linguistics},
-  url = "http://cogcomp.org/papers/RothSa07.pdf",
-  funding = {Boeing, ARDA, ACQUAINT, Google},
-  projects = {TE},
-  comment = {Textual Entailment; Compositional semantics; Search-based inference; Modular framework},
-}
-
-@inproceedings{ChangRaRo07,
-  author = {M. Chang and L. Ratinov and D. Roth},
-  title = {Guiding Semi-Supervision with Constraint-Driven Learning},
-  booktitle = {Proc. of the Annual Meeting of the Association for Computational Linguistics (ACL)},
-  pages = {280--287},
-  month = {6},
-  year = {2007},
-  address = {Prague, Czech Republic},
-  publisher = {Association for Computational Linguistics},
-  url = "http://cogcomp.org/papers/ChangRaRo07.pdf",
-  funding = {SoD,Boeing},
-  projects = {USS,CCM,IE},
-  comment = {Semi-supervised learning with very little supervision; Constraints; Constraints Driven Learning; Information Extraction},
-}
-
-@inproceedings{RizzoloRo07,
-  author = {N. Rizzolo and D. Roth},
-  title = {Modeling Discriminative Global Inference},
-  booktitle = {Proc. of the IEEE International Conference on Semantic Computing (ICSC)},
-  pages = {597-604},
-  month = {9},
-  year = {2007},
-  address = {Irvine, California},
-  publisher = {IEEE},
-  url = "http://cogcomp.org/papers/RizzoloRo07.pdf",
-  funding = {NSF-SoD, LBP},
-  projects = {LBP,CCM},
-  comment = {Learning Based Java: a Modeling language that facilitates developing of systems with learning and inference componenets.},
-}
-
-@inproceedings{ConnorRo07,
-  author = {M. Connor and D. Roth},
-  title = {Context Sensitive Paraphrasing with a Single Unsupervised Classifier},
-  booktitle = {Proc. of the European Conference on Machine Learning (ECML)},
-  month = {9},
-  year = {2007},
-  acceptance = {69/592 (12\%) (regular papers)},
-  url = "http://cogcomp.org/papers/ConnorRo07.pdf",
-  funding = {ITR-EDU,Psych},
-  projects = {NLP,LP,TE,USS},
-  comment = {Trains a single classifier to decided context sensitive paraphrases of verbs. Bootstraps training set through unsupervised training of subtask classifiers and confident example selection.},
-}
-
-@inproceedings{KlementievRoSm07,
-  author = {A. Klementiev and D. Roth and K. Small},
-  title = {An Unsupervised Learning Algorithm for Rank Aggregation},
-  booktitle = {Proc. of the European Conference on Machine Learning (ECML)},
-  month = {9},
-  year = {2007},
-  url = "http://cogcomp.org/papers/KlementievRoSm07.pdf",
-  funding = {ITR-EDU, MIAS},
-  projects = {USS,RANK},
-}
-
-@article{RothYi07,
-  author = {D. Roth and W. Yih},
-  title = {Global Inference for Entity and Relation Identification via a Linear Programming Formulation},
-  booktitle = {Introduction to Statistical Relational Learning},
-  year = {2007},
-  publisher = {MIT Press},
-  editor = {Lise Getoor and Ben Taskar},
-  url = "http://cogcomp.org/papers/RothYi07.pdf",
-  funding = {ITR-BI,ARDA,XPRESSMP},
-  projects = {LT,LINL,ILP,CCM,NER,PL},
-  comment = {Learning and Inference with Constraints; Integer Linear Programming for Information extraction; Simultaneous recognition of entities and Relations},
-}
-
-@incollection{BrazAmRo07,
-  author = {R. de Salvo Braz and E. Amir and D. Roth},
-  title = {Lifted First-Order Probabilistic Inference},
-  booktitle = {Introduction to Statistical Relational Learning},
-  year = {2007},
-  publisher = {MIT Press},
-  editor = {Lise Getoor and Ben Taskar},
-  url = "http://cogcomp.org/papers/BrazAmRo07.pdf",
-  funding = {ARDA, ITR-BI, SoD},
-  projects = {FOPI},
-  comment = {Relational Inference; Probabilistic Relational (first order) Models; First-order probabilistic inference without propositionalization; Lifted Probabilistic Inference},
-}
-
-@inproceedings{Har-PeledRoZi07,
-  author = {S. Har-Peled and D. Roth and D. Zimak},
-  title = {Maximum Margin Coresets for Active and Noise Tolerant Learning},
-  booktitle = {Proc. of the International Joint Conference on Artificial Intelligence (IJCAI)},
-  pages = {LT},
-  year = {2007},
-  acceptance = {212/1353 (16\%)},
-  url = "http://cogcomp.org/papers/Har-PeledRoZi07.pdf",
-  funding = {KINDLE,REFLEX,MURI,XPRESSMP},
-  projects = {IE,LINL,SP,ILP,AL},
-  comment = {Learning large margin halfspaces using coresets; algorithm and analysis; applications include analysis of large margin active learning and an algorithm for agnostic learning in the presence of outlier noise.},
-}
-
-@article{ZTLHPRL07,
-  author = {Z. Zeng and J. Tu and M. Liu and T. Huang and B. Pianfetti and D. Roth and S. Levinson},
-  title = {Audio-Visual Affect Recognition},
-  pages = {424-428},
-  year = {2007},
-  journal = {IEEE Transactions on Multimedia},
-  volume = {9},
-  number = {2},
-  url = "http://cogcomp.org/papers/ZTLHPRL07.pdf",
-  funding = {ITR-BI},
-}
-
-%%%%%%%%%%%%%%
-%%%  2006  %%%
-%%%%%%%%%%%%%%
-@thesis{Zimak06,
-  author = {D. Zimak},
-  title = {Algorithms and Analysis for Multi-Category Classification},
-  booktitle = {UIUC PhD Thesis},
-  year = {2006},
-  url = "http://cogcomp.org/papers/Zimak06.pdf",
-}
-
-@inproceedings{ChangDoRo06,
-  author = {M. Chang and Q. Do and D. Roth},
-  title = {Multilingual Dependency Parsing: A Pipeline Approach},
-  booktitle = {Proc. of the Conference on Recent Advances in Natural Language Processing},
-  pages = {55--78},
-  month = {7},
-  year = {2006},
-  editor = {Nicolas Nicolov and Kalina Bontcheva and Galia Angelova and Ruslan Mitkov},
-  url = "http://cogcomp.org/papers/ChangDoRo06b.pdf",
-  funding = {ARDA,REFLEX,SoD},
-  projects = {DP,PL},
-  comment = {Analysis of A pipeline model with applications to dependency parsing. Combines ACL'06 and CoNLL'06},
-}
-
-@inproceedings{RothSm06a,
-  author = {D. Roth and K. Small},
-  title = {Margin-based Active Learning for Structured Output Spaces},
-  booktitle = {Proc. of the European Conference on Machine Learning (ECML)},
-  month = {9},
-  year = {2006},
-  publisher = {Springer},
-  url = "http://cogcomp.org/papers/RothSm06a.pdf",
-  funding = {MOTOROLA,ITR-EDU},
-  projects = {AL,SRL},
-  comment = {Active Learning; Structured Output},
-}
-
-@workshop{BrazAmRo06a,
-  author = {R. de Salvo Braz and E. Amir and D. Roth},
-  title = {MPE and Partial Inversion in Lifted Probabilistic Variable Elimination},
-  booktitle = {Proc. of the Conference on Artificial Intelligence (AAAI)},
-  month = {7},
-  year = {2006},
-  url = "http://cogcomp.org/papers/BrazAmRo06a.pdf",
-  funding = {ARDA,ITR-BI},
-  projects = {FOPI},
-  comment = {Relational Inference; Probabilistic Relational (first order) Models; First-order probabilistic inference without propositionalization; Lifted Probabilistic Inference},
-}
-
-@inproceedings{KlementievRo06a,
-  author = {A. Klementiev and D. Roth},
-  title = {Weakly Supervised Named Entity Transliteration and Discovery from Multilingual Comparable Corpora},
-  booktitle = {Proc. of the Annual Meeting of the Association for Computational Linguistics (ACL)},
-  pages = {USS,TL,ADAPT},
-  month = {7},
-  year = {2006},
-  url = "http://cogcomp.org/papers/KlementievRo06a.pdf",
-  funding = {KINDLE,REFLEX},
-  projects = {REFLEX,USS,TL,ADAPT},
-  comment = {Multilingual named entities; multilingual search; multilingual named entities discovery and recognition; discriminatory transliteration model; Fourier Transform for temporal sequence similarity},
-}
-
-@inproceedings{ChangDoRo06a,
-  author = {M. Chang and Q. Do and D. Roth},
-  title = {Local Search for Bottom-Up Dependency Parsing},
-  booktitle = {Proc. of the Annual Meeting of the Association for Computational Linguistics (ACL)},
-  month = {7},
-  year = {2006},
-  url = "http://cogcomp.org/papers/ChangDoRo06a.pdf",
-  funding = {ARDA,REFLEX},
-  projects = {DP},
-  comment = {Analysis of A pipeline model with applications to dependency parsing},
-}
-
-@inproceedings{ChangDoRo06,
-  author = {M. Chang and Q. Do and D. Roth},
-  title = {A Pipeline Model for Bottom-Up Dependency Parsing Shared Task Paper},
-  booktitle = {Proc. of the Conference on Computational Natural Language Learning (CoNLL)},
-  pages = {186--190},
-  month = {6},
-  year = {2006},
-  url = "http://cogcomp.org/papers/ChangDoRo06.pdf",
-  funding = {KINDLE,REFLEX},
-  projects = {DP,PL},
-  comment = {Multilingual Dependency Parsing; a shift reduced parsing model; study of shift reduced parsing as a pipeline model},
-}
-
-@workshop{BrazAmRo06,
-  author = {R. de Salvo Braz and E. Amir and D. Roth},
-  title = {MPE and Partial Inversion in Lifted Probabilistic Variable Elimination},
-  booktitle = {Proc. of the International Conference on Machine Learning (ICML)},
-  month = {6},
-  year = {2006},
-  url = "http://cogcomp.org/papers/BrazAmRo06.pdf",
-  funding = {ARDA},
-  projects = {FOPI},
-  comment = {Earlier Version of a AAAI'06 paper.},
-}
-
-@workshop{RothSm06,
-  author = {D. Roth and K. Small},
-  title = {Active Learning with Perceptron for Structured Output},
-  booktitle = {Proc. of the International Conference on Machine Learning (ICML)},
-  month = {6},
-  year = {2006},
-  url = "http://cogcomp.org/papers/RothSm06.pdf",
-  funding = {MOTOROLA,ITR-EDU},
-  projects = {AL},
-  comment = {Earlier Version of an ECML'06 paper},
-}
-
-@inproceedings{KlementievRo06,
-  author = {A. Klementiev and D. Roth},
-  title = {Named Entity Transliteration and Discovery from Multilingual Comparable Corpora},
-  booktitle = {Proc. of the Annual Conference of the North American Chapter of the Association for Computational Linguistics (NAACL)},
-  pages = {82--88},
-  month = {6},
-  year = {2006},
-  url = "http://cogcomp.org/papers/KlementievRo06.pdf",
-  funding = {KINDLE,REFLEX},
-  projects = {REFLEX,TL,USS,ADAPT},
-  comment = {Multilingual named entities; multilingual search; multilingual named entities discovery and recognition; discriminatory transliteration model; Fourier Transform for temporal sequence similarity},
-}
-
-@incollection{BGPRS06,
-  author = {R. de Salvo Braz and R. Girju and V. Punyakanok and D. Roth and M. Sammons},
-  title = {An Inference Model for Semantic Entailment in Natural Language},
-  pages = {261--286},
-  year = {2006},
-  publisher = {Springer},
-  editor = {J. Quinonero Candela and I. Dagan and B. Magnini and F. d'Alche-Buc},
-  journal = {Machine Learning Challenges, Evaluating Predictive Uncertainty, Visual Object Classification and Recognizing Textual Entailment, First PASCAL Machine Learning Challenges Workshop, Revised Selected Papers},
-  volume = {3944},
-  url = "http://cogcomp.org/papers/BGPRS06.pdf",
-  funding = {ARDA,ITR-BI,TRECC,CLUSTER,XPRESSMP},
-  projects = {KINDLE,TE,KRNLP},
-  comment = {Revised version of PASCAL RTE Challenge. Textual Entailment, integrating NLP text analyis, shallow semantic inference},
-}
-
-@techreport{Har-PeledRoZi06a,
-  author = {S. Har-Peled and D. Roth and D. Zimak},
-  title = {Maximum Margin Coresets for Active and Noise Tolerant Learning},
-  year = {2006},
-  institution = {UIUC Computer Science Department},
-  number = {No. UIUCDCS-R-2006-2784},
-  url = {},
-  funding = {ITR-BI,ITR-MIT},
-  projects = {AL},
-  invisible = {true},
-}
-
-@techreport{DoanLiRo06,
-  author = {A. Doan and X. Li and D. Roth},
-  title = {MEDIATE: Learning to match entity mentions across text and data bases},
-  year = {2006},
-  institution = {UIUC Computer Science Department},
-  number = {No. UIUCDCS-R-2006-2692},
-  url = "http://cogcomp.org/papers/DoanLiRo06.pdf",
-  funding = {MURI,ITR-BI},
-  projects = {MIRROR,COREF,NER},
-  comment = {UIUC Tech Report UIUCDCS-R-2006-2692. Semantic Integration; Entity Uncertainty; Automatic matching of entity mentions across text and databases.},
-  invisible = {true},
-}
-
-@article{MengshoelRoWi06,
-  author = {O. J. Mengshoel and D. Roth and D. C. Wilkins},
-  title = {Controlled generation of hard and easy Bayesian networks: Impact on maximal clique size in tree clustering},
-  year = {2006},
-  journal = {Artificial Intelligence},
-  url = "http://cogcomp.org/papers/MengshoelWiRo06.pdf",
-}
-
-%%%%%%%%%%%%%%
-%%%  2005  %%%
-%%%%%%%%%%%%%%
-@thesis{Yih05,
-  author = {W. Yih},
-  title = {Learning and Inference for Information Extraction},
-  booktitle = {UIUC PhD thesis},
-  year = {2005},
-  url = "http://cogcomp.org/papers/Yih05.pdf",
-}
-
-@inproceedings{RothYi05,
-  author = {D. Roth and W. Yih},
-  title = {Integer Linear Programming Inference for Conditional Random Fields},
-  booktitle = {Proc. of the International Conference on Machine Learning (ICML)},
-  pages = {737--744},
-  year = {2005},
-  acceptance = {143/491 (29\%)},
-  url = "http://cogcomp.org/papers/RothYi05.pdf",
-  funding = {MURI,ITR-BI,ITR-MIT,ARDA,XPRESSMP},
-  projects = {LT,LINL,ILP,CCM},
-  comment = {Extending Conditional Random Fields with expressive, non-sequential, constraints. Comparing multiple joint inference training paradigms for structure learning in the context of SRL.},
-}
-
-@inproceedings{PunyakanokRoYi05,
-  author = {V. Punyakanok and D. Roth and W. Yih},
-  title = {The Necessity of Syntactic Parsing for Semantic Role Labeling},
-  booktitle = {Proc. of the International Joint Conference on Artificial Intelligence (IJCAI)},
-  pages = {1117--1123},
-  year = {2005},
-  acceptance = {240/1329 (18\%)},
-  url = "http://cogcomp.org/papers/PunyakanokRoYi05.pdf",
-  funding = {KINDLE,REFLEX,MURI,XPRESSMP},
-  projects = {IE,LINL,SP,ILP,SRL},
-  comment = {An Analysis of the impact of syntactic parsing on semantic role labeling. Joint inference is used both to guarantee coherent SRL output and to combine several SRL systems.},
-}
-
-@inproceedings{PRYZ05,
-  author = {V. Punyakanok and D. Roth and W. Yih and D. Zimak},
-  title = {Learning and Inference over Constrained Output},
-  booktitle = {Proc. of the International Joint Conference on Artificial Intelligence (IJCAI)},
-  pages = {1124--1129},
-  year = {2005},
-  acceptance = {240/1329 (18\%)},
-  url = "http://cogcomp.org/papers/PRYZ05.pdf",
-  funding = {KINDLE,REFLEX,MURI,XPRESSMP,ITR-BI},
-  projects = {LT,CCM},
-  comment = {Structure Learning; Joint Inference; Learning + Inference vs. Inference based Training Algorithms},
-}
-
-@inproceedings{BrazAmRo05,
-  author = {R. de Salvo Braz and E. Amir and D. Roth},
-  title = {Lifted First-order Probabilistic Inference},
-  booktitle = {Proc. of the International Joint Conference on Artificial Intelligence (IJCAI)},
-  pages = {1319--1125},
-  year = {2005},
-  acceptance = {240/1329 (18\%)},
-  url = "http://cogcomp.org/papers/BrazAmRo05.pdf",
-  funding = {ITR-BI, CAREER},
-  comment = {Relational Inference; Probabilistic Relational (first order) Models; First-order probabilistic inference without propositionalization},
-}
-
-@inproceedings{BGPRS05,
-  author = {R. de Salvo Braz and R. Girju and V. Punyakanok and D. Roth and M. Sammons},
-  title = {An Inference Model for Semantic Entailment in Natural Language},
-  booktitle = {Proc. of the Conference on Artificial Intelligence (AAAI)},
-  pages = {1678--1679},
-  year = {2005},
-  acceptance = {223/803 (28\%)},
-  url = "http://cogcomp.org/papers/BGPRS05.pdf",
-  funding = {ARDA,ITR-BI,TRECC,CLUSTER,XPRESSMP},
-  projects = {KINDLE,TE,KRNLP},
-  comment = {Textual Entailment; Mapping sentences to a description logic based representation, Pascal Entailment Task},
-}
-
-@workshop{BGPRS05a,
-  author = {R. de Salvo Braz and R. Girju and V. Punyakanok and D. Roth and M. Sammons},
-  title = {Knowledge Representation for Semantic Entailment and Question-Answering},
-  booktitle = {Proc. of the International Joint Conference on Artificial Intelligence (IJCAI)},
-  year = {2005},
-  url = "http://cogcomp.org/papers/BGPRS05a.pdf",
-  funding = {ARDA,ITR-BI,TRECC,CLUSTER,XPRESSMP,TE},
-  projects = {KINDLE},
-  comment = {Analysis of our Textual Entailment system},
-}
-
-@inproceedings{BGPRS05b,
-  author = {R. de Salvo Braz and R. Girju and V. Punyakanok and D. Roth and M. Sammons},
-  title = {An Inference Model for Semantic Entailment in Natural Language},
-  booktitle = {Proc. of the International Joint Conference on Artificial Intelligence (IJCAI)},
-  year = {2005},
-  acceptance = {112/450 (25\%)},
-  url = "http://cogcomp.org/papers/BGPRS05b.pdf",
-  funding = {ARDA,ITR-BI,TRECC,CLUSTER,XPRESSMP},
-  projects = {KINDLE,TE},
-  comment = {Textual Entailment; Mapping sentences to a description logic based representation},
-}
-
-@inproceedings{AlmRoSp05,
-  author = {C. Alm and D. Roth and R. Sproat},
-  title = {Emotions from text: machine learning for text-based emotion prediction.},
-  booktitle = {Proc. of the Conference on Empirical Methods in Natural Language Processing (EMNLP)},
-  year = {2005},
-  url = "http://cogcomp.org/papers/AlmRoSp05.pdf",
-  funding = {ITR-EDU},
-}
-
-@inproceedings{AgarwalRo05,
-  author = {S. Agarwal and D. Roth},
-  title = {Learnability of Bipartite Ranking Functions},
-  booktitle = {Proc. of the ACM Conference on Computational Learning Theory (COLT)},
-  pages = {16--31},
-  year = {2005},
-  acceptance = {45/119 (37.8\%)},
-  url = "http://cogcomp.org/papers/Agarwalro05.pdf",
-  funding = {ITR-BI,ITR-MIT,TRECC},
-  projects = {LT,RANK},
-}
-
-@inproceedings{AgarwalHaRo05,
-  author = {S. Agarwal and S. Har-Peled and D. Roth},
-  title = {A Uniform Convergence Bound for the Area Under the ROC Curve},
-  booktitle = {Proc. of the International Workshop on Artificial Intelligence and Statistics (AISTATS)},
-  pages = {1-8},
-  year = {2005},
-  acceptance = {51/150 (34\%)},
-  url = "http://cogcomp.org/papers/AgarwalHaRo05.pdf",
-  funding = {ITR-BI,ITR-MIT,TRECC},
-  projects = {LT,RANK},
-  comment = {Bipartite Ranking: uniform convergence properties of the AUC in terms of bipartite rank-shatter coefficients.},
-}
-
-@inproceedings{AGHR05,
-  author = {S. Agarwal and T. Graepel and R. Herbrich and D. Roth},
-  title = {A Large Deviation Bound for the Area Under the ROC Curve},
-  booktitle = {Proc. of the Conference on Neural Information Processing Systems (NIPS)},
-  pages = {9--16},
-  year = {2005},
-  acceptance = {207/823 (25\%)},
-  url = "http://cogcomp.org/papers/AgarwalGrHeRo05.pdf",
-  funding = {ITR-BI,ITR-MIT,TRECC},
-  projects = {LT,RANK},
-  comment = {Bipartite Ranking: bounding the expected accuracy of a ranking function in terms of its empirical AUC.},
-}
-
-@article{AGHHR05,
-  author = {S. Agarwal and T. Graepel and R. Herbrich and S. Har-Peled and D. Roth},
-  title = {Generalization Bounds for the Area Under the ROC Curve},
-  pages = {393--425},
-  year = {2005},
-  journal = {Journal of Machine Learning Research},
-  volume = {6},
-  url = "http://cogcomp.org/papers/AgarwalGrHeHaRo05.pdf",
-  funding = {ITR-BI,ITR-MIT,TRECC},
-  projects = {LT,RANK},
-}
-
-@article{KhardonRoSe05,
-  author = {R. Khardon and D. Roth and R. Servedio},
-  title = {Efficiency versus Convergence of Boolean Kernels for On-Line Learning Algorithms},
-  pages = {341-356},
-  year = {2005},
-  journal = {Journal of Machine Learning Research},
-  volume = {24},
-  url = "http://cogcomp.org/papers/KhardonRoSe05.pdf",
-  funding = {ITR-MIT NSF98 CAREER},
-  projects = {KR,LT},
-}
-
-@article{FungRo05,
-  author = {P. Fung and D. Roth},
-  title = {Guest Editors Introduction: Machine Learning in Speech and Language Technologies},
-  pages = {1-6},
-  year = {2005},
-  journal = {Machine Learning},
-  volume = {60},
-  number = {1/2/3},
-  url = "http://cogcomp.org/papers/FungRo05.pdf",
-  funding = {ITR-BI,CAREER,MURI},
-  projects = {LNL,LT},
-}
-
-@article{Roth05,
-  author = {D. Roth},
-  title = {Learning based Programming},
-  year = {2005},
-  publisher = {Springer-Verlag},
-  editor = {L.C. Jain and D. Holmes},
-  journal = {Innovations in Machine Learning: Theory and Applications},
-  url = "http://cogcomp.org/papers/Roth05.pdf",
-  funding = {ITR-BI,MURI,TRECC},
-  projects = {LBP},
-  comment = {Suggests a paradigm and a programming language for the programming of learning intensive computer systems. Springer: http://dx.doi.org/10.1007/3-540-33486-6_3},
-}
-
-@workshop{GirjuRoSa05,
-  author = {R. Girju and D. Roth and M. Sammons},
-  title = {Token-level Disambiguation of VerbNet classes},
-  booktitle = {Proc. of the Interdisciplinary Workshop on Verb Features and Verb Classes (Verb Workshop)},
-  year = {2005},
-  url = "http://cogcomp.org/papers/GirjuRoSa05.pdf",
-  funding = {KINDLE,TRECC},
-  projects = {SM},
-  comment = {Context Sensitive Identification of VerbNet Classes; Levin Classes.},
-}
-
-@article{LiMoRo05,
-  author = {X. Li and P. Morie and D. Roth},
-  title = {Semantic Integration in Text: From Ambiguous Names to Identifiable Entities},
-  pages = {45--68},
-  year = {2005},
-  journal = {AI Magazine. Special Issue on Semantic Integration},
-  url = "http://cogcomp.org/papers/LiMoRo05.pdf",
-  funding = {MURI,TRECC,CLUSTER},
-  projects = {MIRROR,COREF,NER},
-  comment = {Named Entity Recognition; coreference resolution; entity identification; matching Entities Mentions within and across documents.},
-}
-
-@inproceedings{ShenLiDo05,
-  author = {W. Shen and X. Li and A. Doan},
-  title = {Constraint-Based Entity Matching},
-  booktitle = {Proc. of the Conference on Artificial Intelligence (AAAI)},
-  year = {2005},
-  acceptance = {223/803 (28\%)},
-  url = "http://cogcomp.org/papers/ShenLiDn05.pdf",
-  funding = {MURI,ITR-MIT},
-  projects = {MIRROR,NER,COREF},
-  comment = {Entity Identification, Generative Model, Record Linkage, Constraint, Relaxation Labeling},
-}
-
-@inproceedings{LiRo05,
-  author = {X. Li and D. Roth},
-  title = {Discriminative Training of Clustering Functions: Theory and Experiments with Entity Identification},
-  booktitle = {Proc. of the Conference on Computational Natural Language Learning (CoNLL)},
-  pages = {64--71},
-  year = {2005},
-  publisher = {Association for Computational Linguistics},
-  editor = {Ido Dagan and Dan Gildea},
-  acceptance = {19/70 (27\%)},
-  url = "http://cogcomp.org/papers/LiRo05.pdf",
-  funding = {ITR-BI,MURI,TRECC},
-  projects = {MIRROR,NER},
-  comment = {Clustering; metric learning; training metrics; entity identification},
-}
-
-@inproceedings{KPRY05,
-  author = {P. Koomen and V. Punyakanok and D. Roth and W. Yih},
-  title = {Generalized Inference with Multiple Semantic Role Labeling Systems Shared Task Paper},
-  booktitle = {Proc. of the Conference on Computational Natural Language Learning (CoNLL)},
-  pages = {181-184},
-  year = {2005},
-  editor = {Ido Dagan and Dan Gildea},
-  url = "http://cogcomp.org/papers/PunyakanokRoYi05a.pdf",
-  funding = {MURI,KINDLE,CLUSTER,XPRESSMP},
-  projects = {SM,KINDLE,SRL},
-  comment = {Semantic Parsing; joint inference; integer linear programming; combining SRL systems via joint inference; Top system in CoNLL shared task},
-}
-
-@article{LiRo05a,
-  author = {X. Li and D. Roth},
-  title = {Learning Question Classifiers: The Role of Semantic Information},
-  year = {2005},
-  journal = {Journal of Natural Language Engineering},
-  volume = {11},
-  number = {4},
-  url = "http://cogcomp.org/papers/LiRo05a.pdf",
-  funding = {MURI,ITR-MIT},
-  projects = {QA,MCR,TE},
-  comment = {Question Classification; Hierarchical classifiers; Sequential Model; Expressive Feature generation with semantic information.},
-}
-
-@techreport{PunyakanokRo05,
-  author = {V. Punyakanok and D. Roth},
-  title = {Inference with Classifiers: The Phrase Identification Problem},
-  year = {2005},
-  journal = {UIUC Technical Report},
-  url = "http://cogcomp.org/papers/Punyakanok-05.pdf",
-  funding = {CAREER,ITR-MIT,NSF98,KINDLE},
-  projects = {LnI,IE,NE,CCM},
-  comment = {Shallow Parsing; Chunking; HMMs, Conditional Models and Constraint Satisfaction Models. Top results on phrase chunking},
-}
-
-@inproceedings{ZDCR05,
-  author = {B. Ziebart and A. Dey and R. Campbell and D. Roth},
-  title = {Learning Automation Policies for Pervasive Computing Environments},
-  booktitle = {Proc. of the International Conference on Autonomic Computing (ICAC)},
-  pages = {204-215},
-  year = {2005},
-  acceptance = {64/150 (43\%)},
-  url = "http://cogcomp.org/papers/ZDRC05.pdf",
-  funding = {ITR-BI},
-  projects = {LBP},
-}
-
-@inproceedings{LiRo05b,
-  author = {X. Li and D. Roth},
-  title = {Discriminative Training of Clustering Functions: Theory and Experiments with Entity Identification},
-  booktitle = {Proc. of the Midwest Computational Linguistics Colloquium (MCLC)},
-  month = {5},
-  year = {2005},
-  url = {},
-  funding = {MURI,TRECC},
-  projects = {LT,NER},
-  comment = {Supervised Learning, Clustering, Metric Learning},
-  invisible = {true},
-}
-
-%%%%%%%%%%%%%%
-%%%  2004  %%%
-%%%%%%%%%%%%%%
-@inproceedings{LiMoRo04,
-  author = {X. Li and P. Morie and D. Roth},
-  title = {Identification and Tracing of Ambiguous Names: Discriminative and Generative Approaches},
-  booktitle = {Proc. of the Conference on Artificial Intelligence (AAAI)},
-  pages = {419--424},
-  year = {2004},
-  acceptance = {120/453 (26.5\%)},
-  url = "http://cogcomp.org/papers/LiMoRo04.pdf",
-  funding = {MURI,TRECC,CLUSTER},
-  projects = {MIRROR,COREF,NER},
-  comment = {Comparing discriminatory and generative models for entity identification; named entity recognition; coreference resolution; matching entities mentions within and across documents; distance metrics for named entities},
-}
-
-@inproceedings{LiMoRo04a,
-  author = {X. Li and P. Morie and D. Roth},
-  title = {Robust Reading: Identification and Tracing of Ambiguous Names},
-  booktitle = {Proc. of the Annual Conference of the North American Chapter of the Association for Computational Linguistics (NAACL)},
-  pages = {17--24},
-  year = {2004},
-  url = "http://cogcomp.org/papers/LiMoRo04a.pdf",
-  funding = {MURI,TRECC,CLUSTER},
-  projects = {MIRROR,NER,COREF},
-  comment = {A generative model for entity identification; Named Entity Recognition; coreference resolution; matching entities mentions within and across documents},
-}
-
-@inproceedings{DayaRoWi04,
-  author = {E. Daya and D. Roth and S. Wintner},
-  title = {Learning Hebrew Roots: Machine Learning with Linguistic Constraints},
-  booktitle = {Proc. of the Conference on Empirical Methods in Natural Language Processing (EMNLP)},
-  pages = {168--178},
-  month = {7},
-  year = {2004},
-  url = "http://cogcomp.org/papers/DayaRoWi04.pdf",
-  funding = {CAREER,MURI, REFLEX},
-  projects = {LnI,SI,NLP},
-  comment = {Inference with Classifiers; Learning and Inference with Constraints; Hebrew Morphology},
-}
-
-@inproceedings{RothYi04,
-  author = {D. Roth and W. Yih},
-  title = {A Linear Programming Formulation for Global Inference in Natural Language Tasks},
-  booktitle = {Proc. of the Conference on Computational Natural Language Learning (CoNLL)},
-  pages = {1--8},
-  year = {2004},
-  publisher = {Association for Computational Linguistics},
-  editor = {Hwee Tou Ng and Ellen Riloff},
-  acceptance = {11/23 (48\%)},
-  url = "http://cogcomp.org/papers/RothYi04.pdf",
-  funding = {ITR-BI,MURI,XPRESSMP},
-  projects = {IE,LnI,CCM,NER,PL},
-  comment = {Simultaneous recognition of Named Entities and Relations between them. Learning and Inference via an Integer Linear Programming framework; Structure Learning; Avoiding Pipeline Processing},
-}
-
-@inproceedings{PRYZ04,
-  author = {V. Punyakanok and D. Roth and W. Yih and D. Zimak},
-  title = {Semantic Role Labeling via Integer Linear Programming Inference},
-  booktitle = {Proc. of the International Conference on Computational Linguistics (COLING)},
-  pages = {1346--1352},
-  month = {8},
-  year = {2004},
-  address = {Geneva, Switzerland},
-  url = "http://cogcomp.org/papers/PRYZ04.pdf",
-  funding = {ITR-BI,MURI,KINDLE,XPRESSMP},
-  projects = {SP,LnI,CCM,SRL},
-  comment = {Semantic Parsing; Structure Learning with Expressive Constraints; Constraint Optimization; Integer Linear Programming},
-}
-
-@inproceedings{PRYZT04,
-  author = {V. Punyakanok and D. Roth and W. Yih and D. Zimak and Y. Tu},
-  title = {Semantic Role Labeling via Generalized Inference over Classifiers Shared Task Paper},
-  booktitle = {Proc. of the Conference on Computational Natural Language Learning (CoNLL)},
-  pages = {130--133},
-  year = {2004},
-  editor = {Hwee Tou Ng and Ellen Riloff},
-  url = "http://cogcomp.org/papers/PRYZT04.pdf",
-  funding = {CAREER,MURI,CAREER,KINDLE,CLUSTER,XPRESSMP},
-  projects = {SM,SRL,CCM},
-  comment = {Semantic Parsing; Structure Learning with Expressive Constraints; Constraint Optimization; Integer Linear Programming},
-}
-
-@inproceedings{ZTLZRZHRL04,
-  author = {Z. Zeng and J. Tu and M. Liu and T. Zhang and N. Rizzolo and Z. Zhang and T. Huang and D. Roth and S. Levinson},
-  title = {Bimodal HCI-related Affect Recognition},
-  booktitle = {Proc. of the International Conference on Multimodal Interfaces (ICMI)},
-  pages = {137--143},
-  month = {10},
-  year = {2004},
-  acceptance = {56/257 (28\%)},
-  url = "http://cogcomp.org/papers/ZTKZRZHRL04.pdf",
-  funding = {TRECC,ITR-BI},
-}
-
-@inproceedings{LiRoSm04,
-  author = {X. Li and D. Roth and K. Small},
-  title = {The Role of Semantic Information in Learning Question Classifiers},
-  booktitle = {Proc. of the International Joint Conference on Natural Language Processing (IJCNLP)},
-  year = {2004},
-  acceptance = {67/211 (32\%)},
-  url = "http://cogcomp.org/papers/LiRoSm04.pdf",
-  funding = {MURI,ITR-MIT},
-  projects = {QA,MCR,TE},
-  comment = {Question Classification; Hierarchical classifiers; Sequential Model; Expressive Feature Generation with semantic information.},
-}
-
-@article{AgarwalAwRo04,
-  author = {S. Agarwal and A. Awan and D. Roth},
-  title = {Learning to Detect Objects in Images via a Sparse, Part-Based Representation},
-  pages = {1475--1490},
-  year = {2004},
-  journal = {IEEE Transactions on Pattern Analysis and Machine Intelligence},
-  volume = {20},
-  number = {11},
-  url = "http://cogcomp.org/papers/AgarwalAwRo04.pdf",
-  funding = {CAREER,ITR-MIT},
-  projects = {LV,KR},
-}
-
-@inproceedings{YihChKi04,
-  author = {W. Yih and P. Chang and W. Kim},
-  title = {Mining Online Deal Forums for Hot Deals},
-  booktitle = {Proc. of the IEEE/WIC/ACM International Conference on Web Intelligence (WI)},
-  pages = {384--390},
-  year = {2004},
-  publisher = {IEEE Computer Society},
-  url = "http://scottyih.org/YihChKi-wi04.pdf",
-  funding = {ITR-BI,MURI},
-  projects = {IIA},
-  comment = {Applying topic and sentiment text classification to online web forums},
-}
-
-@unpublished{RothYi04a,
-  author = {D. Roth and W. Yih},
-  title = {A Linear Programming Formulation for Global Inference in Natural Language Tasks},
-  booktitle = {Proc. of the International Symposium on Artificial Intelligence and Mathematics (AIM)},
-  pages = {1--8},
-  year = {2004},
-  url = "http://cogcomp.org/papers/RothYi04a.pdf",
-  funding = {ITR-BI,MURI,CLUSTER,XPRESSMP},
-  projects = {IE,LnI,CCM},
-  comment = {An early version of the CoNLL paper},
-  invisible = {true},
-}
-
-@article{PunyakanokRoYi04a,
-  author = {V. Punyakanok and D. Roth and W. Yih},
-  title = {Mapping Dependencies Trees: An Application to Question Answering},
-  booktitle = {Proc. of the International Symposium on Artificial Intelligence and Mathematics (AIM)},
-  month = {1},
-  year = {2004},
-  acceptance = {30-64 (47\%)},
-  url = "http://cogcomp.org/papers/PunyakanokRoYi04a.pdf",
-  funding = {MURI,KINDLE},
-  projects = {QA,KINDLE,TE},
-}
-
-@inproceedings{LiRo04b,
-  author = {X. Li and D. Roth},
-  title = {Supervised Discriminative Clustering},
-  booktitle = {Proc. of the Conference on Neural Information Processing Systems (NIPS) Workshop on Learning Structured Output},
-  year = {2004},
-  url = {},
-  funding = {MURI,TRECC},
-  projects = {LT},
-  comment = {Supervised Learning, Clustering, Metric Learning},
-  invisible = {true},
-}
-
-@inproceedings{PRYZ04a,
-  author = {V. Punyakanok and D. Roth and W. Yih and D. Zimak},
-  title = {Learning via Inference over Structurally Constrained Output},
-  booktitle = {Proc. of the Conference on Neural Information Processing Systems (NIPS) Workshop on Learning Structured Output},
-  year = {2004},
-  url = "http://cogcomp.org/papers/PRYZ04a.pdf",
-  funding = {ITR-BI,ITR-MIT,MURI,KINDLE,XPRESSMP},
-  projects = {LT,CCM},
-  comment = {Learning + Inference vs. Inference based Training Algorithms},
-  invisible = {true},
-}
-
-@techreport{BrazRo04,
-  author = {R. de Salvo Braz and D. Roth},
-  title = {Functional Subsumption in Feature Description Logic},
-  year = {2004},
-  institution = {UIUC Computer Science Department},
-  number = {UIUCDCS-R-2004-2423},
-  url = {},
-  funding = {ITR-BI,CAREER},
-  projects = {KINDLE,KR},
-  invisible = {true},
-}
-
-@techreport{HannekeRo04,
-  author = {S. Hanneke and D. Roth},
-  title = {Iterative Labeling for Semi-Supervised Learning},
-  month = {6},
-  year = {2004},
-  institution = {UIUC Computer Science Department},
-  number = {UIUCDCS-R-2004-2442},
-  url = "http://cogcomp.org/papers/HannekeRo04.pdf",
-  funding = {ITR-MIT,MURI,TRECC,CLUSTER},
-  projects = {LP,USS},
-  invisible = {true},
-}
-
-@techreport{BrazRoAm04,
-  author = {R. de Salvo Braz and D. Roth and E. Amir},
-  title = {First-order probabilistic inference revisited},
-  month = {6},
-  year = {2004},
-  institution = {UIUC Computer Science Department},
-  number = {UIUCDCS-R-2004-2443},
-  url = {},
-  funding = {ITR-BI},
-  projects = {KR,FOPI},
-  comment = {First order Probabilistic Inference without grounding.},
-  invisible = {true},
-}
-
-%%%%%%%%%%%%%%
-%%%  2003  %%%
-%%%%%%%%%%%%%%
-@inproceedings{HinrichsRo03,
-  author = {E. Hinrichs and D. Roth Program Chairs},
-  title = {Proceedings of the 41st Annual Meeting of the Association for Computational Linguistics},
-  year = {2003},
-  editor = {E. Hinrichs and D. Roth},
-  url = {},
-}
-
-@inproceedings{Har-PeledRoZi03,
-  author = {S. Har-Peled and D. Roth and D. Zimak},
-  title = {Constraint Classification for Multiclass Classification and Ranking},
-  booktitle = {Proc. of the Conference on Neural Information Processing Systems (NIPS)},
-  pages = {785--792},
-  year = {2003},
-  acceptance = {207/694 (30\%)},
-  url = "http://cogcomp.org/papers/nips02.pdf",
-  funding = {ITR-MIT ITR-BI CAREER},
-  projects = {CCR,LT,MC},
-}
-
-@inproceedings{CumbyRo03,
-  author = {C. Cumby and D. Roth},
-  title = {On Kernel Methods for Relational Learning},
-  booktitle = {Proc. of the International Conference on Machine Learning (ICML)},
-  pages = {107--114},
-  year = {2003},
-  acceptance = {118-371 (32\%)},
-  url = "http://cogcomp.org/papers/CumbyRo03.pdf",
-  funding = {NSF98,ITR-BI,CAREER},
-  projects = {LT,KR},
-  comment = {Parameterized kernels over structures. Relational Kernels. Advantages and disadvantages of graph kernels.},
-}
-
-@inproceedings{GargRo03,
-  author = {A. Garg and D. Roth},
-  title = {Margin Distribution and Learning Algorithms},
-  booktitle = {Proc. of the International Conference on Machine Learning (ICML)},
-  pages = {210--217},
-  year = {2003},
-  acceptance = {118/371 (32\%)},
-  url = "http://cogcomp.org/papers/GargRo03.pdf",
-  funding = {ITR-BI,ITR-MIT,CAREER},
-  projects = {LT,LCC},
-  comment = {Linear classifiers that optimize the margin distribution},
-}
-
-@inproceedings{LiRoTu03,
-  author = {X. Li and D. Roth and Y. Tu},
-  title = {Phrasenet: towards context sensitive lexical semantics},
-  booktitle = {Proc. of the Conference on Computational Natural Language Learning (CoNLL)},
-  year = {2003},
-  url = "http://cogcomp.org/papers/LiRoTu.pdf",
-  funding = {MURI,ITR-BI},
-  projects = {NLP, PHRASENET,LS},
-  comment = {Extending WordNet to taxonomy over phrases},
-}
-
-@workshop{CumbyRo03a,
-  author = {C. Cumby and D. Roth},
-  title = {Feature Extraction Languages for Propositionalized Relational Learning},
-  booktitle = {Proc. of the International Joint Conference on Artificial Intelligence (IJCAI)},
-  year = {2003},
-  acceptance = {33/40 (83\%)},
-  url = "http://cogcomp.org/papers/CumbyRo03a.pdf",
-  funding = {NSF98,ITR-BI,CAREER},
-  projects = {LT,KR,KINDLE},
-}
-
-@inproceedings{BrazRo03,
-  author = {R. de Salvo Braz and D. Roth},
-  title = {Functional subsumption in Description Logics},
-  booktitle = {Proc. of the Conference on Neural Information Processing Systems (NIPS) Workshop on Feature Extraction and Selection},
-  year = {2003},
-  url = {},
-  funding = {ITR-BI,CAREER},
-  projects = {KR,KINDLE},
-  comment = {Relational Feature Extraction; Feature Description Logic},
-}
-
-@techreport{LiMoRo03,
-  author = {X. Li and P. Morie and D. Roth},
-  title = {Robust Reading of Ambiguous Writing},
-  month = {8},
-  year = {2003},
-  institution = {UIUC Computer Science Department},
-  number = {UIUCDCS-R-2003-2371},
-  url = "http://cogcomp.org/papers/LiMoRo03.pdf",
-  funding = {MURI,ITR-BI},
-  projects = {MIRROR,COREF,NER},
-  invisible = {true},
-}
-
-@techreport{CumbyRo03c,
-  author = {C. Cumby and D. Roth},
-  title = {Kernel Methods for Relational Learning},
-  month = {5},
-  year = {2003},
-  institution = {UIUC Computer Science Department},
-  number = {UIUCDCS-R-2003-2345},
-  url = "http://cogcomp.org/papers/CumbyRo03c.pdf",
-  funding = {NSF98,ITR-BI,CAREER},
-  projects = {LT,KR},
-  invisible = {true},
-}
-
-@techreport{CumbyRo03b,
-  author = {C. Cumby and D. Roth},
-  title = {Feature Extraction Languages for Propositionalized Relational Learning},
-  month = {5},
-  year = {2003},
-  institution = {UIUC Computer Science Department},
-  number = {UIUCDCS-R-2003-2346},
-  url = "http://cogcomp.org/papers/CumbyRo03b.pdf",
-  funding = {NSF98,ITR-BI,CAREER},
-  projects = {LT,KR},
-  invisible = {true},
-}
-
-@techreport{AgarwalRo03,
-  author = {S. Agarwal and D. Roth},
-  title = {Minimum Risk Feature Transformations},
-  month = {12},
-  year = {2003},
-  institution = {UIUC Computer Science Department},
-  number = {UIUCDCS-R-2003-2627},
-  url = "http://cogcomp.org/papers/AgarwalRo03.pdf",
-  comment = {UIUC Tech Report UIUCDCS-R-2003-2627. A preliminary framework for Feature Generation},
-}
-
-%%%%%%%%%%%%%%
-%%%  2002  %%%
-%%%%%%%%%%%%%%
-@inproceedings{Rothva02,
-  author = {D. Roth and A. van den Bosch Program Chairs},
-  title = {Proceedings of CoNLL 2002, the Sixth Workshop on Computational Natural Language Learning},
-  year = {2002},
-  editor = {D. Roth and A. van den Bosch},
-  url = {},
-}
-
-@inproceedings{GargHaRo02,
-  author = {A. Garg and S. Har-Peled and D. Roth},
-  title = {On generalization bounds, projection profile, and margin distribution},
-  booktitle = {Proc. of the International Conference on Machine Learning (ICML)},
-  pages = {171--178},
-  year = {2002},
-  acceptance = {86/261 (33\%)},
-  url = "http://cogcomp.org/papers/icml02.pdf",
-  funding = {ITR-MIT,ITR-BI,CAREER},
-  projects = {LCC,LT},
-  comment = {Random Projection; Generalization Bounds for Linear Classifiers.},
-}
-
-@inproceedings{CumbyRo02,
-  author = {C. Cumby and D. Roth},
-  title = {Learning with Feature Description Logics},
-  booktitle = {Proc. of the International Conference on Inductive Logic Programming (ILP)},
-  pages = {32--47},
-  year = {2002},
-  url = "http://cogcomp.org/papers/ilp02.pdf",
-  funding = {NSF98,ITR-MIT,CAREER},
-  projects = {KR,KINDLE},
-  comment = {A Description Logic based Formalism for Feature Extraction; Expressive Features; A language for Feature Extraction},
-}
-
-@inproceedings{RothYi02,
-  author = {D. Roth and W. Yih},
-  title = {Probabilistic Reasoning for Entity and Relation Recognition},
-  booktitle = {Proc. of the International Conference on Computational Linguistics (COLING)},
-  pages = {835--841},
-  year = {2002},
-  acceptance = {198-435 (45\%)},
-  url = "http://cogcomp.org/papers/er-coling02.pdf",
-  funding = {MURI,ITR-MIT},
-  projects = {IE,NE,LnI,NER},
-  comment = {Entity And Relation Recognition. Simultaneous Identification of Entities and Relations.},
-}
-
-@inproceedings{LiRo02,
-  author = {X. Li and D. Roth},
-  title = {Learning Question Classifiers},
-  booktitle = {Proc. of the International Conference on Computational Linguistics (COLING)},
-  pages = {556--562},
-  year = {2002},
-  acceptance = {198-435 (45\%)},
-  url = "http://cogcomp.org/papers/qc-coling02.pdf",
-  funding = {NSF98,MURI,ITR-MIT},
-  projects = {CCR,QA,TE},
-  comment = {Classifying Answer Type for Question Answering. Sequential Classification. Multiclass Classification.},
-}
-
-@inproceedings{CMPR02,
-  author = {X. Carreras and L. Marquez and V. Punyakanok and D. Roth},
-  title = {Learning and Inference for Clause Identification},
-  booktitle = {Proc. of the European Conference on Machine Learning (ECML)},
-  pages = {35--47},
-  year = {2002},
-  acceptance = {80/218 (37\%)},
-  url = "http://cogcomp.org/papers/ecml02.pdf",
-  funding = {MURI,SBC-MIT,CAREER},
-  projects = {LnI,SI,IE},
-  comment = {Shallow Parsing; Chunking and Clause identification.},
-}
-
-@inproceedings{Har-PeledRoZi02,
-  author = {S. Har-Peled and D. Roth and D. Zimak},
-  title = {Constraint Classification: a new approach to Multiclass Classification},
-  booktitle = {Proc. of the International Workshop on Algorithmic Learning Theory (ALT)},
-  pages = {135--150},
-  year = {2002},
-  publisher = {Springer-Verlag},
-  acceptance = {21/42 (50\%)},
-  url = "http://cogcomp.org/papers/Har-PeledRoZi02.pdf",
-  funding = {ITR-MIT,ITR-BI,CAREER},
-  projects = {CCR,LT,MC},
-}
-
-@inproceedings{AgarwalRo02,
-  author = {S. Agarwal and D. Roth},
-  title = {Learning a Sparse Representation for Object Detection},
-  booktitle = {Proc. of the European Conference on Computer Vision (ECCV)},
-  pages = {113--128},
-  year = {2002},
-  acceptance = {45/600 (7.5\%) Oral Presentations; 225/600 (37\%) overall},
-  url = "http://cogcomp.org/papers/AgarwalRo02.pdf",
-  funding = {MURI,SBC-MIT,CAREER},
-  projects = {LV,KR},
-}
-
-@inproceedings{YangRoAh02,
-  author = {M. Yang and D. Roth and N. Ahuja},
-  title = {A Tale of Two Classifiers: SNoW vs. SVM in Visual Recognition},
-  booktitle = {Proc. of the European Conference on Computer Vision (ECCV)},
-  pages = {685--700},
-  year = {2002},
-  acceptance = {45/600 (7.5\%) Oral Presentations; 225/600 (37\%) overall},
-  url = "http://cogcomp.org/papers/YangRoAh02.pdf",
-  funding = {NSF98,ITR-MIT},
-  projects = {LT,LV},
-}
-
-@article{RothYaAh02,
-  author = {D. Roth and M. Yang and N. Ahuja},
-  title = {Learning to Recognize 3D Objects},
-  pages = {1071--1104},
-  year = {2002},
-  journal = {Neural Computation},
-  volume = {14},
-  number = {5},
-  acceptance = {NSF98,ITR-MIT},
-  url = "http://cogcomp.org/papers/objectsJ.pdf",
-  funding = {LT,LV},
-}
-
-@inproceedings{RCLMNPRSY02,
-  author = {D. Roth and C. Cumby and X. Li and P. Morie and R. Nagarajan and V. Punyakanok and N. Rizzolo and K. Small and W. Yih},
-  title = {Question-Answering via Enhanced Understanding of Questions},
-  booktitle = {Proc. of the Text Retrieval Conference (TREC)},
-  year = {2002},
-  url = "http://cogcomp.org/papers/trec02.pdf",
-  funding = {NSF98,MURI,ITR-MIT},
-  projects = {QA,TE},
-}
-
-@article{GreinerGrRo02,
-  author = {R. Greiner and A. Grove and D. Roth},
-  title = {Learning Cost-Sensitive Active Classifiers},
-  pages = {137--174},
-  year = {2002},
-  journal = {Artificial Intelligence},
-  volume = {139},
-  number = {2},
-  url = "http://cogcomp.org/papers/activeJ.pdf",
-  funding = {NSF98 CAREER},
-  projects = {DPL,LT,LP},
-  comment = {Earlier version appeared in ICML'96},
-}
-
-%%%%%%%%%%%%%%
-%%%  2001  %%%
-%%%%%%%%%%%%%%
-@inproceedings{KhardonRoSe02,
-  author = {R. Khardon and D. Roth and R. Servedio},
-  title = {Efficiency versus Convergence of Boolean Kernels for On-Line Learning Algorithms},
-  booktitle = {Proc. of the Conference on Neural Information Processing Systems (NIPS)},
-  year = {2001},
-  url = "http://cogcomp.org/papers/kernels01.pdf",
-  funding = {ITR-MIT,NSF98,CAREER},
-  projects = {KR,LT},
-  comment = {Kernel Perceptron with Exponentially Many mistakes; Hardness of Kernel Winnow.},
-}
-
-@inproceedings{PunyakanokRo01,
-  author = {V. Punyakanok and D. Roth},
-  title = {The Use of Classifiers in Sequential Inference},
-  booktitle = {Proc. of the Conference on Neural Information Processing Systems (NIPS)},
-  pages = {995--1001},
-  year = {2001},
-  publisher = {MIT Press},
-  acceptance = {25/514 (4.8\%) Oral Presentations; 152/514 (29\%) overall},
-  url = "http://cogcomp.org/papers/nips01.pdf",
-  funding = {NSF98 CAREER},
-  projects = {LnI,SI,IE,NE,NLP,CCM},
-  comment = {Structured, sequential output; Sequence Prediction: HMM with classifiers, Conditional Models, Constraint Satisfaction},
-}
-
-@inproceedings{RothYi01,
-  author = {D. Roth and W. Yih},
-  title = {Relational Learning via Propositional Algorithms: An Information Extraction Case Study},
-  booktitle = {Proc. of the International Joint Conference on Artificial Intelligence (IJCAI)},
-  pages = {1257--1263},
-  year = {2001},
-  acceptance = {197/796 (25\%)},
-  url = "http://cogcomp.org/papers/ijcai01.pdf",
-  funding = {ITR-MIT NSF98 MURI},
-  projects = {KR,IE,NE},
-  comment = {Expressive, Relational Features for Information Extraction},
-}
-
-@inproceedings{Roth01,
-  author = {D. Roth},
-  title = {Reasoning with Classifiers},
-  booktitle = {Proc. of the European Conference on Machine Learning (ECML)},
-  pages = {506--510},
-  year = {2001},
-  acceptance = {197/796 (25\%)},
-  url = {},
-  funding = {ITR-MIT NSF98 CAREER},
-  projects = {LnI,SI,IE,NE},
-  comment = {Paper written to accompany an invited talk at ECML'01. Sequential Inference: Conditional Models, Constraint Satisfaction},
-}
-
-@inproceedings{GargRo01,
-  author = {A. Garg and D. Roth},
-  title = {Understanding Probabilistic Classifiers},
-  booktitle = {Proc. of the European Conference on Machine Learning (ECML)},
-  pages = {179--191},
-  year = {2001},
-  acceptance = {90/240 (37.5\%)},
-  url = "http://cogcomp.org/papers/ecml01.pdf",
-  funding = {ITR-MIT ITR-BI CAREER NSF98},
-  projects = {DPL,LT},
-  comment = {An Information Theory based explanation of the good performance of naive Bayes},
-}
-
-@inproceedings{GargRo01a,
-  author = {A. Garg and D. Roth},
-  title = {Learning Coherent Concepts},
-  booktitle = {Proc. of the International Workshop on Algorithmic Learning Theory (ALT)},
-  pages = {135--150},
-  year = {2001},
-  publisher = {Springer-Verlag},
-  acceptance = {21/42 (50\%)},
-  url = "http://cogcomp.org/papers/alt01.pdf",
-  funding = {ITR-MIT ITR-BI CAREER},
-  projects = {LCC,LT},
-}
-
-@inproceedings{LiRo01,
-  author = {X. Li and D. Roth},
-  title = {Exploring Evidence for Shallow Parsing},
-  booktitle = {Proc. of the Conference on Computational Natural Language Learning (CoNLL)},
-  pages = {107--110},
-  year = {2001},
-  url = "http://cogcomp.org/papers/conll01.pdf",
-  funding = {ITR-MIT,NSF98,MURI},
-  projects = {LnI,SI,IE,NE,NLP},
-  comment = {Learning Shallow Parsers vs. Full Parsers for Chunking tasks},
-}
-
-@inproceedings{Even-ZoharRo01,
-  author = {Y. Even-Zohar and D. Roth},
-  title = {A Sequential Model for Multi Class Classification},
-  booktitle = {Proc. of the Conference on Empirical Methods in Natural Language Processing (EMNLP)},
-  pages = {10-19},
-  year = {2001},
-  acceptance = {21/65 (32\%)},
-  url = "http://cogcomp.org/papers/emnlp01.pdf",
-  funding = {ITR-MIT,NSF98,KDI},
-  projects = {MCR,LT,MC},
-  comment = {Multiclass classification: reducing the number of candidate classes; part-of-speech (POS) tagging},
-}
-
-@inproceedings{ChuangRo01a,
-  author = {J. Chuang and D. Roth},
-  title = {Gene Recognition based on DAG shortest paths},
-  booktitle = {Proc. of the International Conference on Intelligent Systems for Molecular Biology (ISMB)},
-  pages = {1--9},
-  year = {2001},
-  acceptance = {40/180 (22\%)},
-  url = "http://cogcomp.org/papers/ismb01.pdf",
-  funding = {NSF98,CAREER},
-  projects = {LnI,SI,LT},
-}
-
-@article{ChuangRo01,
-  author = {J. Chuang and D. Roth},
-  title = {Gene Recognition based on DAG shortest paths},
-  pages = {S56--S64},
-  month = {7},
-  year = {2001},
-  journal = {Bioinformatics},
-  volume = {17},
-  number = {1},
-  url = "http://cogcomp.org/papers/ismb01.pdf",
-  funding = {NSF98,CAREER},
-  projects = {LnI,SI,LT},
-}
-
-@inproceedings{CarlsonRoRo01,
-  author = {A. Carlson and J. Rosen and D. Roth},
-  title = {Scaling Up Context Sensitive Text Correction},
-  booktitle = {Proc. of the Conference on Innovative Applications of Artificial Intelligence (IAAI)},
-  pages = {45--50},
-  year = {2001},
-  acceptance = {12/37 (32\%)},
-  url = "http://cogcomp.org/papers/iaai01.pdf",
-  funding = {NSF98,CAREER,IBM},
-  projects = {LT,NLP},
-}
-
-@inproceedings{RKLNPRYAM01,
-  author = {D. Roth and G. Kao and X. Li and R. Nagarajan and V. Punyakanok and N. Rizzolo and W. Yih and C. Alm and L. G. Moran},
-  title = {Learning Components for a Question Answering System},
-  booktitle = {Proc. of the Text Retrieval Conference (TREC)},
-  pages = {539-548},
-  year = {2001},
-  url = "http://cogcomp.org/papers/trec01.pdf",
-  funding = {NSF98,MURI,ITR-MIT},
-  projects = {QA,TE},
-}
-
-@inproceedings{YangRoAh01,
-  author = {M. Yang and D. Roth and N. Ahuja},
-  title = {Face Detection Using Large Margin Classifiers},
-  booktitle = {Proc. of the IEEE International Conference on Image Processing (ICIP)},
-  pages = {665--668},
-  year = {2001},
-  url = "http://cogcomp.org/papers/YangRoAh01.pdf",
-  funding = {NSF98,ITR-MIT,CAREER},
-  projects = {LV,LT},
-}
-
-@techreport{RothYi01a,
-  author = {D. Roth and W. Yih},
-  title = {Propositionalization of Relational Learning: An Information Extraction Case Study},
-  month = {3},
-  year = {2001},
-  institution = {UIUC Computer Science Department},
-  number = {UIUCDCS-R-2001-2206},
-  url = "http://cogcomp.org/papers/RothYi01a.pdf",
-  funding = {NSF98,MURI,ITR-MIT},
-  projects = {KR,IE,NE},
-}
-
-@techreport{KhardonRoSe01a,
-  author = {R. Khardon and D. Roth and R. Servedio},
-  title = {Efficiency versus Convergence of Boolean Kernels for On-Line Learning Algorithm},
-  month = {6},
-  year = {2001},
-  institution = {UIUC Computer Science Department},
-  number = {UIUCDCS-R-2001-2233},
-  url = "http://cogcomp.org/papers/KhardonRoSe01a.pdf",
-  funding = {ITR-MIT,NSF98,CAREER},
-  projects = {KR,LT},
-  invisible = {true},
-}
-
-@article{GroveRo01,
-  author = {A. Grove and D. Roth},
-  title = {Linear concepts and hidden variables},
-  pages = {123--141},
-  year = {2001},
-  journal = {Machine Learning},
-  volume = {42},
-  number = {1/2},
-  url = "http://cogcomp.org/papers/hiddenJ.pdf",
-  funding = {NSF98,CAREER},
-  projects = {DPL,LT},
-}
-
-@techreport{GargRo01b,
-  author = {A. Garg and D. Roth},
-  title = {Understanding Probabilistic Classifiers},
-  month = {3},
-  year = {2001},
-  institution = {UIUC Computer Science Department},
-  number = {UIUCDCS-R-2001-2205},
-  url = "http://cogcomp.org/papers/GargRo01b.pdf",
-  funding = {ITR-MIT,ITR-BI,CAREER,NSF98},
-  projects = {DPL,LT},
-  invisible = {true},
-}
-
-@techreport{GargHaRo01,
-  author = {A. Garg and S. Har-Peled and D. Roth},
-  title = {Generalization Bounds for Linear Learning Algorithms},
-  month = {6},
-  year = {2001},
-  institution = {UIUC Computer Science Department},
-  number = {UIUCDCS-R-2001-2232},
-  url = "http://cogcomp.org/papers/GargHaRo01.pdf",
-  funding = {ITR-MIT,ITR-BI,CAREER},
-  projects = {LCC,LT},
-  invisible = {true},
-}
-
-@thesis{Cumby01,
-  author = {C. Cumby},
-  title = {Learning family relationships via propositional means},
-  month = {5},
-  year = {2001},
-  url = "http://cogcomp.org/papers/family.pdf",
-  funding = {NSF98,KDI},
-  projects = {KR,LT},
-  comment = {Senior Thesis, UIUC, Dept. of Computer Science},
-}
-
-@thesis{Carlson01,
-  author = {A. Carlson},
-  title = {Learning Based Programming - An Implementation},
-  booktitle = {UIUC Senior Thesis},
-  month = {5},
-  year = {2001},
-  url = {},
-  comment = {Senior Thesis, UIUC, Dept. of Computer Science},
-}
-
-@unpublished{AgarwalRo01,
-  author = {S. Agarwal and D. Roth},
-  title = {Detecting objects by learning relations over parts},
-  month = {6},
-  year = {2001},
-  institution = {UIUC Computer Science Department},
-  number = {UIUCDCS-R-2001-2231},
-  url = "http://cogcomp.org/papers/AgarwalRo01.pdf",
-  invisible = {true},
-}
-
-%%%%%%%%%%%%%%
-%%%  2000  %%%
-%%%%%%%%%%%%%%
-@inproceedings{RothZe00,
-  author = {D. Roth and D. Zelenko},
-  title = {Towards a theory of Coherent Concepts},
-  booktitle = {Proc. of the Conference on Artificial Intelligence (AAAI)},
-  pages = {639--644},
-  year = {2000},
-  acceptance = {141/430 (33\%)},
-  url = "http://cogcomp.org/papers/aaai00.pdf",
-}
-
-@inproceedings{KDDKKPR00,
-  author = {E. F. T. Kim-Sang and W. Daelemans and H. Dejean and R. Koeling and Y. Krymolowski and V. Punyakanok and D. Roth},
-  title = {Applying System Combination to Base Noun Phrase Identification},
-  booktitle = {Proc. of the International Conference on Computational Linguistics and Annual Meeting of the Association for Computational Linguistics (COLING-ACL)},
-  pages = {857--863},
-  year = {2000},
-  url = "http://cogcomp.org/papers/KDDKKPR00.pdf",
-  funding = {NSF98,KDI},
-}
-
-@inproceedings{Even-ZoharRo00,
-  author = {Y. Even-Zohar and D. Roth},
-  title = {A classification approach to word prediction},
-  booktitle = {Proc. of the Annual Conference of the North American Chapter of the Association for Computational Linguistics (NAACL)},
-  pages = {124-131},
-  year = {2000},
-  acceptance = {43/166 (26\%)},
-  url = "http://cogcomp.org/papers/naacl00.pdf",
-  funding = {NSF98,KDI},
-  projects = {LT,KR},
-  comment = {Learning with expressive features; dependency parse based features; verb prediction},
-}
-
-@inproceedings{CumbyRo00,
-  author = {C. Cumby and D. Roth},
-  title = {Relational Representations that facilitate learning},
-  booktitle = {Proc. of the International Conference on Principles of Knowledge Representation and Reasoning (KR)},
-  pages = {425--434},
-  year = {2000},
-  acceptance = {62/172 (36\%)},
-  url = "http://cogcomp.org/papers/kr00.pdf",
-  funding = {NSF98,KDI},
-  projects = {LT,KR},
-  comment = {FEX: feature extraction language; relational features; relational generation functions},
-}
-
-@inproceedings{Roth00,
-  author = {D. Roth},
-  title = {Learning in Natural Language: Theory and Algorithmic Approaches},
-  booktitle = {Proc. of the Conference on Computational Natural Language Learning (CoNLL)},
-  pages = {1--6},
-  year = {2000},
-  address = {Lisbon, Portugal},
-  url = "http://cogcomp.org/papers/lnlp-conll.pdf",
-  funding = {ITR-MIT,NSF98,KDI},
-  comment = {A paper written to accompany and invited talk at CoNLL.},
-}
-
-@inproceedings{YangRoAh00b,
-  author = {M. Yang and D. Roth and N. Ahuja},
-  title = {A SNoW-based Face Detector},
-  booktitle = {Proc. of the Conference on Neural Information Processing Systems (NIPS)},
-  pages = {855--861},
-  year = {2000},
-  publisher = {MIT Press},
-  acceptance = {151/467 (32\%)},
-  url = "http://cogcomp.org/papers/nips00.pdf",
-  funding = {NSF98},
-}
-
-@inproceedings{YangRoAh00a,
-  author = {M. Yang and D. Roth and N. Ahuja},
-  title = {Learning To Recognize 3D Objects With SNoW},
-  booktitle = {Proc. of the European Conference on Computer Vision (ECCV)},
-  month = {6},
-  year = {2000},
-  acceptance = {43/266 (16\%) Oral Presentations; 115/266 (43\%) overall},
-  url = "http://cogcomp.org/papers/YangRoAh00a.pdf",
-}
-
-@inproceedings{YangRoAh00,
-  author = {M. Yang and D. Roth and N. Ahuja},
-  title = {View-Based 3D Object Recognition Using SNoW},
-  booktitle = {Proc. of the Asian Conference on Computer Vision (ACCV)},
-  pages = {830--835},
-  month = {1},
-  year = {2000},
-  volume = {2},
-  acceptance = {172/268 (64\%)},
-  url = "http://cogcomp.org/papers/accv00.pdf",
-}
-
-@inproceedings{RothYaAh00,
-  author = {D. Roth and M. Yang and N. Ahuja},
-  title = {Learning to Recognize Objects},
-  booktitle = {Proc. of the IEEE Conference on Computer Vision and Pattern Recognition (CVPR)},
-  pages = {724--731},
-  year = {2000},
-  acceptance = {200/466 (43\%)},
-  url = "http://cogcomp.org/papers/cvpr00.pdf",
-  funding = {NSF98},
-}
-
-@techreport{Roth00a,
-  author = {D. Roth},
-  title = {Learning in Natural Language},
-  month = {7},
-  year = {2000},
-  institution = {UIUC Computer Science Department},
-  number = {UIUCDCS-R-2000-2180},
-  url = "http://cogcomp.org/papers/Roth00a.pdf",
-  invisible = {true},
-}
-
-@techreport{PunyakanokRo00a,
-  author = {V. Punyakanok and D. Roth},
-  title = {The Use of Classifiers in Sequential Inference},
-  month = {7},
-  year = {2000},
-  institution = {UIUC Computer Science Department},
-  number = {UIUCDCS-R-2000-2181},
-  url = "http://cogcomp.org/papers/PunyakanokRo00a.pdf",
-  invisible = {true},
-}
-
-@inproceedings{PunyakanokRo00,
-  author = {V. Punyakanok and D. Roth},
-  title = {Shallow Parsing by Inferencing with Classifiers},
-  booktitle = {Proc. of the Conference on Computational Natural Language Learning (CoNLL)},
-  pages = {107--110},
-  year = {2000},
-  url = "http://cogcomp.org/papers/PunyakanokRo00.pdf",
-  funding = {ITR-MIT NSF98},
-}
-
-@techreport{MengshoelRoWi00b,
-  author = {O. Mengshoel and D. Roth and D. Wilkins},
-  title = {Hard and Easy Bayesian Networks for Computing the Most Probable Explanation},
-  month = {1},
-  year = {2000},
-  institution = {UIUC Computer Science Department},
-  number = {UIUCDCS-R-2000-2147},
-  url = "http://cogcomp.org/papers/MengshoelRoWi00b.pdf",
-  invisible = {true},
-}
-
-%%%%%%%%%%%%%%
-%%%  1999  %%%
-%%%%%%%%%%%%%%
-@inproceedings{Roth99,
-  author = {D. Roth},
-  title = {Learning in Natural Language},
-  booktitle = {Proc. of the International Joint Conference on Artificial Intelligence (IJCAI)},
-  pages = {898--904},
-  year = {1999},
-  acceptance = {195/760 (26\%)},
-  url = "http://cogcomp.org/papers/ijcai99r.pdf",
-  funding = {NSF98 KDI},
-  projects = {LT,DPL},
-  comment = {Probabilistic classifiers (Naive Bayes; HMM) as linear models; generative vs. discriminative; Best Paper Award},
-}
-
-@inproceedings{MPRZ99a,
-  author = {M. Munoz and V. Punyakanok and D. Roth and D. Zimak},
-  title = {A Learning Approach to Shallow Parsing},
-  booktitle = {Proc. of the Joint Conference on Empirical Methods in Natural Language Processing and Very Large Corpora (EMNLP-VLC)},
-  pages = {168--178},
-  month = {6},
-  year = {1999},
-  url = "http://cogcomp.org/papers/shallow-long.pdf",
-  funding = {NSF98 KDI},
-  projects = {LnI,SI,NLP},
-}
-
-@inproceedings{KhardonRoVa99,
-  author = {R. Khardon and D. Roth and L. G. Valiant},
-  title = {Relational Learning for NLP using Linear Threshold Elements},
-  booktitle = {Proc. of the International Joint Conference on Artificial Intelligence (IJCAI)},
-  pages = {911--917},
-  year = {1999},
-  acceptance = {195/750 (26\%)},
-  url = "http://cogcomp.org/papers/ijcai99krv.pdf",
-  funding = {NSF98 KDI},
-  projects = {KR,LT,NLP},
-}
-
-@article{KhardonRo99,
-  author = {R. Khardon and D. Roth},
-  title = {Learning to Reason with a Restricted View},
-  pages = {95--117},
-  year = {1999},
-  journal = {Machine Learning},
-  volume = {35},
-  number = {2},
-  url = "http://cogcomp.org/papers/partialJ.pdf",
-}
-
-@article{KhardonMaRo99,
-  author = {R. Khardon and H. Mannila and D. Roth},
-  title = {Reasoning with Examples: Propositional Formulae and Database Dependencies},
-  pages = {267--286},
-  month = {7},
-  year = {1999},
-  journal = {Acta Informatica},
-  volume = {36},
-  number = {4},
-  url = "http://cogcomp.org/papers/db.pdf",
-}
-
-@article{GoldingRo99,
-  author = {A. R. Golding and D. Roth},
-  title = {A Winnow based approach to Context-Sensitive Spelling Correction},
-  pages = {107--130},
-  year = {1999},
-  journal = {Machine Learning},
-  volume = {34},
-  number = {1-3},
-  url = "http://cogcomp.org/papers/spellJ.pdf",
-  funding = {NSF98 KDI},
-  projects = {KR,LT,NLP},
-  comment = {Special Issue on Machine Learning and Natural Language.},
-}
-
-@incollection{RothZe99,
-  author = {D. Roth and D. Zelenko},
-  title = {Coherent Concepts, Robust Learning Invited},
-  booktitle = {Proc. of the Conference on Current Trends in Theory and Practice of Informatics (SOFSEM)},
-  pages = {260--272},
-  year = {1999},
-  publisher = {Springer-verlag},
-  editor = {J. Pavelka and G. Tel and  M. Bartosek},
-  url = "http://cogcomp.org/papers/RothZe99.pdf",
-  comment = {Lecture notes in Artificial Intelligence, vol. 1725},
-}
-
-@techreport{Roth99c,
-  author = {D. Roth},
-  title = {Learning Based Programming},
-  month = {10},
-  year = {1999},
-  institution = {UIUC Computer Science Department},
-  number = {UIUCDCS-R-99-2127},
-  url = "http://cogcomp.org/papers/Roth99c.pdf",
-}
-
-@techreport{Roth99b,
-  author = {D. Roth},
-  title = {Relational Knowledge Representations that Facilitate Learning},
-  month = {10},
-  year = {1999},
-  institution = {UIUC Computer Science Department},
-  number = {UIUCDCS-R-99-2126},
-  url = "http://cogcomp.org/papers/Roth99b.pdf",
-  invisible = {true},
-}
-
-@techreport{Roth99a,
-  author = {D. Roth},
-  title = {Memory Based Learning in NLP},
-  month = {3},
-  year = {1999},
-  institution = {UIUC Computer Science Department},
-  number = {UIUCDCS-R-99-2125},
-  url = "http://cogcomp.org/papers/mbl.pdf",
-}
-
-@article{MavronicolasRo99,
-  author = {M. Mavronicolas and D. Roth},
-  title = {Linearizable Read/Write Objects},
-  pages = {267--319},
-  month = {6},
-  year = {1999},
-  journal = {Theoretical Computer Science},
-  volume = {220},
-  number = {1},
-  url = "http://cogcomp.org/papers/linearJ.pdf",
-}
-
-@techreport{MPRZ99b,
-  author = {M. Munoz and V. Punyakanok and D. Roth and D. Zimak},
-  title = {A Learning Approach to Shallow Parsing},
-  month = {4},
-  year = {1999},
-  institution = {UIUC Computer Science Department},
-  number = {UIUCDCS-R-99-2087},
-  url = "http://cogcomp.org/papers/MPRZ99b.pdf",
-  invisible = {true},
-}
-
-@inproceedings{Even-ZoharRoZe99,
-  author = {Y. Even-Zohar and D. Roth and D. Zelenko},
-  title = {Word Clustering via Classification},
-  booktitle = {Proc. of the Bar-Ilan Symposium on Foundations of Artificial Intelligence (BISFAI)},
-  year = {1999},
-  address = {Bar-Ilan, Israel},
-  acceptance = {78/160 (48\%)},
-  url = "http://cogcomp.org/papers/Even-ZoharRoZe99.pdf",
-  funding = {NSF98,KDI},
-}
-
-@techreport{CCRR99,
-  author = {A. Carlson and C. Cumby and J. Rosen and D. Roth},
-  title = {The SNoW Learning Architecture},
-  month = {5},
-  year = {1999},
-  institution = {UIUC Computer Science Department},
-  number = {UIUCDCS-R-99-2101},
-  url = "http://cogcomp.org/papers/CCRR99.pdf",
-}
-
-%%%%%%%%%%%%%%
-%%%  1998  %%%
-%%%%%%%%%%%%%%
-@inproceedings{RothZe98,
-  author = {D. Roth and D. Zelenko},
-  title = {Part of Speech Tagging Using a Network of Linear Separators},
-  booktitle = {Coling-Acl, The 17th International Conference on Computational Linguistics},
-  pages = {1136--1142},
-  year = {1998},
-  acceptance = {137/550 (25\%)},
-  url = "http://cogcomp.org/papers/pos.pdf",
-  funding = {NSF98,KDI},
-  projects = {SI,NLP},
-}
-
-@inproceedings{Roth98,
-  author = {D. Roth},
-  title = {Learning to Resolve Natural Language Ambiguities: A Unified Approach},
-  booktitle = {Proc. of the Conference on Artificial Intelligence (AAAI)},
-  pages = {806--813},
-  year = {1998},
-  acceptance = {143/475 (30\%)},
-  url = "http://cogcomp.org/papers/aaai98.pdf",
-  funding = {NSF98,KDI},
-  projects = {DPL,NLP},
-  comment = {Many Natural Language Classifiers are Linear; including probabilistic classifiers; argues for a discriminative approach; SNoW},
-}
-
-@article{Roth98a,
-  author = {D. Roth},
-  title = {Learning and Reasoning with Connectionist Representations},
-  booktitle = {Neural Computing Surveys},
-  pages = {1--40},
-  year = {1998},
-  publisher = {Lawrence Erlbaum Associates},
-  editor = {A. Jagota, T. Plate, L. Shastri, R. Sun},
-  url = "http://cogcomp.org/papers/Roth98a.pdf",
-  comment = {A contribution to ``Connectionist Symbol Processing: Dead or Alive''},
-}
-
-@workshop{KrymolowskiRo98,
-  author = {Y. Krymolowski and D. Roth},
-  title = {Incorporating Knowledge in Natural Language Learning: A Case Study},
-  booktitle = {Coling-Acl workshop on the Usage of WordNet in Natural Language Processing Systems},
-  pages = {121--127},
-  year = {1998},
-  url = "http://cogcomp.org/papers/pp-wn.pdf",
-  funding = {NSF98,KDI},
-  projects = {NLP},
-  comment = {Prepositional Phrase Attachment (PPA); using WordNet to generate expressive features.},
-}
-
-@inproceedings{GroveRo98,
-  author = {A. Grove and D. Roth},
-  title = {Linear concepts and hidden variables: An empirical study},
-  booktitle = {Proc. of the Conference on Neural Information Processing Systems (NIPS)},
-  pages = {500--506},
-  year = {1998},
-  publisher = {MIT Press},
-  acceptance = {150/491 (30\%)},
-  url = "http://cogcomp.org/papers/nips98.pdf",
-  comment = {Margin Winnow (Perceptron); discriminative vs. generative},
-}
-
-@inproceedings{BasriRoJa98,
-  author = {R. Basari and D. Roth and D. Jacobs},
-  title = {Clustering Appearances of 3D Objects},
-  booktitle = {Proc. of the IEEE Conference on Computer Vision and Pattern Recognition (CVPR)},
-  pages = {414-420},
-  year = {1998},
-  acceptance = {136/450 (30\%)},
-  url = "http://cogcomp.org/papers/cvpr98.pdf",
-  comment = {Clustering of Curves},
-}
-
-@article{ABKKPR98,
-  author = {H. Aizenstein and A. Blum and R. Khardon and A. Kushilevitz and L. Pitt and D. Roth},
-  title = {On learning read-k satisfy-j DNF},
-  pages = {1515--1530},
-  month = {7},
-  year = {1998},
-  journal = {SIAM Journal of Computing},
-  volume = {27},
-  number = {6},
-  url = "http://cogcomp.org/papers/rksjJ.pdf",
-}
-
-%%%%%%%%%%%%%%
-%%%  1997  %%%
-%%%%%%%%%%%%%%
-@incollection{Roth97,
-  author = {D. Roth},
-  title = {Learning to perform knowledge intensive inferences Invited Abstract},
-  booktitle = {Proc. of the International Symposium on the Mathematical Foundations of Computer Science (MFCS)},
-  pages = {108--109},
-  year = {1997},
-  publisher = {Springer-verlag},
-  editor = {I. Privara  and P. Ruzicka},
-  url = {},
-  comment = {Lecture notes in Computer Science (LNCS) 1295},
-}
-
-@article{KhardonRo97a,
-  author = {R. Khardon and D. Roth},
-  title = {Defaults and Relevance in Model Based Reasoning},
-  pages = {169--193},
-  month = {12},
-  year = {1997},
-  journal = {Artificial Intelligence},
-  volume = {97},
-  number = {1-2},
-  url = "http://cogcomp.org/papers/relevanceJ.pdf",
-}
-
-@article{KhardonRo97,
-  author = {R. Khardon and D. Roth},
-  title = {Learning to Reason},
-  pages = {697--725},
-  year = {1997},
-  journal = {Journal of the ACM},
-  volume = {44},
-  number = {5},
-  url = "http://cogcomp.org/papers/l2rJ.pdf",
-}
-
-@article{DanielsMiRo97,
-  author = {K. Daniels and V. J. Milenkovic and D. Roth},
-  title = {Finding the Maximum Area Axis-Parallel Rectangle in a Polygon},
-  pages = {125--148},
-  month = {1},
-  year = {1997},
-  journal = {Computational Geometry: Theory and Applications},
-  volume = {7},
-  number = {1-2},
-  url = "http://cogcomp.org/papers/maaprJ.pdf",
-}
-
-@inproceedings{DaganKaRo97,
-  author = {I. Dagan and Y. Karov and D. Roth},
-  title = {Mistake-Driven Learning in Text Categorization},
-  booktitle = {Proc. of the Conference on Empirical Methods in Natural Language Processing (EMNLP)},
-  pages = {55-63},
-  month = {8},
-  year = {1997},
-  url = "http://cogcomp.org/papers/DaganKaRo97.pdf",
-}
-
-%%%%%%%%%%%%%%
-%%%  1996  %%%
-%%%%%%%%%%%%%%
-@article{Roth96,
-  author = {D. Roth},
-  title = {On the hardness of approximate reasoning},
-  pages = {273--302},
-  month = {4},
-  year = {1996},
-  journal = {Artificial Intelligence},
-  volume = {82},
-  number = {1-2},
-  url = "http://cogcomp.org/papers/hardJ.pdf",
-  comment = {Hardness of Reasoning with Bayesian Networks; Exact inference is #P-Complete; Approximate Reasoning is NP-Hard.},
-}
-
-@article{KushilevitzRo96,
-  author = {A. Kushilevitz and D. Roth},
-  title = {On Learning Visual Concepts and DNF Formulae},
-  pages = {65--85},
-  year = {1996},
-  journal = {Machine Learning},
-  volume = {24},
-  number = {1},
-  url = "http://cogcomp.org/papers/visualJ.pdf",
-}
-
-@article{KhardonRo96,
-  author = {R. Khardon and D. Roth},
-  title = {Reasoning with Models},
-  pages = {187--213},
-  year = {1996},
-  journal = {Artificial Intelligence},
-  volume = {87},
-  number = {1-2},
-  url = "http://cogcomp.org/papers/modelsJ.pdf",
-  comment = {Characteristic Models of Boolean Functions},
-}
-
-@inproceedings{GreinerGrRo96,
-  author = {R. Greiner and A. Grove and D. Roth},
-  title = {Learning Active Classifiers},
-  booktitle = {Proc. of the International Conference on Machine Learning (ICML)},
-  pages = {207--215},
-  year = {1996},
-  acceptance = {63/257 (24\%)},
-  url = "http://cogcomp.org/papers/active.pdf",
-}
-
-@inproceedings{GoldingRo96,
-  author = {A. R. Golding and D. Roth},
-  title = {Applying Winnow to Context-Sensitive Spelling Correction},
-  booktitle = {Proc. of the International Conference on Machine Learning (ICML)},
-  pages = {182--190},
-  year = {1996},
-  acceptance = {63/257 (24\%)},
-  url = "http://cogcomp.org/papers/spell.pdf",
-}
-
-@inproceedings{Roth96d,
-  author = {D. Roth},
-  title = {Learning in Order to Reason Invited},
-  booktitle = {Proc. of the AAAI Fall Symposium on Learning Complex Behaviors in Adaptive Intelligent Systems},
-  pages = {46--52},
-  year = {1996},
-  url = "http://cogcomp.org/papers/approach.pdf",
-}
-
-@incollection{Roth96c,
-  author = {D. Roth},
-  title = {Learning in Order to Reason: The Approach},
-  booktitle = {Proc. of the Conference on Current Trends in Theory and Practice of Informatics (SOFSEM)},
-  pages = {113--124},
-  year = {1996},
-  publisher = {Springer-verlag},
-  editor = {K. G. Jeffery and J. Kral and M. Bartosek},
-  url = "http://cogcomp.org/papers/approach.pdf",
-  comment = {Lecture notes in Computer Science, vol. 1175},
-}
-
-@inproceedings{Roth96b,
-  author = {D. Roth},
-  title = {On the hardness of approximate reasoning},
-  booktitle = {Proc. of the AAAI Fall Symposium on AI and NP Hard Problems},
-  pages = {137-143},
-  year = {1996},
-  url = "http://cogcomp.org/papers/hardJ.pdf",
-}
-
-@inproceedings{Roth96a,
-  author = {D. Roth},
-  title = {A Connectionist Framework for Reasoning: Reasoning with Examples},
-  booktitle = {Proc. of the Conference on Artificial Intelligence (AAAI)},
-  pages = {1256--1261},
-  year = {1996},
-  acceptance = {197/640 (31\%)},
-  url = "http://cogcomp.org/papers/nreason.pdf",
-}
-
-%%%%%%%%%%%%%%
-%%%  1995  %%%
-%%%%%%%%%%%%%%
-@inproceedings{Roth95,
-  author = {D. Roth},
-  title = {Learning to Reason: The Non-Monotonic Case},
-  booktitle = {Proc. of the International Joint Conference on Artificial Intelligence (IJCAI)},
-  pages = {1178--1184},
-  month = {8},
-  year = {1995},
-  acceptance = {249/1112 (22\%)},
-  url = "http://cogcomp.org/papers/nonmon.pdf",
-}
-
-@techreport{KhardonRo95b,
-  author = {R. Khardon and D. Roth},
-  title = {Defaults and Relevance in Model Based Reasoning},
-  month = {10},
-  year = {1995},
-  institution = {Dept. of App. Math. and Computer Science, Weizmann Institute of Science},
-  number = {CS95-30},
-  url = "http://cogcomp.org/papers/KhardonRo95b.pdf",
-}
-
-@inproceedings{KhardonRo95a,
-  author = {R. Khardon and D. Roth},
-  title = {Learning to Reason with a Restricted View},
-  booktitle = {Proc. of the ACM Conference on Computational Learning Theory (COLT)},
-  pages = {301--310},
-  month = {7},
-  year = {1995},
-  acceptance = {24/74 (32\%)},
-  url = {},
-}
-
-@inproceedings{KhardonRo95,
-  author = {R. Khardon and D. Roth},
-  title = {Default-Reasoning with Models},
-  booktitle = {Proc. of the International Joint Conference on Artificial Intelligence (IJCAI)},
-  pages = {319--325},
-  month = {8},
-  year = {1995},
-  acceptance = {249/112 (22\%)},
-  url = {},
-}
-
-%%%%%%%%%%%%%%
-%%%  1994  %%%
-%%%%%%%%%%%%%%
-@inproceedings{KhardonRo94e,
-  author = {R. Khardon and D. Roth},
-  title = {A note on Horn Theories},
-  year = {1994},
-  url = {},
-  comment = {Manuscript.},
-}
-
-@techreport{KhardonRo94d,
-  author = {R. Khardon and D. Roth},
-  title = {Learning to Reason},
-  month = {1},
-  year = {1994},
-  institution = {Aiken Computation Lab., Harvard University},
-  number = {TR-2-94},
-  url = {},
-  invisible = {true},
-}
-
-@techreport{KhardonRo94c,
-  author = {R. Khardon and D. Roth},
-  title = {Reasoning with Models},
-  month = {1},
-  year = {1994},
-  institution = {Aiken Computation Lab., Harvard University},
-  number = {TR-1-94},
-  url = {},
-  invisible = {true},
-}
-
-@inproceedings{KhardonRo94b,
-  author = {R. Khardon and D. Roth},
-  title = {Exploiting Relevance through Model-based reasoning},
-  booktitle = {Proc. of the AAAI Fall Symposium on Relevance},
-  pages = {109-114},
-  year = {1994},
-  url = "http://cogcomp.org/papers/relevanceP.pdf",
-}
-
-@inproceedings{KhardonRo94a,
-  author = {R. Khardon and D. Roth},
-  title = {Learning to Reason},
-  booktitle = {Proc. of the Conference on Artificial Intelligence (AAAI)},
-  pages = {682--687},
-  year = {1994},
-  acceptance = {222/725 (31\%)},
-  url = "http://cogcomp.org/papers/KhardonRo94a.pdf",
-}
-
-@inproceedings{KhardonRo94,
-  author = {R. Khardon and D. Roth},
-  title = {Reasoning with Models},
-  booktitle = {Proc. of the Conference on Artificial Intelligence (AAAI)},
-  pages = {1148--1153},
-  year = {1994},
-  acceptance = {225/725 (31\%)},
-  url = "http://cogcomp.org/papers/KhardonRo94.pdf",
-}
-
-@inproceedings{BKKPR94,
-  author = {A. Blum and R. Khardon and A. Kushilevitz and L. Pitt and D. Roth},
-  title = {On learning read-k satisfy-j DNF},
-  booktitle = {Proc. of the ACM Conference on Computational Learning Theory (COLT)},
-  pages = {110--117},
-  year = {1994},
-  url = "http://cogcomp.org/papers/BKKPR94.pdf",
-}
-
-%%%%%%%%%%%%%%
-%%%  1993  %%%
-%%%%%%%%%%%%%%
-@inproceedings{Roth93,
-  author = {D. Roth},
-  title = {On the hardness of approximate reasoning},
-  booktitle = {Proc. of the International Joint Conference on Artificial Intelligence (IJCAI)},
-  pages = {613--618},
-  month = {8},
-  year = {1993},
-  acceptance = {220/876 (25\%)},
-  url = {},
-  comment = {Hardness of Reasoning with Bayesian Networks; Exact inference is #P-Complete; Approximate Reasoning is NP-Hard.},
-}
-
-@inproceedings{KushilevitzRo93,
-  author = {A. Kushilevitz and D. Roth},
-  title = {On Learning Visual Concepts and DNF Formulae},
-  booktitle = {Proc. of the ACM Conference on Computational Learning Theory (COLT)},
-  pages = {317--326},
-  year = {1993},
-  url = {},
-  comment = {30/83 (37%)},
-}
-
-@inproceedings{DanielsMiRo93,
-  author = {K. Daniels and V. J. Milenkovic and D. Roth},
-  title = {Finding the Maximum Area Axis-Parallel Rectangle in a Simple Polygon},
-  booktitle = {Proc. of the Canadian Conference on Computational Geometry (CCCG)},
-  pages = {322--327},
-  year = {1993},
-  url = {},
-}
-
-%%%%%%%%%%%%%%
-%%%  1992  %%%
-%%%%%%%%%%%%%%
-@inproceedings{MavronicolasRo92,
-  author = {M. Mavronicolas and D. Roth},
-  title = {Efficient, Strongly Consistent Implementation of Shared Memory},
-  booktitle = {Proc. of the Workshop on Distributed Algorithms (WDAG)},
-  pages = {346--361},
-  year = {1992},
-  acceptance = {24/38 (63\%)},
-  url = "http://cogcomp.org/papers/wdagP.pdf",
-}
-
-%%%%%%%%%%%%%%
-%%%  1991  %%%
-%%%%%%%%%%%%%%
-@inproceedings{MavronicolasRo91,
-  author = {M. Mavronicolas and D. Roth},
-  title = {Sequential Consistency and Linearizability: Read/Write Objects},
-  booktitle = {Proc. of the Allerton Conference on Communications, Control and Computing},
-  pages = {683--692},
-  year = {1991},
-  acceptance = {32/77 (42\%)},
-  url = {},
-}
-
-%%%%%%%%%%%%%%
-%%%  0  %%%
-%%%%%%%%%%%%%%
-{,
-  year = {0},
-  url = "http://cogcomp.org/papers/Resume.pdf",
+@string{MIT = {MIT Press}}
+@Article{AgarwalAwRo04,
+  Title                    = {Learning to Detect Objects in Images via a Sparse, Part-Based Representation},
+  Author                   = {S. Agarwal and A. Awan and D. Roth},
+  Journal                  = {IEEE Transactions on Pattern Analysis and Machine Intelligence},
+  Year                     = {2004},
+  Number                   = {11},
+  Pages                    = {1475--1490},
+  Volume                   = {20},
+
+  Funding                  = {CAREER,ITR-MIT},
+  Projects                 = {LV,KR},
+  Url                      = {http://cogcomp.org/papers/AgarwalAwRo04.pdf}
+}
+
+@Article{AGHHR05,
+  Title                    = {Generalization Bounds for the Area Under the ROC Curve},
+  Author                   = {S. Agarwal and T. Graepel and R. Herbrich and S. Har-Peled and D. Roth},
+  Journal                  = {Journal of Machine Learning Research},
+  Year                     = {2005},
+  Pages                    = {393--425},
+  Volume                   = {6},
+
+  Funding                  = {ITR-BI,ITR-MIT,TRECC},
+  Projects                 = {LT,RANK},
+  Url                      = {http://cogcomp.org/papers/AgarwalGrHeHaRo05.pdf}
+}
+
+@InProceedings{AGHR05,
+  Title                    = {A Large Deviation Bound for the Area Under the ROC Curve},
+  Author                   = {S. Agarwal and T. Graepel and R. Herbrich and D. Roth},
+  Booktitle                = {Proc. of the Conference on Neural Information Processing Systems (NIPS)},
+  Year                     = {2005},
+  Pages                    = {9--16},
+
+  Acceptance               = {207/823 (25\%)},
+  Comment                  = {Bipartite Ranking: bounding the expected accuracy of a ranking function in terms of its empirical AUC.},
+  Funding                  = {ITR-BI,ITR-MIT,TRECC},
+  Projects                 = {LT,RANK},
+  Url                      = {http://cogcomp.org/papers/AgarwalGrHeRo05.pdf}
+}
+
+@InProceedings{AgarwalHaRo05,
+  Title                    = {A Uniform Convergence Bound for the Area Under the ROC Curve},
+  Author                   = {S. Agarwal and S. Har-Peled and D. Roth},
+  Booktitle                = {Proc. of the International Workshop on Artificial Intelligence and Statistics (AISTATS)},
+  Year                     = {2005},
+  Pages                    = {1-8},
+
+  Acceptance               = {51/150 (34\%)},
+  Comment                  = {Bipartite Ranking: uniform convergence properties of the AUC in terms of bipartite rank-shatter coefficients.},
+  Funding                  = {ITR-BI,ITR-MIT,TRECC},
+  Projects                 = {LT,RANK},
+  Url                      = {http://cogcomp.org/papers/AgarwalHaRo05.pdf}
+}
+
+@InProceedings{AgarwalRo05,
+  Title                    = {Learnability of Bipartite Ranking Functions},
+  Author                   = {S. Agarwal and D. Roth},
+  Booktitle                = {Proc. of the ACM Conference on Computational Learning Theory (COLT)},
+  Year                     = {2005},
+  Pages                    = {16--31},
+
+  Acceptance               = {45/119 (37.8\%)},
+  Funding                  = {ITR-BI,ITR-MIT,TRECC},
+  Projects                 = {LT,RANK},
+  Url                      = {http://cogcomp.org/papers/Agarwalro05.pdf}
+}
+
+@TechReport{AgarwalRo03,
+  Title                    = {Minimum Risk Feature Transformations},
+  Author                   = {S. Agarwal and D. Roth},
+  Institution              = {UIUC Computer Science Department},
+  Year                     = {2003},
+  Month                    = {12},
+  Number                   = {UIUCDCS-R-2003-2627},
+
+  Comment                  = {UIUC Tech Report UIUCDCS-R-2003-2627. A preliminary framework for Feature Generation},
+  Url                      = {http://cogcomp.org/papers/AgarwalRo03.pdf}
+}
+
+@InProceedings{AgarwalRo02,
+  Title                    = {Learning a Sparse Representation for Object Detection},
+  Author                   = {S. Agarwal and D. Roth},
+  Booktitle                = {Proc. of the European Conference on Computer Vision (ECCV)},
+  Year                     = {2002},
+  Pages                    = {113--128},
+
+  Acceptance               = {45/600 (7.5\%) Oral Presentations; 225/600 (37\%) overall},
+  Funding                  = {MURI,SBC-MIT,CAREER},
+  Projects                 = {LV,KR},
+  Url                      = {http://cogcomp.org/papers/AgarwalRo02.pdf}
+}
+
+@Unpublished{AgarwalRo01,
+  Title                    = {Detecting objects by learning relations over parts},
+  Author                   = {S. Agarwal and D. Roth},
+
+  Month                    = {6},
+  Year                     = {2001},
+
+  Institution              = {UIUC Computer Science Department},
+  Invisible                = {true},
+  Number                   = {UIUCDCS-R-2001-2231},
+  Url                      = {http://cogcomp.org/papers/AgarwalRo01.pdf}
+}
+
+@Article{ABKKPR98,
+  Title                    = {On learning read-k satisfy-j DNF},
+  Author                   = {H. Aizenstein and A. Blum and R. Khardon and A. Kushilevitz and L. Pitt and D. Roth},
+  Journal                  = {SIAM Journal of Computing},
+  Year                     = {1998},
+
+  Month                    = {7},
+  Number                   = {6},
+  Pages                    = {1515--1530},
+  Volume                   = {27},
+
+  Url                      = {http://cogcomp.org/papers/rksjJ.pdf}
+}
+
+@Other{Alm08,
+  Title                    = {Affect in Text and Speech},
+  Author                   = {C. Alm},
+  Booktitle                = {UIUC PhD Thesis},
+  Url                      = {http://cogcomp.org/papers/Alm thesis(1).pdf},
+  Year                     = {2008}
+}
+
+@InProceedings{AlmRoSp05,
+  Title                    = {Emotions from text: machine learning for text-based emotion prediction.},
+  Author                   = {C. Alm and D. Roth and R. Sproat},
+  Booktitle                = {Proc. of the Conference on Empirical Methods in Natural Language Processing (EMNLP)},
+  Year                     = {2005},
+
+  Funding                  = {ITR-EDU},
+  Url                      = {http://cogcomp.org/papers/AlmRoSp05.pdf}
+}
+
+@InProceedings{ArivazhaganChRo16,
+  Title                    = {Labeling the Semantic Roles of Commas},
+  Author                   = {Naveen Arivazhagan and Christos Christodoulopoulos and Dan Roth},
+  Booktitle                = {Proc. of the Conference on Artificial Intelligence (AAAI)},
+  Year                     = {2016},
+  Month                    = {2},
+
+  Projects                 = {DEFT},
+  Url                      = {http://cogcomp.org/papers/ArivazhaganChRo16.pdf}
+}
+
+@InProceedings{BasariRoJa98,
+  Title                    = {Clustering Appearances of 3D Objects},
+  Author                   = {R. Basari and D. Roth and D. Jacobs},
+  Booktitle                = {Proc. of the IEEE Conference on Computer Vision and Pattern Recognition (CVPR)},
+  Year                     = {1998},
+  Pages                    = {414-420},
+
+  Acceptance               = {136/450 (30\%)},
+  Comment                  = {Clustering of Curves},
+  Url                      = {http://cogcomp.org/papers/cvpr98.pdf}
+}
+
+@InProceedings{BengtsonRo08,
+  Title                    = {Understanding the Value of Features for Coreference Resolution},
+  Author                   = {E. Bengtson and D. Roth},
+  Booktitle                = {Proc. of the Conference on Empirical Methods in Natural Language Processing (EMNLP)},
+  Year                     = {2008},
+  Month                    = {10},
+
+  Comment                  = {The importance of good features for coreference resolution},
+  Funding                  = {Boeing,SoD},
+  Projects                 = {COREF,TE},
+  Url                      = {http://cogcomp.org/papers/BengtsonRo08.pdf}
+}
+
+@InProceedings{BKKPR94,
+  Title                    = {On learning read-k satisfy-j DNF},
+  Author                   = {A. Blum and R. Khardon and A. Kushilevitz and L. Pitt and D. Roth},
+  Booktitle                = {Proc. of the ACM Conference on Computational Learning Theory (COLT)},
+  Year                     = {1994},
+  Pages                    = {110--117},
+
+  Url                      = {http://cogcomp.org/papers/BKKPR94.pdf}
+}
+
+@Article{BBCRWZ14,
+  Title                    = {Introduction to the special issue on learning semantics},
+  Author                   = {Antoine Bordes and L�on Bottou and Ronan Collobert and Dan Roth and Jason Weston and Luke Zettlemoyer},
+  Journal                  = {Machine Learning},
+  Year                     = {2014},
+
+  Month                    = {2},
+  Number                   = {2},
+  Pages                    = {127-131},
+  Volume                   = {94},
+
+  Publisher                = {Springer},
+  Url                      = {http://cogcomp.org/papers/BBCRWZ14.pdf}
+}
+
+@InProceedings{BurgardCh11,
+  Title                    = {Proceedings of the 25th AAAI Conference on Artificial Intelligence},
+  Author                   = {W. Burgard and D. Roth Program Chairs},
+  Booktitle                = {Proc. of the Conference on Artificial Intelligence (AAAI)},
+  Year                     = {2011},
+  Editor                   = {W. Burgard and D. Roth}
+}
+
+@Other{Carlson01,
+  Title                    = {Learning Based Programming - An Implementation},
+  Author                   = {A. Carlson},
+  Booktitle                = {UIUC Senior Thesis},
+  Comment                  = {Senior Thesis, UIUC, Dept. of Computer Science},
+  Month                    = {5},
+  Year                     = {2001}
+}
+
+@TechReport{CCRR99,
+  Title                    = {The SNoW Learning Architecture},
+  Author                   = {A. Carlson and C. Cumby and J. Rosen and D. Roth},
+  Institution              = {UIUC Computer Science Department},
+  Year                     = {1999},
+  Month                    = {5},
+  Number                   = {UIUCDCS-R-99-2101},
+
+  Url                      = {http://cogcomp.org/papers/CCRR99.pdf}
+}
+
+@InProceedings{CarlsonRoRo01,
+  Title                    = {Scaling Up Context Sensitive Text Correction},
+  Author                   = {A. Carlson and J. Rosen and D. Roth},
+  Booktitle                = {Proc. of the Conference on Innovative Applications of Artificial Intelligence (IAAI)},
+  Year                     = {2001},
+  Pages                    = {45--50},
+
+  Acceptance               = {12/37 (32\%)},
+  Funding                  = {NSF98,CAREER,IBM},
+  Projects                 = {LT,NLP},
+  Url                      = {http://cogcomp.org/papers/iaai01.pdf}
+}
+
+@InProceedings{CMPR02,
+  Title                    = {Learning and Inference for Clause Identification},
+  Author                   = {X. Carreras and L. Marquez and V. Punyakanok and D. Roth},
+  Booktitle                = {Proc. of the European Conference on Machine Learning (ECML)},
+  Year                     = {2002},
+  Pages                    = {35--47},
+
+  Acceptance               = {80/218 (37\%)},
+  Comment                  = {Shallow Parsing; Chunking and Clause identification.},
+  Funding                  = {MURI,SBC-MIT,CAREER},
+  Projects                 = {LnI,SI,IE},
+  Url                      = {http://cogcomp.org/papers/ecml02.pdf}
+}
+
+@InProceedings{ChanRo11,
+  Title                    = {Exploiting Syntactico-Semantic Structures for Relation Extraction},
+  Author                   = {Y. Chan and D. Roth},
+  Booktitle                = {Proc. of the Annual Meeting of the Association for Computational Linguistics (ACL)},
+  Year                     = {2011},
+
+  Address                  = {Portland, Oregon},
+
+  Funding                  = {MR},
+  Projects                 = {NLP, IE},
+  Url                      = {http://cogcomp.org/papers/ChanRo11.pdf}
+}
+
+@InProceedings{ChanRo10,
+  Title                    = {Exploiting Background Knowledge for Relation Extraction},
+  Author                   = {Y. Chan and D. Roth},
+  Booktitle                = {Proc. of the International Conference on Computational Linguistics (COLING)},
+  Year                     = {2010},
+
+  Address                  = {Beijing, China},
+  Month                    = {8},
+
+  Comment                  = {Relation extraction, background knowledge, constraints, information extraction},
+  Funding                  = {MR},
+  Projects                 = {NLP, IE},
+  Url                      = {http://cogcomp.org/papers/ChanRo10.pdf}
+}
+
+@Other{Chang15,
+  Title                    = {Selective Algorithms for Large-Scale Classification and Structured Learning},
+  Author                   = {Kai-Wei Chang},
+  Booktitle                = {UIUC PhD Thesis},
+  Url                      = {http://cogcomp.org/papers/Chang15.pdf},
+  Year                     = {2015}
+}
+
+@InProceedings{CDHR12,
+  Title                    = {Efficient Pattern-Based Time Series Classification on GPU },
+  Author                   = {Kai-Wei Chang and Biplab Deka and Wen-Mei W. Hwu and Dan Roth},
+  Booktitle                = {Proc. of the IEEE International Conference on Data Mining (ICDM)},
+  Year                     = {2012},
+
+  Acceptance               = {10.7\%},
+  Funding                  = {MR, BL},
+  Url                      = {http://cogcomp.org/papers/undefined.pdf}
+}
+
+@InProceedings{ChangRo11,
+  Title                    = {Selective Block Minimization for Faster Convergence of Limited Memory Large-scale Linear Models},
+  Author                   = {K.-W. Chang and D. Roth},
+  Booktitle                = {Proc. of the ACM SIGKDD Conference on Knowledge Discovery and Data Mining (KDD)},
+  Year                     = {2011},
+
+  Acceptance               = {17.5\%},
+  Funding                  = {BL, MR},
+  Url                      = {http://cogcomp.org/papers/ChangRo11(4).pdf}
+}
+
+@InProceedings{ChangSaRo13,
+  Title                    = {A Constrained Latent Variable Model for Coreference Resolution},
+  Author                   = {Kai-Wei Chang and Rajhans Samdani and Dan Roth},
+  Booktitle                = {Proc. of the Conference on Empirical Methods in Natural Language Processing (EMNLP)},
+  Year                     = {2013},
+
+  Url                      = {http://cogcomp.org/papers/ChangSaRo13.pdf}
+}
+
+@InProceedings{CSRRSR11,
+  Title                    = {Inference Protocols for Coreference Resolution},
+  Author                   = {K.-W. Chang and R. Samdani and A. Rozovskaya and N. Rizzolo and M. Sammons and D. Roth},
+  Booktitle                = {Proc. of the Conference on Computational Natural Language Learning (CoNLL)},
+  Year                     = {2011},
+
+  Address                  = {Portland, Oregon, USA},
+  Pages                    = {40--44},
+  Publisher                = {Association for Computational Linguistics},
+
+  Funding                  = {MR},
+  Url                      = {http://cogcomp.org/papers/CSRRSR11.pdf}
+}
+
+@InProceedings{CSRSR12,
+  Title                    = {Illinois-Coref: The UI System in the CoNLL-2012 Shared Task},
+  Author                   = {Kai-Wei Chang and Rajhans Samdani and Alla Rozovskaya and Mark Sammons and Dan Roth},
+  Booktitle                = {Proc. of the Conference on Computational Natural Language Learning (CoNLL)},
+  Year                     = {2012},
+
+  Funding                  = {Machine Reading, ARL},
+  Projects                 = {Coreference Within and Across Documents},
+  Url                      = {http://cogcomp.org/papers/CSRSR12.pdf}
+}
+
+@InProceedings{ChangSrRo13,
+  Title                    = {Multi-core Structural SVM Training},
+  Author                   = {K.-W. Chang and V. Srikumar and D. Roth},
+  Booktitle                = {Proc. of the European Conference on Machine Learning and Principles and Practice of Knowledge Discovery in Databases (ECML PKDD)},
+  Year                     = {2013},
+
+  Acceptance               = {25\%},
+  Funding                  = {ONR, DEFT},
+  Url                      = {http://cogcomp.org/papers/ChangSrRo13.pdf}
+}
+
+@InProceedings{CUKR15,
+  Title                    = {Structural Learning with Amortized Inference},
+  Author                   = {Kai-Wei Chang and Shyam Upadhyay and Gourab Kundu and Dan Roth},
+  Booktitle                = {Proc. of the Conference on Artificial Intelligence (AAAI)},
+  Year                     = {2015},
+
+  Funding                  = {ONR,ARL,DEFT},
+  Url                      = {http://cogcomp.org/papers/CUKR15.pdf}
+}
+
+@Other{Chang11,
+  Title                    = {Structured Prediction with Indirect Supervision},
+  Author                   = {M. Chang},
+  Booktitle                = {UIUC PhD Thesis},
+  Url                      = {http://cogcomp.org/papers/Chang11.pdf},
+  Year                     = {2011}
+}
+
+@InProceedings{ChangCoRo10,
+  Title                    = {The Necessity of Combining Adaptation Methods},
+  Author                   = {M. Chang and M. Connor and D. Roth},
+  Booktitle                = {Proc. of the Conference on Empirical Methods in Natural Language Processing (EMNLP)},
+  Year                     = {2010},
+
+  Address                  = {Massachusetts, USA},
+  Month                    = {10},
+
+  Funding                  = {DARPA},
+  Projects                 = {Adaptation},
+  Url                      = {http://cogcomp.org/papers/ChangCoRo10.pdf}
+}
+
+@InProceedings{ChangDoRo06,
+  Title                    = {Multilingual Dependency Parsing: A Pipeline Approach},
+  Author                   = {M. Chang and Q. Do and D. Roth},
+  Booktitle                = {Proc. of the Conference on Recent Advances in Natural Language Processing},
+  Year                     = {2006},
+  Editor                   = {Nicolas Nicolov and Kalina Bontcheva and Galia Angelova and Ruslan Mitkov},
+  Month                    = {7},
+  Pages                    = {55--78},
+
+  Comment                  = {Analysis of A pipeline model with applications to dependency parsing. Combines ACL'06 and CoNLL'06},
+  Funding                  = {ARDA,REFLEX,SoD},
+  Projects                 = {DP,PL},
+  Url                      = {http://cogcomp.org/papers/ChangDoRo06b.pdf}
+}
+
+@InProceedings{ChangDoRo06a,
+  Title                    = {Local Search for Bottom-Up Dependency Parsing},
+  Author                   = {M. Chang and Q. Do and D. Roth},
+  Booktitle                = {Proc. of the Annual Meeting of the Association for Computational Linguistics (ACL)},
+  Year                     = {2006},
+  Month                    = {7},
+
+  Comment                  = {Analysis of A pipeline model with applications to dependency parsing},
+  Funding                  = {ARDA,REFLEX},
+  Projects                 = {DP},
+  Url                      = {http://cogcomp.org/papers/ChangDoRo06a.pdf}
+}
+
+@InProceedings{ChangDoRo06b,
+  Title                    = {A Pipeline Model for Bottom-Up Dependency Parsing Shared Task Paper},
+  Author                   = {M. Chang and Q. Do and D. Roth},
+  Booktitle                = {Proc. of the Conference on Computational Natural Language Learning (CoNLL)},
+  Year                     = {2006},
+  Month                    = {6},
+  Pages                    = {186--190},
+
+  Comment                  = {Multilingual Dependency Parsing; a shift reduced parsing model; study of shift reduced parsing as a pipeline model},
+  Funding                  = {KINDLE,REFLEX},
+  Projects                 = {DP,PL},
+  Url                      = {http://cogcomp.org/papers/ChangDoRo06.pdf}
+}
+
+@InProceedings{CGRS10,
+  Title                    = {Discriminative Learning over Constrained Latent Representations},
+  Author                   = {M. Chang and D. Goldwasser and D. Roth and V. Srikumar},
+  Booktitle                = {Proc. of the Annual Conference of the North American Chapter of the Association for Computational Linguistics (NAACL)},
+  Year                     = {2010},
+  Month                    = {6},
+
+  Comment                  = {learning over latent representation, learning feature representation, intermediate representation, generalized alignment for various NLP tasks},
+  Funding                  = {DARPA,SoD,MIAS,MR},
+  Projects                 = {CCM,TL},
+  Url                      = {http://cogcomp.org/papers/CGRS10.pdf}
+}
+
+@InProceedings{CGRT09,
+  Title                    = {Unsupervised Constraint Driven Learning For Transliteration Discovery},
+  Author                   = {M. Chang and D. Goldwasser and D. Roth and Y. Tu},
+  Booktitle                = {Proc. of the Annual Conference of the North American Chapter of the Association for Computational Linguistics (NAACL)},
+  Year                     = {2009},
+  Month                    = {5},
+
+  Comment                  = {Transliteration; Constrained optimization; constrained conditional models, unsupervised learning; named entity discovery; multilingual corpora; bootstrapping, romanization table, feature selection for transliteration; Discriminative training of Objective function; Dynamic Programming},
+  Funding                  = {DARPA,SoD,MIAS},
+  Projects                 = {CCM,TL},
+  Url                      = {http://cogcomp.org/papers/CGRT09.pdf}
+}
+
+@InProceedings{CRRR08,
+  Title                    = {Learning and Inference with Constraints},
+  Author                   = {M. Chang and L. Ratinov and N. Rizzolo and D. Roth},
+  Booktitle                = {Proc. of the Conference on Artificial Intelligence (AAAI)},
+  Year                     = {2008},
+  Month                    = {7},
+
+  Funding                  = {SoD,MIAS,Library,Boeing},
+  Projects                 = {CCM,LBP},
+  Url                      = {http://cogcomp.org/papers/CRRR08.pdf}
+}
+
+@Other{ChangRaRo08,
+  Title                    = {Constraints as Prior Knowledge},
+  Author                   = {M. Chang and L. Ratinov and D. Roth},
+  Booktitle                = {Proc. of the International Conference on Machine Learning (ICML)},
+  Funding                  = {SoD, LIBRARY, MIAS},
+  Month                    = {7},
+  Pages                    = {32-39},
+  Projects                 = {USS,IE,CCM},
+  Url                      = {http://cogcomp.org/papers/ChangRaRo08.pdf},
+  Year                     = {2008}
+}
+
+@InProceedings{ChangRaRo07,
+  Title                    = {Guiding Semi-Supervision with Constraint-Driven Learning},
+  Author                   = {M. Chang and L. Ratinov and D. Roth},
+  Booktitle                = {Proc. of the Annual Meeting of the Association for Computational Linguistics (ACL)},
+  Year                     = {2007},
+
+  Address                  = {Prague, Czech Republic},
+  Month                    = {6},
+  Pages                    = {280--287},
+  Publisher                = {Association for Computational Linguistics},
+
+  Comment                  = {Semi-supervised learning with very little supervision; Constraints; Constraints Driven Learning; Information Extraction},
+  Funding                  = {SoD,Boeing},
+  Projects                 = {USS,CCM,IE},
+  Url                      = {http://cogcomp.org/papers/ChangRaRo07.pdf}
+}
+
+@InProceedings{CRRS08,
+  Title                    = {Importance of Semantic Representation: Dataless Classification},
+  Author                   = {M. Chang and L. Ratinov and D. Roth and V. Srikumar},
+  Booktitle                = {Proc. of the Conference on Artificial Intelligence (AAAI)},
+  Year                     = {2008},
+  Month                    = {7},
+
+  Funding                  = {SoD,MIAS,Library,Boeing},
+  Projects                 = {DC},
+  Url                      = {http://cogcomp.org/papers/CRRS08.pdf}
+}
+
+@InProceedings{CSGR10,
+  Title                    = {Structured Output Learning with Indirect Supervision},
+  Author                   = {M. Chang and V. Srikumar and D. Goldwasser and D. Roth},
+  Booktitle                = {Proc. of the International Conference on Machine Learning (ICML)},
+  Year                     = {2010},
+
+  Comment                  = {indirect supervision, structured learning, joint learning of binary and structured learning tasks},
+  Funding                  = {DARPA,SoD,MIAS,MR},
+  Projects                 = {CCM,TL},
+  Url                      = {http://cogcomp.org/papers/CSGR10.pdf}
+}
+
+@Article{ChangRaRo12,
+  Title                    = {Structured Learning with Constrained Conditional Models},
+  Author                   = {Ming-Wei Chang and Lev Ratinov and Dan Roth},
+  Journal                  = {Machine Learning},
+  Year                     = {2012},
+
+  Month                    = {6},
+  Number                   = {3},
+  Pages                    = {399-431},
+  Volume                   = {88},
+
+  Editor                   = {Hal Daume III},
+  Publisher                = {Springer},
+  Url                      = {http://cogcomp.org/papers/ChangRaRo12.pdf}
+}
+
+@InProceedings{ChaturvediPeRo17,
+  Title                    = {Story Comprehension for Predicting What Happens Next},
+  Author                   = {Snigdha Chaturvedi and Haoruo Peng and Dan Roth},
+  Booktitle                = {In proceedings of the Conference on Empirical Methods in Natural Language Processing},
+  Year                     = {2017},
+
+  Funding                  = { IBM-ILLINOIS Center for Cognitive Computing Systems Research (C3SR), US Defense Advanced Research Projects Agency (DARPA) under contract FA8750-13-2-0008, Army Research Laboratory (ARL) under agreement W911NF-09-2-0053},
+  Url                      = {http://cogcomp.org/papers/ChaturvediPeRo17.pdf}
+}
+
+@InProceedings{CCSCFSWRWR13,
+  Title                    = {Illinois Cognitive Computation Group UI-CCG TAC 2013 Entity Linking and Slot Filler Validation Systems},
+  Author                   = {Xiao Cheng and Bingling Chen and Rajhans Samdani and Kai-Wei Chang and Zhiye Fei and Mark Sammons and John Wieting and Subhro Roy and Chizheng Wang and Dan Roth},
+  Booktitle                = {Proc. of the Text Analysis Conference (TAC)},
+  Year                     = {2013},
+
+  Url                      = {http://cogcomp.org/papers/UI_CCG.TAC2013.proceedings.pdf}
+}
+
+@InProceedings{ChengRo13,
+  Title                    = {Relational Inference for Wikification},
+  Author                   = {Xiao Cheng and Dan Roth},
+  Booktitle                = {Proc. of the Conference on Empirical Methods in Natural Language Processing (EMNLP)},
+  Year                     = {2013},
+
+  Funding                  = {DEFT,ARL,MIAS},
+  Url                      = {http://cogcomp.org/papers/ChengRo13.pdf}
+}
+
+@Other{ChristodoulopoulosRoFi16,
+  Title                    = {An incremental model of syntactic bootstrapping},
+  Author                   = { Christos Christodoulopoulos and Dan Roth and Cynthia Fisher},
+  Booktitle                = {7th Workshop on Cognitive Aspects of Computational Language Learning, Proc. of the Annual Meeting of the Association for Computational Linguistics (ACL)},
+  Month                    = {8},
+  Url                      = {http://cogcomp.org/papers/christodoulopoulos_16_incremental.pdf},
+  Year                     = {2016}
+}
+
+@InProceedings{ChuangRo01,
+  Title                    = {Gene Recognition based on DAG shortest paths},
+  Author                   = {J. Chuang and D. Roth},
+  Booktitle                = {Proc. of the International Conference on Intelligent Systems for Molecular Biology (ISMB)},
+  Year                     = {2001},
+  Pages                    = {1--9},
+
+  Acceptance               = {40/180 (22\%)},
+  Funding                  = {NSF98,CAREER},
+  Projects                 = {LnI,SI,LT},
+  Url                      = {http://cogcomp.org/papers/ismb01.pdf}
+}
+
+@Article{ChuangRo01a,
+  Title                    = {Gene Recognition based on DAG shortest paths},
+  Author                   = {J. Chuang and D. Roth},
+  Journal                  = {Bioinformatics},
+  Year                     = {2001},
+
+  Month                    = {7},
+  Number                   = {1},
+  Pages                    = {S56--S64},
+  Volume                   = {17},
+
+  Funding                  = {NSF98,CAREER},
+  Projects                 = {LnI,SI,LT},
+  Url                      = {http://cogcomp.org/papers/ismb01.pdf}
+}
+
+@InProceedings{CGCR10,
+  Title                    = {Driving Semantic Parsing from the World's Response},
+  Author                   = {J. Clarke and D. Goldwasser and M. Chang and D. Roth},
+  Booktitle                = {Proc. of the Conference on Computational Natural Language Learning (CoNLL)},
+  Year                     = {2010},
+  Month                    = {7},
+
+  Comment                  = {Learning semantic parsers without complex logical form annotations. Supervision provided in the form of a binary feedback signal recieved from an external world.},
+  Funding                  = {BL,MR},
+  Projects                 = {NLP, SP, COMP, USS},
+  Url                      = {http://cogcomp.org/papers/CGCR10.pdf}
+}
+
+@InProceedings{CSSR12,
+  Title                    = {An NLP Curator (or: How I Learned to Stop Worrying and Love NLP Pipelines)},
+  Author                   = {James Clarke and Vivek Srikumar and Mark Sammons and Dan Roth},
+  Booktitle                = {Proc. of the International Conference on Language Resources and Evaluation (LREC)},
+  Year                     = {2012},
+  Month                    = {5},
+
+  Url                      = {http://cogcomp.org/papers/ClarkeSrSaRo2012.pdf}
+}
+
+@Other{Connor11,
+  Title                    = {Minimal Supervision for Language Learning: Bootstrapping Global Patterns from Local Knowledge},
+  Author                   = {M. Connor},
+  Booktitle                = {UIUC PhD Thesis},
+  Url                      = {http://cogcomp.org/papers/Connor11.pdf},
+  Year                     = {2011}
+}
+
+@InCollection{ConnorFiRo12,
+  Title                    = {Starting from Scratch in Semantic Role Labeling: Early Indirect Supervision},
+  Author                   = {Michael Connor and Cynthia Fisher and Dan Roth},
+  Publisher                = {Springer},
+  Year                     = {2012},
+  Editor                   = {A. Alishahi and T. Poibeau and A. Korhonen},
+  Month                    = {11},
+
+  Journal                  = {Cognitive Aspects of Computational Language Acquisition},
+  Url                      = {http://cogcomp.org/papers/ConnorFiRo12.pdf}
+}
+
+@InProceedings{ConnorFiRo11,
+  Title                    = {The Origin of Syntactic Bootstrapping: A computational Model},
+  Author                   = {M. Connor and C. Fisher and D. Roth},
+  Booktitle                = {Proc. of the Boston University Conference on Language Development},
+  Year                     = {2011}
+}
+
+@InProceedings{ConnorFiRo11a,
+  Title                    = {Online Latent Structure Training for Language Acquisition},
+  Author                   = {M. Connor and C. Fisher and D. Roth},
+  Booktitle                = {Proc. of the International Joint Conference on Artificial Intelligence (IJCAI)},
+  Year                     = {2011},
+  Month                    = {7},
+
+  Comment                  = {Indirect supervision; language acquisition; BabySRL; psycholinguistically plausible features; },
+  Funding                  = {Psych},
+  Projects                 = {PSYCHO},
+  Url                      = {http://cogcomp.org/papers/ConnorFiRo11.pdf}
+}
+
+@InProceedings{CGFR10,
+  Title                    = {Starting from Scratch in Semantic Role Labeling},
+  Author                   = {M. Connor and Y. Gertner and C. Fisher and D. Roth},
+  Booktitle                = {Proc. of the Annual Meeting of the Association for Computational Linguistics (ACL)},
+  Year                     = {2010},
+
+  Address                  = {Uppsala, Sweden},
+  Month                    = {7},
+  Publisher                = {Association for Computational Linguistics},
+
+  Comment                  = {Minimal supervision; language acquisition; BabySRL; psycholinguistically plausible features; unsupervised HMM; background knowledge and linguistic constraints},
+  Funding                  = {Psych},
+  Projects                 = {PSYCHO},
+  Url                      = {http://cogcomp.org/papers/CGFR10.pdf}
+}
+
+@InProceedings{CGFR09,
+  Title                    = {Minimally Supervised Model of Early Language Acquisition},
+  Author                   = {M. Connor and Y. Gertner and C. Fisher and D. Roth},
+  Booktitle                = {Proc. of the Conference on Computational Natural Language Learning (CoNLL)},
+  Year                     = {2009},
+  Month                    = {6},
+
+  Comment                  = {Minimal supervision; language acquisition; BabySRL; a semantic role labeling system with simple, psycholinguistically plausible features; trained using background knowledge plus linguistic constraints},
+  Funding                  = {Psych},
+  Projects                 = {PSYCHO},
+  Url                      = {http://cogcomp.org/papers/CGFR09.pdf}
+}
+
+@InProceedings{CGFR08,
+  Title                    = {Baby SRL: Modeling Early Language Acquisition},
+  Author                   = {M. Connor and Y. Gertner and C. Fisher and D. Roth},
+  Booktitle                = {Proc. of the Conference on Computational Natural Language Learning (CoNLL)},
+  Year                     = {2008},
+  Month                    = {8},
+
+  Comment                  = {Evaluating the psycholinguistics structure-mapping assumption; a semantic role labeling system with simple, psycholinguistically plausible features; language acquisition},
+  Funding                  = {Psych},
+  Projects                 = {PSYCHO},
+  Url                      = {http://cogcomp.org/papers/CGFR08.pdf}
+}
+
+@InProceedings{ConnorRo07,
+  Title                    = {Context Sensitive Paraphrasing with a Single Unsupervised Classifier},
+  Author                   = {M. Connor and D. Roth},
+  Booktitle                = {Proc. of the European Conference on Machine Learning (ECML)},
+  Year                     = {2007},
+  Month                    = {9},
+
+  Acceptance               = {69/592 (12\%) (regular papers)},
+  Comment                  = {Trains a single classifier to decided context sensitive paraphrases of verbs. Bootstraps training set through unsupervised training of subtask classifiers and confident example selection.},
+  Funding                  = {ITR-EDU,Psych},
+  Projects                 = {NLP,LP,TE,USS},
+  Url                      = {http://cogcomp.org/papers/ConnorRo07.pdf}
+}
+
+@Other{Cumby01,
+  Title                    = {Learning family relationships via propositional means},
+  Author                   = {C. Cumby},
+  Comment                  = {Senior Thesis, UIUC, Dept. of Computer Science},
+  Funding                  = {NSF98,KDI},
+  Month                    = {5},
+  Projects                 = {KR,LT},
+  Url                      = {http://cogcomp.org/papers/family.pdf},
+  Year                     = {2001}
+}
+
+@InProceedings{CumbyRo03,
+  Title                    = {On Kernel Methods for Relational Learning},
+  Author                   = {C. Cumby and D. Roth},
+  Booktitle                = {Proc. of the International Conference on Machine Learning (ICML)},
+  Year                     = {2003},
+  Pages                    = {107--114},
+
+  Acceptance               = {118-371 (32\%)},
+  Comment                  = {Parameterized kernels over structures. Relational Kernels. Advantages and disadvantages of graph kernels.},
+  Funding                  = {NSF98,ITR-BI,CAREER},
+  Projects                 = {LT,KR},
+  Url                      = {http://cogcomp.org/papers/CumbyRo03.pdf}
+}
+
+@Other{CumbyRo03a,
+  Title                    = {Feature Extraction Languages for Propositionalized Relational Learning},
+  Acceptance               = {33/40 (83\%)},
+  Author                   = {C. Cumby and D. Roth},
+  Booktitle                = {Proc. of the International Joint Conference on Artificial Intelligence (IJCAI)},
+  Funding                  = {NSF98,ITR-BI,CAREER},
+  Projects                 = {LT,KR,KINDLE},
+  Url                      = {http://cogcomp.org/papers/CumbyRo03a.pdf},
+  Year                     = {2003}
+}
+
+@TechReport{CumbyRo03b,
+  Title                    = {Kernel Methods for Relational Learning},
+  Author                   = {C. Cumby and D. Roth},
+  Institution              = {UIUC Computer Science Department},
+  Year                     = {2003},
+  Month                    = {5},
+  Number                   = {UIUCDCS-R-2003-2345},
+
+  Funding                  = {NSF98,ITR-BI,CAREER},
+  Invisible                = {true},
+  Projects                 = {LT,KR},
+  Url                      = {http://cogcomp.org/papers/CumbyRo03c.pdf}
+}
+
+@TechReport{CumbyRo03c,
+  Title                    = {Feature Extraction Languages for Propositionalized Relational Learning},
+  Author                   = {C. Cumby and D. Roth},
+  Institution              = {UIUC Computer Science Department},
+  Year                     = {2003},
+  Month                    = {5},
+  Number                   = {UIUCDCS-R-2003-2346},
+
+  Funding                  = {NSF98,ITR-BI,CAREER},
+  Invisible                = {true},
+  Projects                 = {LT,KR},
+  Url                      = {http://cogcomp.org/papers/CumbyRo03b.pdf}
+}
+
+@InProceedings{CumbyRo02,
+  Title                    = {Learning with Feature Description Logics},
+  Author                   = {C. Cumby and D. Roth},
+  Booktitle                = {Proc. of the International Conference on Inductive Logic Programming (ILP)},
+  Year                     = {2002},
+  Pages                    = {32--47},
+
+  Comment                  = {A Description Logic based Formalism for Feature Extraction; Expressive Features; A language for Feature Extraction},
+  Funding                  = {NSF98,ITR-MIT,CAREER},
+  Projects                 = {KR,KINDLE},
+  Url                      = {http://cogcomp.org/papers/ilp02.pdf}
+}
+
+@InProceedings{CumbyRo00,
+  Title                    = {Relational Representations that facilitate learning},
+  Author                   = {C. Cumby and D. Roth},
+  Booktitle                = {Proc. of the International Conference on Principles of Knowledge Representation and Reasoning (KR)},
+  Year                     = {2000},
+  Pages                    = {425--434},
+
+  Acceptance               = {62/172 (36\%)},
+  Comment                  = {FEX: feature extraction language; relational features; relational generation functions},
+  Funding                  = {NSF98,KDI},
+  Projects                 = {LT,KR},
+  Url                      = {http://cogcomp.org/papers/kr00.pdf}
+}
+
+@Article{DDMR09,
+  Title                    = {Guest Editors Introduction: Recognizing Textual Entailment: Rational, Evaluation and Approaches},
+  Author                   = {I. Dagan and B. Dolan and B. Magnini and D. Roth},
+  Journal                  = {Journal of Natural Language Engineering},
+  Year                     = {2009},
+  Pages                    = {459--476},
+  Volume                   = {15},
+
+  Projects                 = {TE},
+  Publisher                = {Cambridge University Press}
+}
+
+@InProceedings{DaganKaRo97,
+  Title                    = {Mistake-Driven Learning in Text Categorization},
+  Author                   = {I. Dagan and Y. Karov and D. Roth},
+  Booktitle                = {Proc. of the Conference on Empirical Methods in Natural Language Processing (EMNLP)},
+  Year                     = {1997},
+  Month                    = {8},
+  Pages                    = {55-63},
+
+  Url                      = {http://cogcomp.org/papers/DaganKaRo97.pdf}
+}
+
+@Unpublished{DRSZ13,
+  Title                    = {Recognizing Textual Entailment: Models and Applications},
+  Author                   = {Ido Dagan and Dan Roth and Mark Sammons and Fabio Massimo Zanzoto},
+
+  Month                    = {7},
+  Year                     = {2013},
+
+  Booktitle                = {Recognizing Textual Entailment: Models and Applications},
+  Publisher                = {Morgan and Claypool}
+}
+
+@Article{DanielsMiRo97,
+  Title                    = {Finding the Maximum Area Axis-Parallel Rectangle in a Polygon},
+  Author                   = {K. Daniels and V. J. Milenkovic and D. Roth},
+  Journal                  = {Computational Geometry: Theory and Applications},
+  Year                     = {1997},
+
+  Month                    = {1},
+  Number                   = {1-2},
+  Pages                    = {125--148},
+  Volume                   = {7},
+
+  Url                      = {http://cogcomp.org/papers/maaprJ.pdf}
+}
+
+@InProceedings{DanielsMiRo93,
+  Title                    = {Finding the Maximum Area Axis-Parallel Rectangle in a Simple Polygon},
+  Author                   = {K. Daniels and V. J. Milenkovic and D. Roth},
+  Booktitle                = {Proc. of the Canadian Conference on Computational Geometry (CCCG)},
+  Year                     = {1993},
+  Pages                    = {322--327}
+}
+
+@Article{DayaRoWi08,
+  Title                    = {Learning Hebrew Roots: Machine Learning with Linguistic Constraints},
+  Author                   = {E. Daya and D. Roth and S. Wintner},
+  Journal                  = {Computational Linguistics},
+  Year                     = {2008},
+  Number                   = {3},
+  Volume                   = {34},
+
+  Funding                  = {CAREER,MURI, REFLEX},
+  Projects                 = {LnI,SI,NLP},
+  Url                      = {http://cogcomp.org/papers/DayaRoWi08.pdf}
+}
+
+@InProceedings{DayaRoWi04,
+  Title                    = {Learning Hebrew Roots: Machine Learning with Linguistic Constraints},
+  Author                   = {E. Daya and D. Roth and S. Wintner},
+  Booktitle                = {Proc. of the Conference on Empirical Methods in Natural Language Processing (EMNLP)},
+  Year                     = {2004},
+  Month                    = {7},
+  Pages                    = {168--178},
+
+  Comment                  = {Inference with Classifiers; Learning and Inference with Constraints; Hebrew Morphology},
+  Funding                  = {CAREER,MURI, REFLEX},
+  Projects                 = {LnI,SI,NLP},
+  Url                      = {http://cogcomp.org/papers/DayaRoWi04.pdf}
+}
+
+@Other{Do12,
+  Title                    = {Background Knowledge in Learning-Based Relation Extraction},
+  Author                   = {Quang Do},
+  Booktitle                = {UIUC PhD Thesis},
+  Url                      = {http://cogcomp.org/papers/Do12.pdf},
+  Year                     = {2012}
+}
+
+@InProceedings{DoChRo11,
+  Title                    = {Minimally Supervised Event Causality Identification},
+  Author                   = {Q. Do and Y. Chan and D. Roth},
+  Booktitle                = {Proc. of the Conference on Empirical Methods in Natural Language Processing (EMNLP)},
+  Year                     = {2011},
+
+  Address                  = {Edinburgh, Scotland},
+  Month                    = {7},
+
+  Funding                  = {MR},
+  Url                      = {http://cogcomp.org/papers/DoChaRo11.pdf}
+}
+
+@InProceedings{DoLuRo12,
+  Title                    = {Joint Inference for Event Timeline Construction},
+  Author                   = {Quang Do and Wei Lu and Dan Roth},
+  Booktitle                = {Proc. of the Conference on Empirical Methods in Natural Language Processing (EMNLP)},
+  Year                     = {2012},
+
+  Url                      = {http://cogcomp.org/papers/DoLuRo12.pdf}
+}
+
+@Article{DoRo12,
+  Title                    = {Exploiting the Wikipedia Structure in Local and Global Classification of Taxonomic Relations},
+  Author                   = {Quang Do and Dan Roth},
+  Journal                  = {Journal of Natural Language Engineering (JNLE)},
+  Year                     = {2012},
+
+  Month                    = {4},
+  Number                   = {2},
+  Pages                    = {235-262},
+  Volume                   = {18},
+
+  Comment                  = {http://journals.cambridge.org/action/displayAbstract?fromPage=online&aid=8511905&fulltextType=RA&fileId=S1351324912000046},
+  Publisher                = {Cambridge University Press},
+  Url                      = {http://cogcomp.org/papers/DoRo12.pdf}
+}
+
+@InProceedings{DoRo10,
+  Title                    = {Relational Constraints based Taxonomic Relation Classification},
+  Author                   = {Q. Do and D. Roth},
+  Booktitle                = {Proc. of the Conference on Empirical Methods in Natural Language Processing (EMNLP)},
+  Year                     = {2010},
+
+  Address                  = {Massachusetts, USA},
+  Month                    = {10},
+  Pages                    = {1099-1109},
+
+  Funding                  = {DARPA},
+  Projects                 = {Machine Reading},
+  Url                      = {http://cogcomp.org/papers/DoRo10.pdf}
+}
+
+@TechReport{DRSTV09,
+  Title                    = {Robust, Light-weight Approaches to compute Lexical Similarity},
+  Author                   = {Q. Do and D. Roth and M. Sammons and Y. Tu and V. Vydiswaran},
+  Year                     = {2009},
+
+  Booktitle                = {Computer Science Research and Technical Reports, University of Illinois},
+  Url                      = {http://cogcomp.org/papers/DRSTV09.pdf}
+}
+
+@TechReport{DoanLiRo06,
+  Title                    = {MEDIATE: Learning to match entity mentions across text and data bases},
+  Author                   = {A. Doan and X. Li and D. Roth},
+  Institution              = {UIUC Computer Science Department},
+  Year                     = {2006},
+  Number                   = {No. UIUCDCS-R-2006-2692},
+
+  Comment                  = {UIUC Tech Report UIUCDCS-R-2006-2692. Semantic Integration; Entity Uncertainty; Automatic matching of entity mentions across text and databases.},
+  Funding                  = {MURI,ITR-BI},
+  Invisible                = {true},
+  Projects                 = {MIRROR,COREF,NER},
+  Url                      = {http://cogcomp.org/papers/DoanLiRo06.pdf}
+}
+
+@InProceedings{ECGR09,
+  Title                    = {Reading to Learn: Constructing Features from Semantic Abstracts},
+  Author                   = {J. Eisenstein and J. Clarke and D. Goldwasser and D. Roth},
+  Booktitle                = {Proc. of the Conference on Empirical Methods in Natural Language Processing (EMNLP)},
+  Year                     = {2009},
+
+  Address                  = {Singapore},
+
+  Comment                  = {Proposes a novel form of semantic analysis where the goal is to obtain a high-level semantic abstract of documents in a representation that facilitates learning. The abstract is obtained through a generative model that requires no labeled data. The semantic abstract is converted into a transformed feature space for relational learning.},
+  Funding                  = {SoD, BL},
+  Projects                 = {COMP, USS},
+  Url                      = {http://cogcomp.org/papers/ECGR09.pdf}
+}
+
+@InProceedings{Even-ZoharRo01,
+  Title                    = {A Sequential Model for Multi Class Classification},
+  Author                   = {Y. Even-Zohar and D. Roth},
+  Booktitle                = {Proc. of the Conference on Empirical Methods in Natural Language Processing (EMNLP)},
+  Year                     = {2001},
+  Pages                    = {10-19},
+
+  Acceptance               = {21/65 (32\%)},
+  Comment                  = {Multiclass classification: reducing the number of candidate classes; part-of-speech (POS) tagging},
+  Funding                  = {ITR-MIT,NSF98,KDI},
+  Projects                 = {MCR,LT,MC},
+  Url                      = {http://cogcomp.org/papers/emnlp01.pdf}
+}
+
+@InProceedings{Even-ZoharRo00,
+  Title                    = {A classification approach to word prediction},
+  Author                   = {Y. Even-Zohar and D. Roth},
+  Booktitle                = {Proc. of the Annual Conference of the North American Chapter of the Association for Computational Linguistics (NAACL)},
+  Year                     = {2000},
+  Pages                    = {124-131},
+
+  Acceptance               = {43/166 (26\%)},
+  Comment                  = {Learning with expressive features; dependency parse based features; verb prediction},
+  Funding                  = {NSF98,KDI},
+  Projects                 = {LT,KR},
+  Url                      = {http://cogcomp.org/papers/naacl00.pdf}
+}
+
+@InProceedings{Even-ZoharRoZe99,
+  Title                    = {Word Clustering via Classification},
+  Author                   = {Y. Even-Zohar and D. Roth and D. Zelenko},
+  Booktitle                = {Proc. of the Bar-Ilan Symposium on Foundations of Artificial Intelligence (BISFAI)},
+  Year                     = {1999},
+
+  Address                  = {Bar-Ilan, Israel},
+
+  Acceptance               = {78/160 (48\%)},
+  Funding                  = {NSF98,KDI},
+  Url                      = {http://cogcomp.org/papers/Even-ZoharRoZe99.pdf}
+}
+
+@Other{FKPWR15,
+  Title                    = {ILLINOIS-PROFILER: Knowledge Schemas at Scale},
+  Author                   = {Zhiye Fei and Daniel Khashabi and Haoruo Peng and Hao Wu and Dan Roth},
+  Booktitle                = {Workshop on Cognitive Knowledge Acquisition and Applications, Proc. of the International Joint Conference on Artificial Intelligence (IJCAI)},
+  Url                      = {http://cogcomp.org/papers/profiler_ijcai.pdf},
+  Year                     = {2015}
+}
+
+@Article{FungRo05,
+  Title                    = {Guest Editors Introduction: Machine Learning in Speech and Language Technologies},
+  Author                   = {P. Fung and D. Roth},
+  Journal                  = {Machine Learning},
+  Year                     = {2005},
+  Number                   = {1/2/3},
+  Pages                    = {1-6},
+  Volume                   = {60},
+
+  Funding                  = {ITR-BI,CAREER,MURI},
+  Projects                 = {LNL,LT},
+  Url                      = {http://cogcomp.org/papers/FungRo05.pdf}
+}
+
+@InProceedings{GargHaRo02,
+  Title                    = {On generalization bounds, projection profile, and margin distribution},
+  Author                   = {A. Garg and S. Har-Peled and D. Roth},
+  Booktitle                = {Proc. of the International Conference on Machine Learning (ICML)},
+  Year                     = {2002},
+  Pages                    = {171--178},
+
+  Acceptance               = {86/261 (33\%)},
+  Comment                  = {Random Projection; Generalization Bounds for Linear Classifiers.},
+  Funding                  = {ITR-MIT,ITR-BI,CAREER},
+  Projects                 = {LCC,LT},
+  Url                      = {http://cogcomp.org/papers/icml02.pdf}
+}
+
+@TechReport{GargHaRo01,
+  Title                    = {Generalization Bounds for Linear Learning Algorithms},
+  Author                   = {A. Garg and S. Har-Peled and D. Roth},
+  Institution              = {UIUC Computer Science Department},
+  Year                     = {2001},
+  Month                    = {6},
+  Number                   = {UIUCDCS-R-2001-2232},
+
+  Funding                  = {ITR-MIT,ITR-BI,CAREER},
+  Invisible                = {true},
+  Projects                 = {LCC,LT},
+  Url                      = {http://cogcomp.org/papers/GargHaRo01.pdf}
+}
+
+@InProceedings{GargRo03,
+  Title                    = {Margin Distribution and Learning Algorithms},
+  Author                   = {A. Garg and D. Roth},
+  Booktitle                = {Proc. of the International Conference on Machine Learning (ICML)},
+  Year                     = {2003},
+  Pages                    = {210--217},
+
+  Acceptance               = {118/371 (32\%)},
+  Comment                  = {Linear classifiers that optimize the margin distribution},
+  Funding                  = {ITR-BI,ITR-MIT,CAREER},
+  Projects                 = {LT,LCC},
+  Url                      = {http://cogcomp.org/papers/GargRo03.pdf}
+}
+
+@InProceedings{GargRo01,
+  Title                    = {Understanding Probabilistic Classifiers},
+  Author                   = {A. Garg and D. Roth},
+  Booktitle                = {Proc. of the European Conference on Machine Learning (ECML)},
+  Year                     = {2001},
+  Pages                    = {179--191},
+
+  Acceptance               = {90/240 (37.5\%)},
+  Comment                  = {An Information Theory based explanation of the good performance of naive Bayes},
+  Funding                  = {ITR-MIT ITR-BI CAREER NSF98},
+  Projects                 = {DPL,LT},
+  Url                      = {http://cogcomp.org/papers/ecml01.pdf}
+}
+
+@InProceedings{GargRo01a,
+  Title                    = {Learning Coherent Concepts},
+  Author                   = {A. Garg and D. Roth},
+  Booktitle                = {Proc. of the International Workshop on Algorithmic Learning Theory (ALT)},
+  Year                     = {2001},
+  Pages                    = {135--150},
+  Publisher                = {Springer-Verlag},
+
+  Acceptance               = {21/42 (50\%)},
+  Funding                  = {ITR-MIT ITR-BI CAREER},
+  Projects                 = {LCC,LT},
+  Url                      = {http://cogcomp.org/papers/alt01.pdf}
+}
+
+@TechReport{GargRo01b,
+  Title                    = {Understanding Probabilistic Classifiers},
+  Author                   = {A. Garg and D. Roth},
+  Institution              = {UIUC Computer Science Department},
+  Year                     = {2001},
+  Month                    = {3},
+  Number                   = {UIUCDCS-R-2001-2205},
+
+  Funding                  = {ITR-MIT,ITR-BI,CAREER,NSF98},
+  Invisible                = {true},
+  Projects                 = {DPL,LT},
+  Url                      = {http://cogcomp.org/papers/GargRo01b.pdf}
+}
+
+@Other{GirjuRoSa05,
+  Title                    = {Token-level Disambiguation of VerbNet classes},
+  Author                   = {R. Girju and D. Roth and M. Sammons},
+  Booktitle                = {Proc. of the Interdisciplinary Workshop on Verb Features and Verb Classes (Verb Workshop)},
+  Comment                  = {Context Sensitive Identification of VerbNet Classes; Levin Classes.},
+  Funding                  = {KINDLE,TRECC},
+  Projects                 = {SM},
+  Url                      = {http://cogcomp.org/papers/GirjuRoSa05.pdf},
+  Year                     = {2005}
+}
+
+@Article{GHJKRRC09,
+  Title                    = {Who's Who in Your Digital Collection: Developing a Tool for Name Disambiguation and Identity Resolution},
+  Author                   = {C. Godby and P. Hswe and L. Jackson and J. Klavans and L. Ratinov and D. Roth and H. Cho},
+  Year                     = {2009},
+
+  Booktitle                = {Journal of the Chicago Colloquium on Digital Humanities and Computer Science (Proc. of the Chicago Colloquium on Digital Humanities and Computer Science (DHCS))},
+  Comment                  = {Named Entity Recognition (NER) and Wikification; Applications to Digital Libraries},
+  Funding                  = {DARPA,LIBRARY},
+  Projects                 = {IR,LBJ},
+  Url                      = {http://cogcomp.org/papers/GHJKRRC09.pdf}
+}
+
+@Article{GoldingRo99,
+  Title                    = {A Winnow based approach to Context-Sensitive Spelling Correction},
+  Author                   = {A. R. Golding and D. Roth},
+  Journal                  = {Machine Learning},
+  Year                     = {1999},
+  Number                   = {1-3},
+  Pages                    = {107--130},
+  Volume                   = {34},
+
+  Comment                  = {Special Issue on Machine Learning and Natural Language.},
+  Funding                  = {NSF98 KDI},
+  Projects                 = {KR,LT,NLP},
+  Url                      = {http://cogcomp.org/papers/spellJ.pdf}
+}
+
+@InProceedings{GoldingRo96,
+  Title                    = {Applying Winnow to Context-Sensitive Spelling Correction},
+  Author                   = {A. R. Golding and D. Roth},
+  Booktitle                = {Proc. of the International Conference on Machine Learning (ICML)},
+  Year                     = {1996},
+  Pages                    = {182--190},
+
+  Acceptance               = {63/257 (24\%)},
+  Url                      = {http://cogcomp.org/papers/spell.pdf}
+}
+
+@Other{Goldwasser12,
+  Title                    = {Learning from Natural Instructions},
+  Author                   = {Dan Goldwasser },
+  Booktitle                = {UIUC PhD Thesis},
+  Url                      = {http://cogcomp.org/papers/Goldwasser12.pdf},
+  Year                     = {2012}
+}
+
+@InProceedings{GCTR09,
+  Title                    = {Constraint Driven Transliteration Discovery},
+  Author                   = {D. Goldwasser and M. Chang and Y. Tu and D. Roth},
+  Booktitle                = {Proc. of the Conference on Recent Advances in Natural Language Processing},
+  Year                     = {2009},
+  Editor                   = {Nicolas Nicolov},
+  Publisher                = {John Benjamins},
+
+  Comment                  = {Extending Constrained Conditional Model based transliteration; Combines EMNLP'08 and NAACL'09},
+  Funding                  = {BL,SoD},
+  Projects                 = {CCG,TL},
+  Url                      = {http://cogcomp.org/papers/GCTR09.pdf}
+}
+
+@InProceedings{GRCR11,
+  Title                    = {Confidence Driven Unsupervised Semantic Parsing },
+  Author                   = {D. Goldwasser and R. Reichart and J. Clarke and D. Roth },
+  Booktitle                = {Proc. of the Annual Meeting of the Association for Computational Linguistics (ACL)},
+  Year                     = {2011},
+
+  Url                      = {http://cogcomp.org/papers/main(2).pdf}
+}
+
+@Article{GoldwasserRo14,
+  Title                    = {Learning from Natural Instructions},
+  Author                   = {Dan Goldwasser and Dan Roth},
+  Journal                  = {Machine Learning},
+  Year                     = {2014},
+
+  Month                    = {2},
+  Number                   = {2},
+  Pages                    = {205-232},
+  Volume                   = {94},
+
+  Publisher                = {Springer},
+  Url                      = {http://cogcomp.org/papers/GoldwasserRo14.pdf}
+}
+
+@InProceedings{GoldwasserRo13,
+  Title                    = {Leveraging Domain-Independent Information in Semantic Parsing},
+  Author                   = {Dan Goldwasser and Dan Roth},
+  Booktitle                = {Proc. of the Annual Meeting of the Association for Computational Linguistics (ACL)},
+  Year                     = {2013},
+
+  Url                      = {http://cogcomp.org/papers/GoldwasserRoth13.pdf}
+}
+
+@InProceedings{GoldwasserRo11,
+  Title                    = {Learning from Natural Instructions},
+  Author                   = {D. Goldwasser and D. Roth},
+  Booktitle                = {Proc. of the International Joint Conference on Artificial Intelligence (IJCAI)},
+  Year                     = {2011},
+
+  Url                      = {http://cogcomp.org/papers/GoldwasserRo11(2).pdf}
+}
+
+@InProceedings{GoldwasserRo08,
+  Title                    = {Transliteration as Constrained Optimization},
+  Author                   = {D. Goldwasser and D. Roth},
+  Booktitle                = {Proc. of the Conference on Empirical Methods in Natural Language Processing (EMNLP)},
+  Year                     = {2008},
+  Month                    = {10},
+
+  Comment                  = {Transliteration; Constrained optimization; Named entity discovery; bilingual corpora; feature selection for transliteration; Discriminative training of Objective function; Integer Linear Programming;ILP; Hebrew transliteration},
+  Funding                  = {DARPA,SoD},
+  Projects                 = {CCM,TL},
+  Url                      = {http://cogcomp.org/papers/GoldwasserRo08a.pdf}
+}
+
+@InProceedings{GoldwasserRo08a,
+  Title                    = {Active Sample Selection for Named Entity Transliteration},
+  Author                   = {D. Goldwasser and D. Roth},
+  Booktitle                = {Proc. of the Annual Conference of the North American Chapter of the Association for Computational Linguistics (NAACL)},
+  Year                     = {2008},
+
+  Address                  = {Columbus, OH, USA},
+  Month                    = {6},
+  Publisher                = {Association for Computational Linguistics},
+
+  Comment                  = {Named entity discovery; bilingual corpora; active sampling; data selection; domain adaptation; Russian transliteration; Hebrew transliteration},
+  Funding                  = {Darpa},
+  Projects                 = {AL,TL},
+  Url                      = {http://cogcomp.org/papers/GoldwasserRo08.pdf}
+}
+
+@Article{GreinerGrRo02,
+  Title                    = {Learning Cost-Sensitive Active Classifiers},
+  Author                   = {R. Greiner and A. Grove and D. Roth},
+  Journal                  = {Artificial Intelligence},
+  Year                     = {2002},
+  Number                   = {2},
+  Pages                    = {137--174},
+  Volume                   = {139},
+
+  Comment                  = {Earlier version appeared in ICML'96},
+  Funding                  = {NSF98 CAREER},
+  Projects                 = {DPL,LT,LP},
+  Url                      = {http://cogcomp.org/papers/activeJ.pdf}
+}
+
+@InProceedings{GreinerGrRo96,
+  Title                    = {Learning Active Classifiers},
+  Author                   = {R. Greiner and A. Grove and D. Roth},
+  Booktitle                = {Proc. of the International Conference on Machine Learning (ICML)},
+  Year                     = {1996},
+  Pages                    = {207--215},
+
+  Acceptance               = {63/257 (24\%)},
+  Url                      = {http://cogcomp.org/papers/active.pdf}
+}
+
+@Article{GroveRo01,
+  Title                    = {Linear concepts and hidden variables},
+  Author                   = {A. Grove and D. Roth},
+  Journal                  = {Machine Learning},
+  Year                     = {2001},
+  Number                   = {1/2},
+  Pages                    = {123--141},
+  Volume                   = {42},
+
+  Funding                  = {NSF98,CAREER},
+  Projects                 = {DPL,LT},
+  Url                      = {http://cogcomp.org/papers/hiddenJ.pdf}
+}
+
+@InProceedings{GroveRo98,
+  Title                    = {Linear concepts and hidden variables: An empirical study},
+  Author                   = {A. Grove and D. Roth},
+  Booktitle                = {Proc. of the Conference on Neural Information Processing Systems (NIPS)},
+  Year                     = {1998},
+  Pages                    = {500--506},
+  Publisher                = {MIT Press},
+
+  Acceptance               = {150/491 (30\%)},
+  Comment                  = {Margin Winnow (Perceptron); discriminative vs. generative},
+  Url                      = {http://cogcomp.org/papers/nips98.pdf}
+}
+
+@InProceedings{GuptaSaRo16,
+  Title                    = {Will I Get in? - Modeling the Graduate Admission Process for American Universities},
+  Author                   = {Narender Gupta and Aman Sawhney and Dan Roth},
+  Booktitle                = {2016 IEEE 16th International Conference on Data Mining Workshops (ICDMW)},
+  Year                     = {2016},
+  Pages                    = {631--638},
+
+  Url                      = {http://cogcomp.org/papers/Will_I_Get_In.pdf}
+}
+
+@InProceedings{GuptaSiRo17,
+  Title                    = {Entity Linking via Joint Encoding of Types, Descriptions, and Context},
+  Author                   = {Nitish Gupta and Sameer Singh and Dan Roth},
+  Booktitle                = {Proc. of the Conference on Empirical Methods in Natural Language Processing (EMNLP)},
+  Year                     = {2017},
+
+  Url                      = {http://cogcomp.org/papers/GuptaSiRo17.pdf}
+}
+
+@TechReport{HannekeRo04,
+  Title                    = {Iterative Labeling for Semi-Supervised Learning},
+  Author                   = {S. Hanneke and D. Roth},
+  Institution              = {UIUC Computer Science Department},
+  Year                     = {2004},
+  Month                    = {6},
+  Number                   = {UIUCDCS-R-2004-2442},
+
+  Funding                  = {ITR-MIT,MURI,TRECC,CLUSTER},
+  Invisible                = {true},
+  Projects                 = {LP,USS},
+  Url                      = {http://cogcomp.org/papers/HannekeRo04.pdf}
+}
+
+@InProceedings{Har-PeledRoZi07,
+  Title                    = {Maximum Margin Coresets for Active and Noise Tolerant Learning},
+  Author                   = {S. Har-Peled and D. Roth and D. Zimak},
+  Booktitle                = {Proc. of the International Joint Conference on Artificial Intelligence (IJCAI)},
+  Year                     = {2007},
+  Pages                    = {LT},
+
+  Acceptance               = {212/1353 (16\%)},
+  Comment                  = {Learning large margin halfspaces using coresets; algorithm and analysis; applications include analysis of large margin active learning and an algorithm for agnostic learning in the presence of outlier noise.},
+  Funding                  = {KINDLE,REFLEX,MURI,XPRESSMP},
+  Projects                 = {IE,LINL,SP,ILP,AL},
+  Url                      = {http://cogcomp.org/papers/Har-PeledRoZi07.pdf}
+}
+
+@TechReport{Har-PeledRoZi06,
+  Title                    = {Maximum Margin Coresets for Active and Noise Tolerant Learning},
+  Author                   = {S. Har-Peled and D. Roth and D. Zimak},
+  Institution              = {UIUC Computer Science Department},
+  Year                     = {2006},
+  Number                   = {No. UIUCDCS-R-2006-2784},
+
+  Funding                  = {ITR-BI,ITR-MIT},
+  Invisible                = {true},
+  Projects                 = {AL}
+}
+
+@InProceedings{Har-PeledRoZi03,
+  Title                    = {Constraint Classification for Multiclass Classification and Ranking},
+  Author                   = {S. Har-Peled and D. Roth and D. Zimak},
+  Booktitle                = {Proc. of the Conference on Neural Information Processing Systems (NIPS)},
+  Year                     = {2003},
+  Pages                    = {785--792},
+
+  Acceptance               = {207/694 (30\%)},
+  Funding                  = {ITR-MIT ITR-BI CAREER},
+  Projects                 = {CCR,LT,MC},
+  Url                      = {http://cogcomp.org/papers/nips02.pdf}
+}
+
+@InProceedings{Har-PeledRoZi02,
+  Title                    = {Constraint Classification: a new approach to Multiclass Classification},
+  Author                   = {S. Har-Peled and D. Roth and D. Zimak},
+  Booktitle                = {Proc. of the International Workshop on Algorithmic Learning Theory (ALT)},
+  Year                     = {2002},
+  Pages                    = {135--150},
+  Publisher                = {Springer-Verlag},
+
+  Acceptance               = {21/42 (50\%)},
+  Funding                  = {ITR-MIT,ITR-BI,CAREER},
+  Projects                 = {CCR,LT,MC},
+  Url                      = {http://cogcomp.org/papers/Har-PeledRoZi02.pdf}
+}
+
+@InProceedings{HinrichsCh03,
+  Title                    = {Proceedings of the 41st Annual Meeting of the Association for Computational Linguistics},
+  Author                   = {E. Hinrichs and D. Roth Program Chairs},
+  Year                     = {2003},
+  Editor                   = {E. Hinrichs and D. Roth}
+}
+
+@Other{Jindal13,
+  Title                    = {Information Extraction for Clinical Narratives},
+  Author                   = {Prateek Jindal},
+  Booktitle                = {UIUC PhD Thesis},
+  Url                      = {http://cogcomp.org/papers/Jindal13.pdf},
+  Year                     = {2013}
+}
+
+@InProceedings{JindalGuRo14,
+  Title                    = {Detecting Privacy-Sensitive Events in Medical Text},
+  Author                   = {Prateek Jindal and Carl A. Gunter and Dan Roth},
+  Booktitle                = {Proc. of the ACM Conference on Proc. of the International Conference on Bioinformatics Models, Methods and Algorithms, Computational Biology, and Health Informatics},
+  Year                     = {2014},
+  Month                    = {9},
+
+  Url                      = {http://cogcomp.org/papers/JindalGR14.pdf}
+}
+
+@Article{JindalRo13c,
+  Title                    = {Using Domain Knowledge and Domain-Inspired Discourse Model for Coreference Resolution for Clinical Narratives},
+  Author                   = {Prateek Jindal and Dan Roth},
+  Year                     = {2013},
+
+  Month                    = {3},
+  Number                   = {2},
+  Pages                    = {356-362},
+  Volume                   = {20},
+
+  Acceptance               = {19\%},
+  Booktitle                = {Journal of the American Medical Informatics Association (JAMIA)},
+  Editor                   = {Professor Lucila Ohno-Machado},
+  Publisher                = {BMJ Publishing Group Ltd},
+  Url                      = {http://cogcomp.org/papers/JindalRo12.pdf}
+}
+
+@Article{JindalRo13,
+  Title                    = {Extraction of Events and Temporal Expressions from Clinical Narratives},
+  Author                   = {P. Jindal and D. Roth},
+  Journal                  = {Journal of Biomedical Informatics (JBI)},
+  Year                     = {2013},
+
+  Month                    = {10},
+
+  Editor                   = {E.H. Shortliffe},
+  Url                      = {http://cogcomp.org/papers/JindalRo13d.pdf}
+}
+
+@InProceedings{JindalRo13a,
+  Title                    = {Using Soft Constraints in Joint Inference for Clinical Concept Recognition},
+  Author                   = {Prateek Jindal and Dan Roth},
+  Booktitle                = {Proc. of the Conference on Empirical Methods in Natural Language Processing (EMNLP)},
+  Year                     = {2013},
+  Month                    = {10},
+
+  Url                      = {http://cogcomp.org/papers/JindalRo13c.pdf}
+}
+
+@InProceedings{JindalRo13b,
+  Title                    = {End-to-End Coreference Resolution for Clinical Narratives},
+  Author                   = {Prateek Jindal and Dan Roth},
+  Booktitle                = {Proc. of the International Joint Conference on Artificial Intelligence (IJCAI)},
+  Year                     = {2013},
+  Month                    = {8},
+  Pages                    = {2106-2112},
+
+  Acceptance               = {19\%},
+  Funding                  = {HHS 90TR003/01},
+  Url                      = {http://cogcomp.org/papers/JindalRo13.pdf}
+}
+
+@InProceedings{JindalRo12,
+  Title                    = {Using Knowledge and Constraints to Find the Best Antecedent},
+  Author                   = {Prateek Jindal and Dan Roth},
+  Booktitle                = {Proc. of the International Conference on Computational Linguistics (COLING)},
+  Year                     = {2012},
+  Month                    = {12},
+  Pages                    = {1327-1342},
+
+  Acceptance               = {20\%},
+  Funding                  = {Grant HHS 90TR0003/01},
+  Url                      = {http://cogcomp.org/papers/JindalRo12b.pdf}
+}
+
+@InProceedings{JindalRo11,
+  Title                    = {Learning from Negative Examples in Set-Expansion},
+  Author                   = {P. Jindal and D. Roth},
+  Booktitle                = {Proc. of the IEEE International Conference on Data Mining (ICDM)},
+  Year                     = {2011},
+  Month                    = {12},
+  Pages                    = {1110-1115},
+
+  Acceptance               = {18\%},
+  Url                      = {http://cogcomp.org/papers/JindalRo11.pdf}
+}
+
+@InProceedings{JindalRoGu14,
+  Title                    = {Joint Inference for End-to-End Coreference Resolution for Clinical Notes},
+  Author                   = {Prateek Jindal and Dan Roth and Carl A. Gunter},
+  Booktitle                = {Proc. of the ACM Conference on Proc. of the International Conference on Bioinformatics Models, Methods and Algorithms, Computational Biology, and Health Informatics},
+  Year                     = {2014},
+  Month                    = {9},
+
+  Url                      = {http://cogcomp.org/papers/p192-jindal.pdf}
+}
+
+@Other{JohriRoTu10,
+  Title                    = {Experts' Retrieval with Multiword-Enhanced Author Topic Model},
+  Author                   = {N. Johri and D. Roth and Y. Tu},
+  Booktitle                = {Proc. of the Annual Conference of the North American Chapter of the Association for Computational Linguistics (NAACL)},
+  Comment                  = {author topic model; multiword expression; expert search; information retrieval},
+  Funding                  = {MIAS},
+  Projects                 = {SEARCH},
+  Url                      = {http://cogcomp.org/papers/JohriRoTu10(1).pdf},
+  Year                     = {2010}
+}
+
+@Article{KhardonMaRo99,
+  Title                    = {Reasoning with Examples: Propositional Formulae and Database Dependencies},
+  Author                   = {R. Khardon and H. Mannila and D. Roth},
+  Journal                  = {Acta Informatica},
+  Year                     = {1999},
+
+  Month                    = {7},
+  Number                   = {4},
+  Pages                    = {267--286},
+  Volume                   = {36},
+
+  Url                      = {http://cogcomp.org/papers/db.pdf}
+}
+
+@Article{KhardonRo99,
+  Title                    = {Learning to Reason with a Restricted View},
+  Author                   = {R. Khardon and D. Roth},
+  Journal                  = {Machine Learning},
+  Year                     = {1999},
+  Number                   = {2},
+  Pages                    = {95--117},
+  Volume                   = {35},
+
+  Url                      = {http://cogcomp.org/papers/partialJ.pdf}
+}
+
+@Article{KhardonRo97,
+  Title                    = {Defaults and Relevance in Model Based Reasoning},
+  Author                   = {R. Khardon and D. Roth},
+  Journal                  = {Artificial Intelligence},
+  Year                     = {1997},
+
+  Month                    = {12},
+  Number                   = {1-2},
+  Pages                    = {169--193},
+  Volume                   = {97},
+
+  Url                      = {http://cogcomp.org/papers/relevanceJ.pdf}
+}
+
+@Article{KhardonRo97a,
+  Title                    = {Learning to Reason},
+  Author                   = {R. Khardon and D. Roth},
+  Journal                  = {Journal of the ACM},
+  Year                     = {1997},
+  Number                   = {5},
+  Pages                    = {697--725},
+  Volume                   = {44},
+
+  Url                      = {http://cogcomp.org/papers/l2rJ.pdf}
+}
+
+@Article{KhardonRo96,
+  Title                    = {Reasoning with Models},
+  Author                   = {R. Khardon and D. Roth},
+  Journal                  = {Artificial Intelligence},
+  Year                     = {1996},
+  Number                   = {1-2},
+  Pages                    = {187--213},
+  Volume                   = {87},
+
+  Comment                  = {Characteristic Models of Boolean Functions},
+  Url                      = {http://cogcomp.org/papers/modelsJ.pdf}
+}
+
+@TechReport{KhardonRo95,
+  Title                    = {Defaults and Relevance in Model Based Reasoning},
+  Author                   = {R. Khardon and D. Roth},
+  Institution              = {Dept. of App. Math. and Computer Science, Weizmann Institute of Science},
+  Year                     = {1995},
+  Month                    = {10},
+  Number                   = {CS95-30},
+
+  Url                      = {http://cogcomp.org/papers/KhardonRo95b.pdf}
+}
+
+@InProceedings{KhardonRo95a,
+  Title                    = {Learning to Reason with a Restricted View},
+  Author                   = {R. Khardon and D. Roth},
+  Booktitle                = {Proc. of the ACM Conference on Computational Learning Theory (COLT)},
+  Year                     = {1995},
+  Month                    = {7},
+  Pages                    = {301--310},
+
+  Acceptance               = {24/74 (32\%)}
+}
+
+@InProceedings{KhardonRo95b,
+  Title                    = {Default-Reasoning with Models},
+  Author                   = {R. Khardon and D. Roth},
+  Booktitle                = {Proc. of the International Joint Conference on Artificial Intelligence (IJCAI)},
+  Year                     = {1995},
+  Month                    = {8},
+  Pages                    = {319--325},
+
+  Acceptance               = {249/112 (22\%)}
+}
+
+@InProceedings{KhardonRo94,
+  Title                    = {A note on Horn Theories},
+  Author                   = {R. Khardon and D. Roth},
+  Year                     = {1994},
+
+  Comment                  = {Manuscript.}
+}
+
+@TechReport{KhardonRo94a,
+  Title                    = {Learning to Reason},
+  Author                   = {R. Khardon and D. Roth},
+  Institution              = {Aiken Computation Lab., Harvard University},
+  Year                     = {1994},
+  Month                    = {1},
+  Number                   = {TR-2-94},
+
+  Invisible                = {true}
+}
+
+@TechReport{KhardonRo94b,
+  Title                    = {Reasoning with Models},
+  Author                   = {R. Khardon and D. Roth},
+  Institution              = {Aiken Computation Lab., Harvard University},
+  Year                     = {1994},
+  Month                    = {1},
+  Number                   = {TR-1-94},
+
+  Invisible                = {true}
+}
+
+@InProceedings{KhardonRo94c,
+  Title                    = {Exploiting Relevance through Model-based reasoning},
+  Author                   = {R. Khardon and D. Roth},
+  Booktitle                = {Proc. of the AAAI Fall Symposium on Relevance},
+  Year                     = {1994},
+  Pages                    = {109-114},
+
+  Url                      = {http://cogcomp.org/papers/relevanceP.pdf}
+}
+
+@InProceedings{KhardonRo94d,
+  Title                    = {Learning to Reason},
+  Author                   = {R. Khardon and D. Roth},
+  Booktitle                = {Proc. of the Conference on Artificial Intelligence (AAAI)},
+  Year                     = {1994},
+  Pages                    = {682--687},
+
+  Acceptance               = {222/725 (31\%)},
+  Url                      = {http://cogcomp.org/papers/KhardonRo94a.pdf}
+}
+
+@InProceedings{KhardonRo94e,
+  Title                    = {Reasoning with Models},
+  Author                   = {R. Khardon and D. Roth},
+  Booktitle                = {Proc. of the Conference on Artificial Intelligence (AAAI)},
+  Year                     = {1994},
+  Pages                    = {1148--1153},
+
+  Acceptance               = {225/725 (31\%)},
+  Url                      = {http://cogcomp.org/papers/KhardonRo94.pdf}
+}
+
+@Article{KhardonRoSe05,
+  Title                    = {Efficiency versus Convergence of Boolean Kernels for On-Line Learning Algorithms},
+  Author                   = {R. Khardon and D. Roth and R. Servedio},
+  Journal                  = {Journal of Machine Learning Research},
+  Year                     = {2005},
+  Pages                    = {341-356},
+  Volume                   = {24},
+
+  Funding                  = {ITR-MIT NSF98 CAREER},
+  Projects                 = {KR,LT},
+  Url                      = {http://cogcomp.org/papers/KhardonRoSe05.pdf}
+}
+
+@InProceedings{KhardonRoSe01,
+  Title                    = {Efficiency versus Convergence of Boolean Kernels for On-Line Learning Algorithms},
+  Author                   = {R. Khardon and D. Roth and R. Servedio},
+  Booktitle                = {Proc. of the Conference on Neural Information Processing Systems (NIPS)},
+  Year                     = {2001},
+
+  Comment                  = {Kernel Perceptron with Exponentially Many mistakes; Hardness of Kernel Winnow.},
+  Funding                  = {ITR-MIT,NSF98,CAREER},
+  Projects                 = {KR,LT},
+  Url                      = {http://cogcomp.org/papers/kernels01.pdf}
+}
+
+@TechReport{KhardonRoSe01a,
+  Title                    = {Efficiency versus Convergence of Boolean Kernels for On-Line Learning Algorithm},
+  Author                   = {R. Khardon and D. Roth and R. Servedio},
+  Institution              = {UIUC Computer Science Department},
+  Year                     = {2001},
+  Month                    = {6},
+  Number                   = {UIUCDCS-R-2001-2233},
+
+  Funding                  = {ITR-MIT,NSF98,CAREER},
+  Invisible                = {true},
+  Projects                 = {KR,LT},
+  Url                      = {http://cogcomp.org/papers/KhardonRoSe01a.pdf}
+}
+
+@InProceedings{KhardonRoVa99,
+  Title                    = {Relational Learning for NLP using Linear Threshold Elements},
+  Author                   = {R. Khardon and D. Roth and L. G. Valiant},
+  Booktitle                = {Proc. of the International Joint Conference on Artificial Intelligence (IJCAI)},
+  Year                     = {1999},
+  Pages                    = {911--917},
+
+  Acceptance               = {195/750 (26\%)},
+  Funding                  = {NSF98 KDI},
+  Projects                 = {KR,LT,NLP},
+  Url                      = {http://cogcomp.org/papers/ijcai99krv.pdf}
+}
+
+@InProceedings{KKSCER16,
+  Title                    = {Question Answering via Integer Programming over Semi-Structured Knowledge},
+  Author                   = {Daniel Khashabi and Tushar Khot and Ashish Sabharwal and Peter Clark and Oren Etzioni and Dan Roth },
+  Booktitle                = {Proc. of the International Joint Conference on Artificial Intelligence (IJCAI)},
+  Year                     = {2016},
+
+  Url                      = {http://cogcomp.org/papers/KKSCER16.pdf}
+}
+
+@InProceedings{KKSR17,
+  Title                    = {Learning What is Essential in Questions},
+  Author                   = {Daniel Khashabi and Tushar Khot and Ashish Sabharwal and Dan Roth },
+  Booktitle                = {The Conference on Computational Natural Language Learning (Proc. of the Conference on Computational Natural Language Learning (CoNLL))},
+  Year                     = {2017},
+
+  Url                      = {http://cogcomp.org/papers/2017_conll_essential_terms.pdf}
+}
+
+@InProceedings{KDDKKPR00,
+  Title                    = {Applying System Combination to Base Noun Phrase Identification},
+  Author                   = {E. F. T. Kim-Sang and W. Daelemans and H. Dejean and R. Koeling and Y. Krymolowski and V. Punyakanok and D. Roth},
+  Booktitle                = {Proc. of the International Conference on Computational Linguistics and Annual Meeting of the Association for Computational Linguistics (COLING-ACL)},
+  Year                     = {2000},
+  Pages                    = {857--863},
+
+  Funding                  = {NSF98,KDI},
+  Url                      = {http://cogcomp.org/papers/KDDKKPR00.pdf}
+}
+
+@Other{Klementiev09,
+  Title                    = {Learning with Incidental Supervision},
+  Author                   = {A. Klementiev},
+  Booktitle                = {UIUC PhD Thesis },
+  Url                      = {http://cogcomp.org/papers/Klementiev09.pdf},
+  Year                     = {2009}
+}
+
+@InCollection{KlementievRo08,
+  Title                    = {Named Entity Transliteration and Discovery in Multilingual Corpora},
+  Author                   = {A. Klementiev and D. Roth},
+  Booktitle                = {Learning Machine Translation},
+  Publisher                = {MIT Press},
+  Year                     = {2008},
+  Editor                   = {Cyril Goutte and Nicola Cancedda and Marc Dymetman and George Foster},
+
+  Funding                  = {KINDLE,REFLEX},
+  Projects                 = {REFLEX,USS,TL,ADAPT},
+  Url                      = {http://cogcomp.org/papers/KlementievRo08.pdf}
+}
+
+@InProceedings{KlementievRo06,
+  Title                    = {Weakly Supervised Named Entity Transliteration and Discovery from Multilingual Comparable Corpora},
+  Author                   = {A. Klementiev and D. Roth},
+  Booktitle                = {Proc. of the Annual Meeting of the Association for Computational Linguistics (ACL)},
+  Year                     = {2006},
+  Month                    = {7},
+  Pages                    = {USS,TL,ADAPT},
+
+  Comment                  = {Multilingual named entities; multilingual search; multilingual named entities discovery and recognition; discriminatory transliteration model; Fourier Transform for temporal sequence similarity},
+  Funding                  = {KINDLE,REFLEX},
+  Projects                 = {REFLEX,USS,TL,ADAPT},
+  Url                      = {http://cogcomp.org/papers/KlementievRo06a.pdf}
+}
+
+@InProceedings{KlementievRo06a,
+  Title                    = {Named Entity Transliteration and Discovery from Multilingual Comparable Corpora},
+  Author                   = {A. Klementiev and D. Roth},
+  Booktitle                = {Proc. of the Annual Conference of the North American Chapter of the Association for Computational Linguistics (NAACL)},
+  Year                     = {2006},
+  Month                    = {6},
+  Pages                    = {82--88},
+
+  Comment                  = {Multilingual named entities; multilingual search; multilingual named entities discovery and recognition; discriminatory transliteration model; Fourier Transform for temporal sequence similarity},
+  Funding                  = {KINDLE,REFLEX},
+  Projects                 = {REFLEX,TL,USS,ADAPT},
+  Url                      = {http://cogcomp.org/papers/KlementievRo06.pdf}
+}
+
+@Other{KlementievRoSm08,
+  Title                    = {A Framework for Unsupervised Rank Aggregation},
+  Author                   = {A. Klementiev and D. Roth and K. Small},
+  Booktitle                = {Proc. of the ACM SIGIR Conference (SIGIR)},
+  Funding                  = {ITR-EDU, BL, MIAS},
+  Month                    = {7},
+  Pages                    = {32-39},
+  Projects                 = {USS,RANK},
+  Url                      = {http://cogcomp.org/papers/KlementievRoSm08a.pdf},
+  Year                     = {2008}
+}
+
+@InProceedings{KlementievRoSm08a,
+  Title                    = {Unsupervised Rank Aggregation with Distance-Based Models},
+  Author                   = {A. Klementiev and D. Roth and K. Small},
+  Booktitle                = {Proc. of the International Conference on Machine Learning (ICML)},
+  Year                     = {2008},
+  Month                    = {7},
+
+  Acceptance               = {158/583 (27\%) (regular papers)},
+  Comment                  = {We propose a mathematical and algorithmic framework for learning to aggregate (partial) rankings without supervision. We instantiate the framework for the cases of combining permutations and combining top-k lists, and propose a novel metric for the latter.},
+  Funding                  = {ITR-EDU, BL, MIAS},
+  Projects                 = {USS,RANK},
+  Url                      = {http://cogcomp.org/papers/KlementievRoSm08.pdf}
+}
+
+@InProceedings{KlementievRoSm07,
+  Title                    = {An Unsupervised Learning Algorithm for Rank Aggregation},
+  Author                   = {A. Klementiev and D. Roth and K. Small},
+  Booktitle                = {Proc. of the European Conference on Machine Learning (ECML)},
+  Year                     = {2007},
+  Month                    = {9},
+
+  Funding                  = {ITR-EDU, MIAS},
+  Projects                 = {USS,RANK},
+  Url                      = {http://cogcomp.org/papers/KlementievRoSm07.pdf}
+}
+
+@InProceedings{KRST09,
+  Title                    = {Unsupervised Rank Aggregation with Domain-Specific Expertise},
+  Author                   = {A. Klementiev and D. Roth and K. Small and I. Titov},
+  Booktitle                = {Proc. of the International Joint Conference on Artificial Intelligence (IJCAI)},
+  Year                     = {2009},
+  Month                    = {7},
+
+  Acceptance               = {331/1290 (25.7 \%)},
+  Comment                  = {Proposes a framework for learning to aggregate votes of rankers with domain specific expertise without supervision. Applies the learning framework to the settings of aggregating full rankings and aggregating top-k lists, demonstrating significant improvements over a domain-agnostic baseline in both cases.},
+  Funding                  = {ITR-EDU, BL, MIAS},
+  Projects                 = {USS, RANK},
+  Url                      = {http://cogcomp.org/papers/KRST09.pdf}
+}
+
+@InProceedings{KPRY05,
+  Title                    = {Generalized Inference with Multiple Semantic Role Labeling Systems Shared Task Paper},
+  Author                   = {P. Koomen and V. Punyakanok and D. Roth and W. Yih},
+  Booktitle                = {Proc. of the Conference on Computational Natural Language Learning (CoNLL)},
+  Year                     = {2005},
+  Editor                   = {Ido Dagan and Dan Gildea},
+  Pages                    = {181-184},
+
+  Comment                  = {Semantic Parsing; joint inference; integer linear programming; combining SRL systems via joint inference; Top system in CoNLL shared task},
+  Funding                  = {MURI,KINDLE,CLUSTER,XPRESSMP},
+  Projects                 = {SM,KINDLE,SRL},
+  Url                      = {http://cogcomp.org/papers/PunyakanokRoYi05a.pdf}
+}
+
+@InProceedings{KKCMSR16,
+  Title                    = {Better call Saul: Flexible Programming for Learning and Inference in NLP},
+  Author                   = {Parisa Kordjamshidi and Daniel Khashabi and Christos Christodoulopoulos and Bhargav Mangipudi and Sameer Singh and Dan Roth },
+  Booktitle                = {Proc. of the International Conference on Computational Linguistics (COLING)},
+  Year                     = {2016},
+
+  Url                      = {http://cogcomp.org/papers/KKCMSR16.pdf}
+}
+
+@Article{KordjamshidiRoMo15,
+  Title                    = {Structured Learning for Spatial Information Extraction from Biomedical Text: Bacteria Biotopes},
+  Author                   = {Parisa Kordjamshidi and Dan Roth and Marie-Francine Moens},
+  Year                     = {2015},
+
+  Month                    = {4},
+  Number                   = {126},
+  Volume                   = {16},
+
+  Booktitle                = {BMC Proc. of the International Conference on Bioinformatics Models, Methods and Algorithms},
+  Url                      = {http://cogcomp.org/papers/BMC_Bacteria_Biotope.pdf}
+}
+
+@InProceedings{KSKCSSR17,
+  Title                    = {Relational Learning and Feature Extraction by Querying over Heterogeneous Information Networks},
+  Author                   = {Parisa Kordjamshidi and Sameer Singh and Daniel Khashabi and Christos Christodoulopoulos and Mark Summons and Saurabh Sinha and Dan Roth },
+  Booktitle                = {Seventh International Workshop on Statistical Relational AI (StarAI)},
+  Year                     = {2017},
+
+  Url                      = {http://cogcomp.org/papers/2017_saul_relational_learning_starai.pdf}
+}
+
+@InProceedings{KordjamshidiWuRo15,
+  Title                    = {Saul: Towards Declarative Learning Based Programming},
+  Author                   = {Parisa Kordjamshidi and Hao Wu and Dan Roth},
+  Booktitle                = {Proc. of the International Joint Conference on Artificial Intelligence (IJCAI)},
+  Year                     = {2015},
+  Month                    = {7},
+
+  Url                      = {http://cogcomp.org/papers/KordjamshidiRoWu15.pdf}
+}
+
+@Other{KrymolowskiRo98,
+  Title                    = {Incorporating Knowledge in Natural Language Learning: A Case Study},
+  Author                   = {Y. Krymolowski and D. Roth},
+  Booktitle                = {Coling-Acl workshop on the Usage of WordNet in Natural Language Processing Systems},
+  Comment                  = {Prepositional Phrase Attachment (PPA); using WordNet to generate expressive features.},
+  Funding                  = {NSF98,KDI},
+  Pages                    = {121--127},
+  Projects                 = {NLP},
+  Url                      = {http://cogcomp.org/papers/pp-wn.pdf},
+  Year                     = {1998}
+}
+
+@Other{KunduChRo11,
+  Title                    = {Prior Knowledge Driven Domain Adaptation},
+  Author                   = {G. Kundu and M. Chang and D. Roth},
+  Booktitle                = {Proc. of the International Conference on Machine Learning (ICML)},
+  Funding                  = {ARL and DARPA Machine Reading},
+  Month                    = {7},
+  Url                      = {http://cogcomp.org/papers/KunduChRo11(3).pdf},
+  Year                     = {2011}
+}
+
+@InProceedings{KunduRo11,
+  Title                    = {Adapting Text Instead of the Model: An Open Domain Approach},
+  Author                   = {G. Kundu and D. Roth},
+  Booktitle                = {Proc. of the Conference on Computational Natural Language Learning (CoNLL)},
+  Year                     = {2011},
+  Month                    = {6},
+
+  Funding                  = {Darpa MR and ARL},
+  Url                      = {http://cogcomp.org/papers/KunduRo11.pdf}
+}
+
+@Other{KunduRoSa11,
+  Title                    = {Constrained Conditional Models For Information Fusion},
+  Author                   = {G. Kundu and D. Roth and R. Samdani},
+  Booktitle                = {Proc. of the International Conference on Information Fusion},
+  Url                      = {http://cogcomp.org/papers/SamdaniRothKunduFusion2011.pdf},
+  Year                     = {2011}
+}
+
+@InProceedings{KunduSrRo13,
+  Title                    = {Margin-based Decomposed Amortized Inference},
+  Author                   = {Gourab Kundu and Vivek Srikumar and Dan Roth},
+  Booktitle                = {Proc. of the Annual Meeting of the Association for Computational Linguistics (ACL)},
+  Year                     = {2013},
+  Month                    = {8},
+
+  Url                      = {http://cogcomp.org/papers/KunduSrRo13.pdf}
+}
+
+@Article{KushilevitzRo96,
+  Title                    = {On Learning Visual Concepts and DNF Formulae},
+  Author                   = {A. Kushilevitz and D. Roth},
+  Journal                  = {Machine Learning},
+  Year                     = {1996},
+  Number                   = {1},
+  Pages                    = {65--85},
+  Volume                   = {24},
+
+  Url                      = {http://cogcomp.org/papers/visualJ.pdf}
+}
+
+@InProceedings{KushilevitzRo93,
+  Title                    = {On Learning Visual Concepts and DNF Formulae},
+  Author                   = {A. Kushilevitz and D. Roth},
+  Booktitle                = {Proc. of the ACM Conference on Computational Learning Theory (COLT)},
+  Year                     = {1993},
+  Pages                    = {317--326},
+
+  Comment                  = {30/83 (37%)}
+}
+
+@Other{LPAGSAHRSA11,
+  Title                    = {Apollo: Towards Factfinding in Participatory Sensing},
+  Author                   = {H. Khac Le and J. Pasternack and H. Ahmadi and M. Gupta and Y. Sun and T. Abdelzaher and J. Han and D. Roth and B. Szymanski and S. Adali},
+  Booktitle                = {Proc. of the International Conference on Information Processing in Sensor Networks (IPSN)},
+  Url                      = {http://cogcomp.org/papers/LePa11.pdf},
+  Year                     = {2011}
+}
+
+@Other{LCUR15,
+  Title                    = {Distributed Training of Structured SVM},
+  Author                   = {Ching-pei Lee and Kai-Wei Chang and Shyam Upadhyay and Dan Roth},
+  Booktitle                = {OPT Workshop, Proc. of the Conference on Neural Information Processing Systems (NIPS)},
+  Url                      = {http://cogcomp.org/papers/OPT2015_paper_1.pdf},
+  Year                     = {2015}
+}
+
+@InProceedings{LeeRo15,
+  Title                    = {Distributed Box-Constrained Quadratic Optimization for Dual Linear SVM},
+  Author                   = {Ching-pei Lee and Dan Roth},
+  Booktitle                = {Proc. of the International Conference on Machine Learning (ICML)},
+  Year                     = {2015},
+  Month                    = {7},
+
+  Acceptance               = {26\%},
+  Funding                  = {DEFT},
+  Url                      = {http://cogcomp.org/papers/distcd.pdf}
+}
+
+@InProceedings{LDWSVR10,
+  Title                    = {Automatic Model Adaptation for Complex Structured Domains},
+  Author                   = {G. Levine and G. DeJong and L. Wang and R. Samdani and S. Vembu and D. Roth},
+  Booktitle                = {Proc. of the European Conference on Machine Learning and Principles and Practice of Knowledge Discovery in Databases (ECML PKDD)},
+  Year                     = {2010}
+}
+
+@Article{LiMoRo05,
+  Title                    = {Semantic Integration in Text: From Ambiguous Names to Identifiable Entities},
+  Author                   = {X. Li and P. Morie and D. Roth},
+  Journal                  = {AI Magazine. Special Issue on Semantic Integration},
+  Year                     = {2005},
+  Pages                    = {45--68},
+
+  Comment                  = {Named Entity Recognition; coreference resolution; entity identification; matching Entities Mentions within and across documents.},
+  Funding                  = {MURI,TRECC,CLUSTER},
+  Projects                 = {MIRROR,COREF,NER},
+  Url                      = {http://cogcomp.org/papers/LiMoRo05.pdf}
+}
+
+@InProceedings{LiMoRo04,
+  Title                    = {Identification and Tracing of Ambiguous Names: Discriminative and Generative Approaches},
+  Author                   = {X. Li and P. Morie and D. Roth},
+  Booktitle                = {Proc. of the Conference on Artificial Intelligence (AAAI)},
+  Year                     = {2004},
+  Pages                    = {419--424},
+
+  Acceptance               = {120/453 (26.5\%)},
+  Comment                  = {Comparing discriminatory and generative models for entity identification; named entity recognition; coreference resolution; matching entities mentions within and across documents; distance metrics for named entities},
+  Funding                  = {MURI,TRECC,CLUSTER},
+  Projects                 = {MIRROR,COREF,NER},
+  Url                      = {http://cogcomp.org/papers/LiMoRo04.pdf}
+}
+
+@InProceedings{LiMoRo04a,
+  Title                    = {Robust Reading: Identification and Tracing of Ambiguous Names},
+  Author                   = {X. Li and P. Morie and D. Roth},
+  Booktitle                = {Proc. of the Annual Conference of the North American Chapter of the Association for Computational Linguistics (NAACL)},
+  Year                     = {2004},
+  Pages                    = {17--24},
+
+  Comment                  = {A generative model for entity identification; Named Entity Recognition; coreference resolution; matching entities mentions within and across documents},
+  Funding                  = {MURI,TRECC,CLUSTER},
+  Projects                 = {MIRROR,NER,COREF},
+  Url                      = {http://cogcomp.org/papers/LiMoRo04a.pdf}
+}
+
+@TechReport{LiMoRo03,
+  Title                    = {Robust Reading of Ambiguous Writing},
+  Author                   = {X. Li and P. Morie and D. Roth},
+  Institution              = {UIUC Computer Science Department},
+  Year                     = {2003},
+  Month                    = {8},
+  Number                   = {UIUCDCS-R-2003-2371},
+
+  Funding                  = {MURI,ITR-BI},
+  Invisible                = {true},
+  Projects                 = {MIRROR,COREF,NER},
+  Url                      = {http://cogcomp.org/papers/LiMoRo03.pdf}
+}
+
+@InProceedings{LiRo05,
+  Title                    = {Discriminative Training of Clustering Functions: Theory and Experiments with Entity Identification},
+  Author                   = {X. Li and D. Roth},
+  Booktitle                = {Proc. of the Conference on Computational Natural Language Learning (CoNLL)},
+  Year                     = {2005},
+  Editor                   = {Ido Dagan and Dan Gildea},
+  Pages                    = {64--71},
+  Publisher                = {Association for Computational Linguistics},
+
+  Acceptance               = {19/70 (27\%)},
+  Comment                  = {Clustering; metric learning; training metrics; entity identification},
+  Funding                  = {ITR-BI,MURI,TRECC},
+  Projects                 = {MIRROR,NER},
+  Url                      = {http://cogcomp.org/papers/LiRo05.pdf}
+}
+
+@Article{LiRo05a,
+  Title                    = {Learning Question Classifiers: The Role of Semantic Information},
+  Author                   = {X. Li and D. Roth},
+  Journal                  = {Journal of Natural Language Engineering},
+  Year                     = {2005},
+  Number                   = {4},
+  Volume                   = {11},
+
+  Comment                  = {Question Classification; Hierarchical classifiers; Sequential Model; Expressive Feature generation with semantic information.},
+  Funding                  = {MURI,ITR-MIT},
+  Projects                 = {QA,MCR,TE},
+  Url                      = {http://cogcomp.org/papers/LiRo05a.pdf}
+}
+
+@InProceedings{LiRo05b,
+  Title                    = {Discriminative Training of Clustering Functions: Theory and Experiments with Entity Identification},
+  Author                   = {X. Li and D. Roth},
+  Booktitle                = {Proc. of the Midwest Computational Linguistics Colloquium (MCLC)},
+  Year                     = {2005},
+  Month                    = {5},
+
+  Comment                  = {Supervised Learning, Clustering, Metric Learning},
+  Funding                  = {MURI,TRECC},
+  Invisible                = {true},
+  Projects                 = {LT,NER}
+}
+
+@InProceedings{LiRo04,
+  Title                    = {Supervised Discriminative Clustering},
+  Author                   = {X. Li and D. Roth},
+  Booktitle                = {Proc. of the Conference on Neural Information Processing Systems (NIPS) Workshop on Learning Structured Output},
+  Year                     = {2004},
+
+  Comment                  = {Supervised Learning, Clustering, Metric Learning},
+  Funding                  = {MURI,TRECC},
+  Invisible                = {true},
+  Projects                 = {LT}
+}
+
+@InProceedings{LiRo02,
+  Title                    = {Learning Question Classifiers},
+  Author                   = {X. Li and D. Roth},
+  Booktitle                = {Proc. of the International Conference on Computational Linguistics (COLING)},
+  Year                     = {2002},
+  Pages                    = {556--562},
+
+  Acceptance               = {198-435 (45\%)},
+  Comment                  = {Classifying Answer Type for Question Answering. Sequential Classification. Multiclass Classification.},
+  Funding                  = {NSF98,MURI,ITR-MIT},
+  Projects                 = {CCR,QA,TE},
+  Url                      = {http://cogcomp.org/papers/qc-coling02.pdf}
+}
+
+@InProceedings{LiRo01,
+  Title                    = {Exploring Evidence for Shallow Parsing},
+  Author                   = {X. Li and D. Roth},
+  Booktitle                = {Proc. of the Conference on Computational Natural Language Learning (CoNLL)},
+  Year                     = {2001},
+  Pages                    = {107--110},
+
+  Comment                  = {Learning Shallow Parsers vs. Full Parsers for Chunking tasks},
+  Funding                  = {ITR-MIT,NSF98,MURI},
+  Projects                 = {LnI,SI,IE,NE,NLP},
+  Url                      = {http://cogcomp.org/papers/conll01.pdf}
+}
+
+@InProceedings{LiRoSm04,
+  Title                    = {The Role of Semantic Information in Learning Question Classifiers},
+  Author                   = {X. Li and D. Roth and K. Small},
+  Booktitle                = {Proc. of the International Joint Conference on Natural Language Processing (IJCNLP)},
+  Year                     = {2004},
+
+  Acceptance               = {67/211 (32\%)},
+  Comment                  = {Question Classification; Hierarchical classifiers; Sequential Model; Expressive Feature Generation with semantic information.},
+  Funding                  = {MURI,ITR-MIT},
+  Projects                 = {QA,MCR,TE},
+  Url                      = {http://cogcomp.org/papers/LiRoSm04.pdf}
+}
+
+@InProceedings{LiRoTu03,
+  Title                    = {Phrasenet: towards context sensitive lexical semantics},
+  Author                   = {X. Li and D. Roth and Y. Tu},
+  Booktitle                = {Proc. of the Conference on Computational Natural Language Learning (CoNLL)},
+  Year                     = {2003},
+
+  Comment                  = {Extending WordNet to taxonomy over phrases},
+  Funding                  = {MURI,ITR-BI},
+  Projects                 = {NLP, PHRASENET,LS},
+  Url                      = {http://cogcomp.org/papers/LiRoTu.pdf}
+}
+
+@InProceedings{LRSS08,
+  Title                    = {Proactive Intrusion Detection},
+  Author                   = {B. Liebald and D. Roth and N. Shah and V. Srikumar},
+  Booktitle                = {Proc. of the Conference on Artificial Intelligence (AAAI)},
+  Year                     = {2008},
+  Month                    = {7},
+
+  Funding                  = {DARPA,Boeing},
+  Url                      = {http://cogcomp.org/papers/LRSS08.pdf}
+}
+
+@InProceedings{LingSoRo16,
+  Title                    = {Word Embeddings with Limited Memory},
+  Author                   = {Shaoshi Ling and Yangqiu Song and Dan Roth},
+  Booktitle                = {Proc. of the Annual Meeting of the Association for Computational Linguistics (ACL)},
+  Year                     = {2016},
+
+  Url                      = {http://cogcomp.org/papers/LingSoRo16.pdf}
+}
+
+@InProceedings{LuRo12,
+  Title                    = {Automatic Event Extraction with Structured Preference Modeling},
+  Author                   = {Wei Lu and Dan Roth},
+  Booktitle                = {Proc. of the Annual Meeting of the Association for Computational Linguistics (ACL)},
+  Year                     = {2012},
+  Month                    = {7},
+  Pages                    = {10},
+
+  Acceptance               = {19\%},
+  Funding                  = {Machine Reading},
+  Projects                 = {Machine Reading},
+  Url                      = {http://cogcomp.org/papers/LuRo12.pdf}
+}
+
+@InProceedings{LWZR12,
+  Title                    = {Unsupervised Discovery of Opposing Opinion Networks From Forum Discussions},
+  Author                   = {Yue Lu and Hongning Wang and ChengXiang Zhai and Dan Roth},
+  Booktitle                = {Proc. of the ACM Conference on Information and Knowledge Management (CIKM)},
+  Year                     = {2012},
+  Month                    = {10},
+
+  Url                      = {http://cogcomp.org/papers/LWZR12.pdf}
+}
+
+@InProceedings{MKPM15,
+  Title                    = {Machine Reading of Biological Texts: Bacteria-Biotope Extraction},
+  Author                   = {Wouter Massa and Parisa Kordjamshidi and Thomas Provoost and Marie-Francine Moens},
+  Booktitle                = {Proc. of the International Conference on Bioinformatics Models, Methods and Algorithms},
+  Year                     = {2015},
+  Pages                    = {55-64},
+  Publisher                = {SCITEPRESS},
+
+  Url                      = {http://cogcomp.org/papers/MassaetalBIOSTEC2015.pdf}
+}
+
+@Article{MavronicolasRo99,
+  Title                    = {Linearizable Read/Write Objects},
+  Author                   = {M. Mavronicolas and D. Roth},
+  Journal                  = {Theoretical Computer Science},
+  Year                     = {1999},
+
+  Month                    = {6},
+  Number                   = {1},
+  Pages                    = {267--319},
+  Volume                   = {220},
+
+  Url                      = {http://cogcomp.org/papers/linearJ.pdf}
+}
+
+@InProceedings{MavronicolasRo92,
+  Title                    = {Efficient, Strongly Consistent Implementation of Shared Memory},
+  Author                   = {M. Mavronicolas and D. Roth},
+  Booktitle                = {Proc. of the Workshop on Distributed Algorithms (WDAG)},
+  Year                     = {1992},
+  Pages                    = {346--361},
+
+  Acceptance               = {24/38 (63\%)},
+  Url                      = {http://cogcomp.org/papers/wdagP.pdf}
+}
+
+@InProceedings{MavronicolasRo91,
+  Title                    = {Sequential Consistency and Linearizability: Read/Write Objects},
+  Author                   = {M. Mavronicolas and D. Roth},
+  Booktitle                = {Proc. of the Allerton Conference on Communications, Control and Computing},
+  Year                     = {1991},
+  Pages                    = {683--692},
+
+  Acceptance               = {32/77 (42\%)}
+}
+
+@InProceedings{MayhewTsRo17,
+  Title                    = {Cheap Translation for Cross-Lingual Named Entity Recognition},
+  Author                   = {Stephen Mayhew and Chen-Tse Tsai and Dan Roth},
+  Booktitle                = {Proc. of the Conference on Empirical Methods in Natural Language Processing (EMNLP)},
+  Year                     = {2017},
+
+  Funding                  = {LORELEI, DEFT},
+  Url                      = {http://cogcomp.org/papers/MayhewTsRo17.pdf}
+}
+
+@TechReport{MengshoelRoWi00,
+  Title                    = {Hard and Easy Bayesian Networks for Computing the Most Probable Explanation},
+  Author                   = {O. Mengshoel and D. Roth and D. Wilkins},
+  Institution              = {UIUC Computer Science Department},
+  Year                     = {2000},
+  Month                    = {1},
+  Number                   = {UIUCDCS-R-2000-2147},
+
+  Invisible                = {true},
+  Url                      = {http://cogcomp.org/papers/MengshoelRoWi00b.pdf}
+}
+
+@Article{MengshoelRoWi11,
+  Title                    = {Portfolios in Stochastic Local Search: Efficiently Computing Most Probable Explanations in Bayesian Networks},
+  Author                   = {O. J. Mengshoel and D. Roth and D. C. Wilkins},
+  Journal                  = {Journal of Automated Reasoning},
+  Year                     = {2011},
+  Number                   = {2},
+  Pages                    = {103-160},
+  Volume                   = {46},
+
+  Url                      = {http://cogcomp.org/papers/MengshoelRoWi11.pdf}
+}
+
+@Article{MengshoelRoWi06,
+  Title                    = {Controlled generation of hard and easy Bayesian networks: Impact on maximal clique size in tree clustering},
+  Author                   = {O. J. Mengshoel and D. Roth and D. C. Wilkins},
+  Journal                  = {Artificial Intelligence},
+  Year                     = {2006},
+
+  Url                      = {http://cogcomp.org/papers/MengshoelWiRo06.pdf}
+}
+
+@Article{MengshoelWiRo11,
+  Title                    = {Initialization and Restart in Stochastic Local Search: Computing a Most Probable Explanation in Bayesian Networks},
+  Author                   = {O. J. Mengshoel and D. C. Wilkins and D. Roth},
+  Journal                  = {IEEE Transactions on Knowledge and Data Engineering},
+  Year                     = {2011},
+  Number                   = {2},
+  Pages                    = {235-247},
+  Volume                   = {23},
+
+  Url                      = {http://cogcomp.org/papers/MengshoelWiRo11.pdf}
+}
+
+@InProceedings{MPRZ99,
+  Title                    = {A Learning Approach to Shallow Parsing},
+  Author                   = {M. Munoz and V. Punyakanok and D. Roth and D. Zimak},
+  Booktitle                = {Proc. of the Joint Conference on Empirical Methods in Natural Language Processing and Very Large Corpora (EMNLP-VLC)},
+  Year                     = {1999},
+  Month                    = {6},
+  Pages                    = {168--178},
+
+  Funding                  = {NSF98 KDI},
+  Projects                 = {LnI,SI,NLP},
+  Url                      = {http://cogcomp.org/papers/shallow-long.pdf}
+}
+
+@TechReport{MPRZ99a,
+  Title                    = {A Learning Approach to Shallow Parsing},
+  Author                   = {M. Munoz and V. Punyakanok and D. Roth and D. Zimak},
+  Institution              = {UIUC Computer Science Department},
+  Year                     = {1999},
+  Month                    = {4},
+  Number                   = {UIUCDCS-R-99-2087},
+
+  Invisible                = {true},
+  Url                      = {http://cogcomp.org/papers/MPRZ99b.pdf}
+}
+
+@Other{NGDIDNDHPR17,
+  Title                    = {Towards Problem Solving Agents that Communicate and Learn},
+  Author                   = {Anjali Narayan-Chen and Colin Graber and Mayukh Das and Md Rakibul Islam and Soham Dan and Sriraam Natarajan and Janardhan Rao Doppa and Julia Hockenmaier and Martha Palmer and Dan Roth},
+  Url                      = {http://cogcomp.org/papers/ngdidndhpr17.pdf},
+  Year                     = {2017}
+}
+
+@InProceedings{NingFeRo17,
+  Title                    = {A Structured Learning Approach to Temporal Relation Extraction},
+  Author                   = {Qiang Ning and Zhili Feng and Dan Roth},
+  Booktitle                = {Proc. of the Conference on Empirical Methods in Natural Language Processing (EMNLP)},
+  Year                     = {2017},
+
+  Address                  = {Copenhagen, Denmark},
+  Month                    = {9},
+  Pages                    = {1038--1048},
+  Publisher                = {Association for Computational Linguistics},
+
+  Funding                  = {AI2, IBM-ILLINOIS C3SR, DARPA, ARL},
+  Url                      = {http://cogcomp.org/papers/NingFeRo17.pdf}
+}
+
+@Other{Pasternack11,
+  Title                    = {Knowing Who to Trust and What to Believe in the Presence of Conflicting Information},
+  Author                   = {J. Pasternack},
+  Booktitle                = {UIUC PhD Thesis},
+  Invisible                = {true},
+  Url                      = {http://cogcomp.org/papers/Pasternack11.pdf},
+  Year                     = {2011}
+}
+
+@InCollection{PasternackRo14,
+  Title                    = {Judging the Veracity of Claims and Reliability of Sources With Fact-Finders},
+  Author                   = {Jeff Pasternack and Dan Roth},
+  Booktitle                = {Computational Trust Models and Machine Learning},
+  Publisher                = {Chapman and Hall/CRC},
+  Year                     = {2014},
+  Editor                   = {Xin Liu, Anwitaman Datta, and Ee-Peng Lim},
+  Pages                    = {39-72},
+
+  Url                      = {http://cogcomp.org/papers/fact_finder_chapter_clean.pdf}
+}
+
+@InProceedings{PasternackRo13,
+  Title                    = {Latent Credibility Analysis},
+  Author                   = {Jeff Pasternack and Dan Roth},
+  Booktitle                = {Proc. of the International World Wide Web Conference (WWW)},
+  Year                     = {2013},
+
+  Url                      = {http://cogcomp.org/papers/PasternackRo13.pdf}
+}
+
+@InProceedings{PasternackRo11,
+  Title                    = {Making Better Informed Trust Decisions with Generalized Fact-Finding},
+  Author                   = {J. Pasternack and D. Roth},
+  Booktitle                = {Proc. of the International Joint Conference on Artificial Intelligence (IJCAI)},
+  Year                     = {2011},
+
+  Funding                  = {ARL, DHS},
+  Url                      = {http://cogcomp.org/papers/PasternackRo11b.pdf}
+}
+
+@InProceedings{PasternackRo11a,
+  Title                    = {Generalized Fact-Finding},
+  Author                   = {J. Pasternack and D. Roth},
+  Booktitle                = {Proc. of the International World Wide Web Conference (WWW)},
+  Year                     = {2011},
+
+  Url                      = {http://cogcomp.org/papers/PasternackRo11.pdf}
+}
+
+@InProceedings{PasternackRo10,
+  Title                    = {Comprehensive Trust Metrics for Information Networks},
+  Author                   = {J. Pasternack and D. Roth},
+  Booktitle                = {Proc. of the Army Science Conference (ASC)},
+  Year                     = {2010},
+
+  Address                  = {Orlando, Florida},
+  Month                    = {12},
+
+  Url                      = {http://cogcomp.org/papers/PasternackRo10b.pdf}
+}
+
+@InProceedings{PasternackRo10a,
+  Title                    = {Knowing What to Believe (when you already know something)},
+  Author                   = {J. Pasternack and D. Roth},
+  Booktitle                = {Proc. of the International Conference on Computational Linguistics (COLING)},
+  Year                     = {2010},
+
+  Address                  = {Beijing, China},
+  Month                    = {8},
+
+  Comment                  = {Trustworthiness. Truth Finders. Using prior knowledge to both improve the accuracy of trust and belief decisions and permit such decisions to be made subjectively relative to the user},
+  Funding                  = {ARL},
+  Projects                 = {TRUST, IE, USS},
+  Url                      = {http://cogcomp.org/papers/PasternackRo10.pdf}
+}
+
+@InProceedings{PasternackRo09,
+  Title                    = {Learning Better Transliterations},
+  Author                   = {J. Pasternack and D. Roth},
+  Booktitle                = {Proc. of the ACM Conference on Information and Knowledge Management (CIKM)},
+  Year                     = {2009},
+  Month                    = {11},
+
+  Comment                  = {State-of-the-art transliteration with unbounded substring-to-substring productions and capable of both discovery and generation.},
+  Funding                  = {MIAS},
+  Projects                 = {TL},
+  Url                      = {http://cogcomp.org/papers/PasternackRo09a.pdf}
+}
+
+@InProceedings{PasternackRo09a,
+  Title                    = {Extracting Article Text from the Web with Maximum Subsequence Segmentation},
+  Author                   = {J. Pasternack and D. Roth},
+  Booktitle                = {Proc. of the International World Wide Web Conference (WWW)},
+  Year                     = {2009},
+  Month                    = {4},
+
+  Comment                  = {A new global optimization technique, maximum subsequence, is used to accurately identify and extract article text from HTML documents in linear time},
+  Projects                 = {IE},
+  Url                      = {http://cogcomp.org/papers/PasternackRo09.pdf}
+}
+
+@TechReport{PasternackRo08,
+  Title                    = {The Wikipedia Corpus},
+  Author                   = {J. Pasternack and D. Roth},
+  Year                     = {2008},
+
+  Journal                  = {University of Illinois Technical Report},
+  Url                      = {http://cogcomp.org/papers/PasternackRo08.pdf}
+}
+
+@InProceedings{PengChRo15,
+  Title                    = {A Joint Framework for Coreference Resolution and Mention Head Detection},
+  Author                   = {Haoruo Peng and Kai-Wei Chang and Dan Roth},
+  Booktitle                = {Proc. of the Conference on Computational Natural Language Learning (CoNLL)},
+  Year                     = {2015},
+
+  Address                  = {University of Illinois, Urbana-Champaign, Urbana, IL, 61801},
+  Month                    = {7},
+  Pages                    = {10},
+  Publisher                = {ACL},
+
+  Institution              = {University of Illinois at Urbana-Champaign},
+  Url                      = {http://cogcomp.org/papers/MentionDetection.pdf}
+}
+
+@InProceedings{PengChRo17,
+  Title                    = {A Joint Model for Semantic Sequences: Frames, Entities, Sentiments},
+  Author                   = {Haoruo Peng and Snigdha Chaturvedi and Dan Roth},
+  Booktitle                = {Proc. of the Conference on Computational Natural Language Learning (CoNLL)},
+  Year                     = {2017},
+
+  Institution              = {University of Illinois, Urbana-Champaign},
+  Url                      = {http://cogcomp.org/papers/PengChRo17.pdf}
+}
+
+@InProceedings{PengKhRo15,
+  Title                    = {Solving Hard Coreference Problems},
+  Author                   = {Haoruo Peng and Daniel Khashabi and Dan Roth},
+  Booktitle                = {Proc. of the Annual Conference of the North American Chapter of the Association for Computational Linguistics (NAACL)},
+  Year                     = {2015},
+  Month                    = {5},
+
+  Url                      = {http://cogcomp.org/papers/PengKhRo15.pdf}
+}
+
+@InProceedings{PengRo16,
+  Title                    = {Two Discourse Driven Language Models for Semantics},
+  Author                   = {Haoruo Peng and Dan Roth},
+  Booktitle                = {Proc. of the Annual Meeting of the Association for Computational Linguistics (ACL)},
+  Year                     = {2016},
+
+  Url                      = {http://cogcomp.org/papers/PengRo16.pdf}
+}
+
+@InProceedings{PengSoRo16,
+  Title                    = {Event Detection and Co-reference with Minimal Supervision},
+  Author                   = {Haoruo Peng and Yangqiu Song and Dan Roth},
+  Booktitle                = {Proc. of the Conference on Empirical Methods in Natural Language Processing (EMNLP)},
+  Year                     = {2016},
+
+  Url                      = {http://cogcomp.org/papers/PengSoRo16.pdf}
+}
+
+@Other{PRSCR10,
+  Title                    = {Object Search: Supporting Structured Queries in Web Search Engines},
+  Author                   = {K. Pham and N. Rizzolo and K. Small and K. Chang and D. Roth},
+  Booktitle                = {Proc. of the Annual Conference of the North American Chapter of the Association for Computational Linguistics (NAACL) Workshop on Semantic Search},
+  Comment                  = {Searching on the web for objects by their properties without first building a database; uses LBP/LBJ.},
+  Funding                  = {MIAS, NSF-SoD},
+  Month                    = {6},
+  Projects                 = {LBP},
+  Url                      = {http://cogcomp.org/papers/PRSCR10.pdf},
+  Year                     = {2010}
+}
+
+@TechReport{PunyakanokRo05,
+  Title                    = {Inference with Classifiers: The Phrase Identification Problem},
+  Author                   = {V. Punyakanok and D. Roth},
+  Year                     = {2005},
+
+  Comment                  = {Shallow Parsing; Chunking; HMMs, Conditional Models and Constraint Satisfaction Models. Top results on phrase chunking},
+  Funding                  = {CAREER,ITR-MIT,NSF98,KINDLE},
+  Journal                  = {UIUC Technical Report},
+  Projects                 = {LnI,IE,NE,CCM},
+  Url                      = {http://cogcomp.org/papers/Punyakanok-05.pdf}
+}
+
+@InProceedings{PunyakanokRo01,
+  Title                    = {The Use of Classifiers in Sequential Inference},
+  Author                   = {V. Punyakanok and D. Roth},
+  Booktitle                = {Proc. of the Conference on Neural Information Processing Systems (NIPS)},
+  Year                     = {2001},
+  Pages                    = {995--1001},
+  Publisher                = {MIT Press},
+
+  Acceptance               = {25/514 (4.8\%) Oral Presentations; 152/514 (29\%) overall},
+  Comment                  = {Structured, sequential output; Sequence Prediction: HMM with classifiers, Conditional Models, Constraint Satisfaction},
+  Funding                  = {NSF98 CAREER},
+  Projects                 = {LnI,SI,IE,NE,NLP,CCM},
+  Url                      = {http://cogcomp.org/papers/nips01.pdf}
+}
+
+@TechReport{PunyakanokRo00,
+  Title                    = {The Use of Classifiers in Sequential Inference},
+  Author                   = {V. Punyakanok and D. Roth},
+  Institution              = {UIUC Computer Science Department},
+  Year                     = {2000},
+  Month                    = {7},
+  Number                   = {UIUCDCS-R-2000-2181},
+
+  Invisible                = {true},
+  Url                      = {http://cogcomp.org/papers/PunyakanokRo00a.pdf}
+}
+
+@InProceedings{PunyakanokRo00a,
+  Title                    = {Shallow Parsing by Inferencing with Classifiers},
+  Author                   = {V. Punyakanok and D. Roth},
+  Booktitle                = {Proc. of the Conference on Computational Natural Language Learning (CoNLL)},
+  Year                     = {2000},
+  Pages                    = {107--110},
+
+  Funding                  = {ITR-MIT NSF98},
+  Url                      = {http://cogcomp.org/papers/PunyakanokRo00.pdf}
+}
+
+@Article{PunyakanokRoYi08,
+  Title                    = {The Importance of Syntactic Parsing and Inference in Semantic Role Labeling},
+  Author                   = {V. Punyakanok and D. Roth and W. Yih},
+  Journal                  = {Computational Linguistics},
+  Year                     = {2008},
+  Number                   = {2},
+  Volume                   = {34},
+
+  Funding                  = {KINDLE,REFLEX,MURI,XPRESSMP},
+  Projects                 = {IE,LINL,SP,ILP,SRL},
+  Url                      = {http://cogcomp.org/papers/PunyakanokRoYi07.pdf}
+}
+
+@InProceedings{PunyakanokRoYi05,
+  Title                    = {The Necessity of Syntactic Parsing for Semantic Role Labeling},
+  Author                   = {V. Punyakanok and D. Roth and W. Yih},
+  Booktitle                = {Proc. of the International Joint Conference on Artificial Intelligence (IJCAI)},
+  Year                     = {2005},
+  Pages                    = {1117--1123},
+
+  Acceptance               = {240/1329 (18\%)},
+  Comment                  = {An Analysis of the impact of syntactic parsing on semantic role labeling. Joint inference is used both to guarantee coherent SRL output and to combine several SRL systems.},
+  Funding                  = {KINDLE,REFLEX,MURI,XPRESSMP},
+  Projects                 = {IE,LINL,SP,ILP,SRL},
+  Url                      = {http://cogcomp.org/papers/PunyakanokRoYi05.pdf}
+}
+
+@Article{PunyakanokRoYi04,
+  Title                    = {Mapping Dependencies Trees: An Application to Question Answering},
+  Author                   = {V. Punyakanok and D. Roth and W. Yih},
+  Year                     = {2004},
+
+  Month                    = {1},
+
+  Acceptance               = {30-64 (47\%)},
+  Booktitle                = {Proc. of the International Symposium on Artificial Intelligence and Mathematics (AIM)},
+  Funding                  = {MURI,KINDLE},
+  Projects                 = {QA,KINDLE,TE},
+  Url                      = {http://cogcomp.org/papers/PunyakanokRoYi04a.pdf}
+}
+
+@InProceedings{PRYZ05,
+  Title                    = {Learning and Inference over Constrained Output},
+  Author                   = {V. Punyakanok and D. Roth and W. Yih and D. Zimak},
+  Booktitle                = {Proc. of the International Joint Conference on Artificial Intelligence (IJCAI)},
+  Year                     = {2005},
+  Pages                    = {1124--1129},
+
+  Acceptance               = {240/1329 (18\%)},
+  Comment                  = {Structure Learning; Joint Inference; Learning + Inference vs. Inference based Training Algorithms},
+  Funding                  = {KINDLE,REFLEX,MURI,XPRESSMP,ITR-BI},
+  Projects                 = {LT,CCM},
+  Url                      = {http://cogcomp.org/papers/PRYZ05.pdf}
+}
+
+@InProceedings{PRYZ04,
+  Title                    = {Semantic Role Labeling via Integer Linear Programming Inference},
+  Author                   = {V. Punyakanok and D. Roth and W. Yih and D. Zimak},
+  Booktitle                = {Proc. of the International Conference on Computational Linguistics (COLING)},
+  Year                     = {2004},
+
+  Address                  = {Geneva, Switzerland},
+  Month                    = {8},
+  Pages                    = {1346--1352},
+
+  Comment                  = {Semantic Parsing; Structure Learning with Expressive Constraints; Constraint Optimization; Integer Linear Programming},
+  Funding                  = {ITR-BI,MURI,KINDLE,XPRESSMP},
+  Projects                 = {SP,LnI,CCM,SRL},
+  Url                      = {http://cogcomp.org/papers/PRYZ04.pdf}
+}
+
+@InProceedings{PRYZ04a,
+  Title                    = {Learning via Inference over Structurally Constrained Output},
+  Author                   = {V. Punyakanok and D. Roth and W. Yih and D. Zimak},
+  Booktitle                = {Proc. of the Conference on Neural Information Processing Systems (NIPS) Workshop on Learning Structured Output},
+  Year                     = {2004},
+
+  Comment                  = {Learning + Inference vs. Inference based Training Algorithms},
+  Funding                  = {ITR-BI,ITR-MIT,MURI,KINDLE,XPRESSMP},
+  Invisible                = {true},
+  Projects                 = {LT,CCM},
+  Url                      = {http://cogcomp.org/papers/PRYZ04a.pdf}
+}
+
+@InProceedings{PRYZT04,
+  Title                    = {Semantic Role Labeling via Generalized Inference over Classifiers Shared Task Paper},
+  Author                   = {V. Punyakanok and D. Roth and W. Yih and D. Zimak and Y. Tu},
+  Booktitle                = {Proc. of the Conference on Computational Natural Language Learning (CoNLL)},
+  Year                     = {2004},
+  Editor                   = {Hwee Tou Ng and Ellen Riloff},
+  Pages                    = {130--133},
+
+  Comment                  = {Semantic Parsing; Structure Learning with Expressive Constraints; Constraint Optimization; Integer Linear Programming},
+  Funding                  = {CAREER,MURI,CAREER,KINDLE,CLUSTER,XPRESSMP},
+  Projects                 = {SM,SRL,CCM},
+  Url                      = {http://cogcomp.org/papers/PRYZT04.pdf}
+}
+
+@Other{PKMLDY15,
+  Title                    = {SemEval-2015 Task 8: SpaceEval},
+  Author                   = {James Pustejovsky and Parisa Kordjamshidi and Marie-Francine Moens and Aaron Levine and Seth Dworman and Zachary Yocum},
+  Booktitle                = {Proc. of the Annual Meeting of the Association for Computational Linguistics (ACL)},
+  Pages                    = {884-894},
+  Publisher                = {ACL},
+  Url                      = {http://cogcomp.org/papers/PustejovskyetalSemEval2015.pdf},
+  Year                     = {2015}
+}
+
+@InProceedings{RahurkarRoHu08,
+  Title                    = {Which Apple are you talking about},
+  Author                   = {M. Rahurkar and D. Roth and T. Huang},
+  Booktitle                = {Proc. of the International World Wide Web Conference (WWW)},
+  Year                     = {2008},
+  Pages                    = {1197-1198},
+
+  Projects                 = {SEARCH},
+  Url                      = {http://cogcomp.org/papers/RahurkarRoHu08.pdf}
+}
+
+@Other{Ratinov12,
+  Title                    = {Exploiting Knowledge in NLP},
+  Author                   = {Lev Ratinov},
+  Booktitle                = {UIUC PhD Thesis},
+  Url                      = {http://cogcomp.org/papers/Ratinov12.pdf},
+  Year                     = {2012}
+}
+
+@InProceedings{RatinovRo12,
+  Title                    = {Learning-based Multi-Sieve Co-Reference Resolution with Knowledge},
+  Author                   = {Lev Ratinov and Dan Roth},
+  Booktitle                = {Proc. of the Conference on Empirical Methods in Natural Language Processing (EMNLP)},
+  Year                     = {2012},
+
+  Url                      = {http://cogcomp.org/papers/RatinovRo12.pdf}
+}
+
+@Other{RatinovRo11,
+  Title                    = {GLOW TAC-KBP 2011 Entity Linking System},
+  Author                   = {L. Ratinov and D. Roth},
+  Booktitle                = {Proc. of the Text Analysis Conference (TAC)},
+  Funding                  = {MR, ARL },
+  Month                    = {11},
+  Publisher                = {Text Analysis Conference},
+  Url                      = {http://cogcomp.org/papers/RatinovRo11.pdf},
+  Year                     = {2011}
+}
+
+@InProceedings{RatinovRo09,
+  Title                    = {Design Challenges and Misconceptions in Named Entity Recognition},
+  Author                   = {L. Ratinov and D. Roth},
+  Booktitle                = {Proc. of the Conference on Computational Natural Language Learning (CoNLL)},
+  Year                     = {2009},
+  Month                    = {6},
+
+  Comment                  = {Named entity recognition; information extraction; knowledge resources; word class models; gazetteers; non-local features; global features; inference methods; BIO vs. BIOLU; text chunk representation},
+  Funding                  = {MIAS, SoD, Library},
+  Projects                 = {IE},
+  Url                      = {http://cogcomp.org/papers/RatinovRo09.pdf}
+}
+
+@InProceedings{RRDA11,
+  Title                    = {Local and Global Algorithms for Disambiguation to Wikipedia},
+  Author                   = {L. Ratinov and D. Roth and D. Downey and M. Anderson},
+  Booktitle                = {Proc. of the Annual Meeting of the Association for Computational Linguistics (ACL)},
+  Year                     = {2011},
+
+  Url                      = {http://cogcomp.org/papers/RRDA11.pdf}
+}
+
+@TechReport{RedmanSaRo16,
+  Title                    = {Illinois Named Entity Recognizer: Addendum to Ratinov and Roth '09 reporting improved results},
+  Author                   = {Tom Redman and Mark Sammons and Dan Roth},
+  Year                     = {2016},
+
+  Booktitle                = {Tech Reports},
+  Url                      = {http://cogcomp.org/papers/ner-addendum.pdf}
+}
+
+@InProceedings{RiedelCl09,
+  Title                    = {Revisiting Optimal Decoding for Machine Translation IBM Model 4},
+  Author                   = {S. Riedel and J. Clarke},
+  Booktitle                = {Proc. of the Annual Conference of the North American Chapter of the Association for Computational Linguistics (NAACL)},
+  Year                     = {2009},
+
+  Address                  = {Boulder, Colorado},
+
+  Url                      = {http://cogcomp.org/papers/RiedelCl09.pdf}
+}
+
+@Other{Rizzolo11,
+  Title                    = {Learning Based Programming},
+  Author                   = {N. Rizzolo},
+  Booktitle                = {UIUC PhD Thesis},
+  Url                      = {http://cogcomp.org/papers/Rizzolo11.pdf},
+  Year                     = {2011}
+}
+
+@InCollection{RizzoloRo16,
+  Title                    = {Integer Linear Programming for Co-reference Resolution},
+  Author                   = {N. Rizzolo and D. Roth},
+  Booktitle                = {Anaphora Resolution: Algorithms, Resources, and Applications},
+  Publisher                = {Springer-Verlag},
+  Year                     = {2016},
+  Editor                   = {Massimo Poesio, Roland Stuckardt and Yannick Versley},
+
+  Invisible                = {true}
+}
+
+@InProceedings{RizzoloRo10,
+  Title                    = {Learning Based Java for Rapid Development of NLP Systems},
+  Author                   = {N. Rizzolo and D. Roth},
+  Booktitle                = {Proc. of the International Conference on Language Resources and Evaluation (LREC)},
+  Year                     = {2010},
+
+  Address                  = {Valletta, Malta},
+  Month                    = {5},
+
+  Comment                  = {Learning Based Java: a Modeling language that facilitates development of systems with learning and inference componenets.},
+  Funding                  = {NSF-SoD},
+  Projects                 = {LBP, CCM},
+  Url                      = {http://cogcomp.org/papers/RizzoloRo10.pdf}
+}
+
+@InProceedings{RizzoloRo07,
+  Title                    = {Modeling Discriminative Global Inference},
+  Author                   = {N. Rizzolo and D. Roth},
+  Booktitle                = {Proc. of the IEEE International Conference on Semantic Computing (ICSC)},
+  Year                     = {2007},
+
+  Address                  = {Irvine, California},
+  Month                    = {9},
+  Pages                    = {597-604},
+  Publisher                = {IEEE},
+
+  Comment                  = {Learning Based Java: a Modeling language that facilitates developing of systems with learning and inference componenets.},
+  Funding                  = {NSF-SoD, LBP},
+  Projects                 = {LBP,CCM},
+  Url                      = {http://cogcomp.org/papers/RizzoloRo07.pdf}
+}
+
+@Article{Roth98a,
+  Title                    = {Learning and Reasoning with Connectionist Representations},
+  Author                   = {D. Roth},
+  Year                     = {1998},
+  Pages                    = {1--40},
+
+  Booktitle                = {Neural Computing Surveys},
+  Comment                  = {A contribution to ``Connectionist Symbol Processing: Dead or Alive''},
+  Editor                   = {A. Jagota, T. Plate, L. Shastri, R. Sun},
+  Publisher                = {Lawrence Erlbaum Associates},
+  Url                      = {http://cogcomp.org/papers/Roth98a.pdf}
+}
+
+@Article{Roth05,
+  Title                    = {Learning based Programming},
+  Author                   = {D. Roth},
+  Journal                  = {Innovations in Machine Learning: Theory and Applications},
+  Year                     = {2005},
+
+  Comment                  = {Suggests a paradigm and a programming language for the programming of learning intensive computer systems. Springer: http://dx.doi.org/10.1007/3-540-33486-6_3},
+  Editor                   = {L.C. Jain and D. Holmes},
+  Funding                  = {ITR-BI,MURI,TRECC},
+  Projects                 = {LBP},
+  Publisher                = {Springer-Verlag},
+  Url                      = {http://cogcomp.org/papers/Roth05.pdf}
+}
+
+@InCollection{Roth96b,
+  Title                    = {Learning in Order to Reason: The Approach},
+  Author                   = {D. Roth},
+  Booktitle                = {Proc. of the Conference on Current Trends in Theory and Practice of Informatics (SOFSEM)},
+  Publisher                = {Springer-verlag},
+  Year                     = {1996},
+  Editor                   = {K. G. Jeffery and J. Kral and M. Bartosek},
+  Pages                    = {113--124},
+
+  Comment                  = {Lecture notes in Computer Science, vol. 1175},
+  Url                      = {http://cogcomp.org/papers/approach.pdf}
+}
+
+@InCollection{Roth97,
+  Title                    = {Learning to perform knowledge intensive inferences Invited Abstract},
+  Author                   = {D. Roth},
+  Booktitle                = {Proc. of the International Symposium on the Mathematical Foundations of Computer Science (MFCS)},
+  Publisher                = {Springer-verlag},
+  Year                     = {1997},
+  Editor                   = {I. Privara and P. Ruzicka},
+  Pages                    = {108--109},
+
+  Comment                  = {Lecture notes in Computer Science (LNCS) 1295}
+}
+
+@InProceedings{Roth17,
+  Title                    = {Incidental Supervision: Moving beyond Supervised Learning},
+  Author                   = {Dan Roth},
+  Booktitle                = {Proc. of the Conference on Artificial Intelligence (AAAI)},
+  Year                     = {2017},
+  Month                    = {2},
+
+  Url                      = {http://cogcomp.org/papers/Roth-AAAI17-incidental-supervision.pdf}
+}
+
+@InProceedings{Roth01,
+  Title                    = {Reasoning with Classifiers},
+  Author                   = {D. Roth},
+  Booktitle                = {Proc. of the European Conference on Machine Learning (ECML)},
+  Year                     = {2001},
+  Pages                    = {506--510},
+
+  Acceptance               = {197/796 (25\%)},
+  Comment                  = {Paper written to accompany an invited talk at ECML'01. Sequential Inference: Conditional Models, Constraint Satisfaction},
+  Funding                  = {ITR-MIT NSF98 CAREER},
+  Projects                 = {LnI,SI,IE,NE}
+}
+
+@InProceedings{Roth00,
+  Title                    = {Learning in Natural Language: Theory and Algorithmic Approaches},
+  Author                   = {D. Roth},
+  Booktitle                = {Proc. of the Conference on Computational Natural Language Learning (CoNLL)},
+  Year                     = {2000},
+
+  Address                  = {Lisbon, Portugal},
+  Pages                    = {1--6},
+
+  Comment                  = {A paper written to accompany and invited talk at CoNLL.},
+  Funding                  = {ITR-MIT,NSF98,KDI},
+  Url                      = {http://cogcomp.org/papers/lnlp-conll.pdf}
+}
+
+@TechReport{Roth00a,
+  Title                    = {Learning in Natural Language},
+  Author                   = {D. Roth},
+  Institution              = {UIUC Computer Science Department},
+  Year                     = {2000},
+  Month                    = {7},
+  Number                   = {UIUCDCS-R-2000-2180},
+
+  Invisible                = {true},
+  Url                      = {http://cogcomp.org/papers/Roth00a.pdf}
+}
+
+@InProceedings{Roth99,
+  Title                    = {Learning in Natural Language},
+  Author                   = {D. Roth},
+  Booktitle                = {Proc. of the International Joint Conference on Artificial Intelligence (IJCAI)},
+  Year                     = {1999},
+  Pages                    = {898--904},
+
+  Acceptance               = {195/760 (26\%)},
+  Comment                  = {Probabilistic classifiers (Naive Bayes; HMM) as linear models; generative vs. discriminative; Best Paper Award},
+  Funding                  = {NSF98 KDI},
+  Projects                 = {LT,DPL},
+  Url                      = {http://cogcomp.org/papers/ijcai99r.pdf}
+}
+
+@TechReport{Roth99a,
+  Title                    = {Learning Based Programming},
+  Author                   = {D. Roth},
+  Institution              = {UIUC Computer Science Department},
+  Year                     = {1999},
+  Month                    = {10},
+  Number                   = {UIUCDCS-R-99-2127},
+
+  Url                      = {http://cogcomp.org/papers/Roth99c.pdf}
+}
+
+@TechReport{Roth99b,
+  Title                    = {Relational Knowledge Representations that Facilitate Learning},
+  Author                   = {D. Roth},
+  Institution              = {UIUC Computer Science Department},
+  Year                     = {1999},
+  Month                    = {10},
+  Number                   = {UIUCDCS-R-99-2126},
+
+  Invisible                = {true},
+  Url                      = {http://cogcomp.org/papers/Roth99b.pdf}
+}
+
+@TechReport{Roth99c,
+  Title                    = {Memory Based Learning in NLP},
+  Author                   = {D. Roth},
+  Institution              = {UIUC Computer Science Department},
+  Year                     = {1999},
+  Month                    = {3},
+  Number                   = {UIUCDCS-R-99-2125},
+
+  Url                      = {http://cogcomp.org/papers/mbl.pdf}
+}
+
+@InProceedings{Roth98,
+  Title                    = {Learning to Resolve Natural Language Ambiguities: A Unified Approach},
+  Author                   = {D. Roth},
+  Booktitle                = {Proc. of the Conference on Artificial Intelligence (AAAI)},
+  Year                     = {1998},
+  Pages                    = {806--813},
+
+  Acceptance               = {143/475 (30\%)},
+  Comment                  = {Many Natural Language Classifiers are Linear; including probabilistic classifiers; argues for a discriminative approach; SNoW},
+  Funding                  = {NSF98,KDI},
+  Projects                 = {DPL,NLP},
+  Url                      = {http://cogcomp.org/papers/aaai98.pdf}
+}
+
+@Article{Roth96,
+  Title                    = {On the hardness of approximate reasoning},
+  Author                   = {D. Roth},
+  Journal                  = {Artificial Intelligence},
+  Year                     = {1996},
+
+  Month                    = {4},
+  Number                   = {1-2},
+  Pages                    = {273--302},
+  Volume                   = {82},
+
+  Comment                  = {Hardness of Reasoning with Bayesian Networks; Exact inference is #P-Complete; Approximate Reasoning is NP-Hard.},
+  Url                      = {http://cogcomp.org/papers/hardJ.pdf}
+}
+
+@InProceedings{Roth96a,
+  Title                    = {Learning in Order to Reason Invited},
+  Author                   = {D. Roth},
+  Booktitle                = {Proc. of the AAAI Fall Symposium on Learning Complex Behaviors in Adaptive Intelligent Systems},
+  Year                     = {1996},
+  Pages                    = {46--52},
+
+  Url                      = {http://cogcomp.org/papers/approach.pdf}
+}
+
+@InProceedings{Roth96c,
+  Title                    = {On the hardness of approximate reasoning},
+  Author                   = {D. Roth},
+  Booktitle                = {Proc. of the AAAI Fall Symposium on AI and NP Hard Problems},
+  Year                     = {1996},
+  Pages                    = {137-143},
+
+  Url                      = {http://cogcomp.org/papers/hardJ.pdf}
+}
+
+@InProceedings{Roth96d,
+  Title                    = {A Connectionist Framework for Reasoning: Reasoning with Examples},
+  Author                   = {D. Roth},
+  Booktitle                = {Proc. of the Conference on Artificial Intelligence (AAAI)},
+  Year                     = {1996},
+  Pages                    = {1256--1261},
+
+  Acceptance               = {197/640 (31\%)},
+  Url                      = {http://cogcomp.org/papers/nreason.pdf}
+}
+
+@InProceedings{Roth95,
+  Title                    = {Learning to Reason: The Non-Monotonic Case},
+  Author                   = {D. Roth},
+  Booktitle                = {Proc. of the International Joint Conference on Artificial Intelligence (IJCAI)},
+  Year                     = {1995},
+  Month                    = {8},
+  Pages                    = {1178--1184},
+
+  Acceptance               = {249/1112 (22\%)},
+  Url                      = {http://cogcomp.org/papers/nonmon.pdf}
+}
+
+@InProceedings{Roth93,
+  Title                    = {On the hardness of approximate reasoning},
+  Author                   = {D. Roth},
+  Booktitle                = {Proc. of the International Joint Conference on Artificial Intelligence (IJCAI)},
+  Year                     = {1993},
+  Month                    = {8},
+  Pages                    = {613--618},
+
+  Acceptance               = {220/876 (25\%)},
+  Comment                  = {Hardness of Reasoning with Bayesian Networks; Exact inference is #P-Complete; Approximate Reasoning is NP-Hard.}
+}
+
+@InProceedings{RothBo02,
+  Title                    = {Proceedings of CoNLL 2002, the Sixth Workshop on Computational Natural Language Learning},
+  Author                   = {D. Roth and A. van den Bosch Program Chairs},
+  Year                     = {2002},
+  Editor                   = {D. Roth and A. van den Bosch}
+}
+
+@InProceedings{RCLMNPRSY02,
+  Title                    = {Question-Answering via Enhanced Understanding of Questions},
+  Author                   = {D. Roth and C. Cumby and X. Li and P. Morie and R. Nagarajan and V. Punyakanok and N. Rizzolo and K. Small and W. Yih},
+  Booktitle                = {Proc. of the Text Retrieval Conference (TREC)},
+  Year                     = {2002},
+
+  Funding                  = {NSF98,MURI,ITR-MIT},
+  Projects                 = {QA,TE},
+  Url                      = {http://cogcomp.org/papers/trec02.pdf}
+}
+
+@InProceedings{RKLNPRYAM01,
+  Title                    = {Learning Components for a Question Answering System},
+  Author                   = {D. Roth and G. Kao and X. Li and R. Nagarajan and V. Punyakanok and N. Rizzolo and W. Yih and C. Alm and L. G. Moran},
+  Booktitle                = {Proc. of the Text Retrieval Conference (TREC)},
+  Year                     = {2001},
+  Pages                    = {539-548},
+
+  Funding                  = {NSF98,MURI,ITR-MIT},
+  Projects                 = {QA,TE},
+  Url                      = {http://cogcomp.org/papers/trec01.pdf}
+}
+
+@Article{RothSa09,
+  Title                    = {Learning Multi-Linear Representations},
+  Author                   = {D. Roth and R. Samdani},
+  Journal                  = {Machine Learning},
+  Year                     = {2009},
+  Number                   = {2},
+  Pages                    = {195--209},
+  Volume                   = {76},
+
+  Funding                  = {ONR},
+  Projects                 = {CCG},
+  Url                      = {http://cogcomp.org/papers/RothSa09.pdf}
+}
+
+@TechReport{RothSa08,
+  Title                    = {A Unified Representation and Inference Paradigm for Natural Language Processing},
+  Author                   = {D. Roth and M. Sammons},
+  Institution              = {UIUC Computer Science Department},
+  Year                     = {2008},
+  Number                   = {UIUCDCS-R-2008-2969},
+
+  Funding                  = {Boeing},
+  Projects                 = {TE},
+  Url                      = {http://cogcomp.org/papers/RothSa08.pdf}
+}
+
+@Other{RothSa07,
+  Title                    = {Semantic and Logical Inference Model for Textual Entailment},
+  Address                  = {Prague, Czech Republic},
+  Author                   = {D. Roth and M. Sammons},
+  Booktitle                = {Proc. of the Annual Meeting of the Association for Computational Linguistics (ACL)},
+  Comment                  = {Textual Entailment; Compositional semantics; Search-based inference; Modular framework},
+  Funding                  = {Boeing, ARDA, ACQUAINT, Google},
+  Month                    = {6},
+  Pages                    = {107--112},
+  Projects                 = {TE},
+  Publisher                = {Association for Computational Linguistics},
+  Url                      = {http://cogcomp.org/papers/RothSa07.pdf},
+  Year                     = {2007}
+}
+
+@InProceedings{RothSaVy09,
+  Title                    = {A Framework for Entailed Relation Recognition},
+  Author                   = {D. Roth and M. Sammons and V. Vydiswaran},
+  Booktitle                = {Proc. of the Annual Meeting of the Association for Computational Linguistics (ACL)},
+  Year                     = {2009},
+
+  Address                  = {Singapore},
+  Month                    = {8},
+  Publisher                = {Association for Computational Linguistics},
+
+  Comment                  = {semantic retrieval, scalable textual entailment, structured query, similarity metrics, exhaustive search, relation recognition, relation extraction},
+  Funding                  = {Boeing, MIAS},
+  Projects                 = {TE,SEARCH},
+  Url                      = {http://cogcomp.org/papers/RothSaVy09.pdf}
+}
+
+@InProceedings{RothSm09,
+  Title                    = {Interactive Feature Space Construction using Semantic Information},
+  Author                   = {D. Roth and K. Small},
+  Booktitle                = {Proc. of the Conference on Computational Natural Language Learning (CoNLL)},
+  Year                     = {2009},
+  Month                    = {6},
+
+  Funding                  = {DARPA},
+  Projects                 = {AL,NER},
+  Url                      = {http://cogcomp.org/papers/RothSm09.pdf}
+}
+
+@InProceedings{RothSm08,
+  Title                    = {Active Learning for Pipeline Models},
+  Author                   = {D. Roth and K. Small},
+  Booktitle                = {Proc. of the Conference on Artificial Intelligence (AAAI)},
+  Year                     = {2008},
+  Month                    = {7},
+
+  Funding                  = {Darpa, DHS},
+  Projects                 = {AL,PL,NER},
+  Url                      = {http://cogcomp.org/papers/RothSm08.pdf}
+}
+
+@InProceedings{RothSm06,
+  Title                    = {Margin-based Active Learning for Structured Output Spaces},
+  Author                   = {D. Roth and K. Small},
+  Booktitle                = {Proc. of the European Conference on Machine Learning (ECML)},
+  Year                     = {2006},
+  Month                    = {9},
+  Publisher                = {Springer},
+
+  Comment                  = {Active Learning; Structured Output},
+  Funding                  = {MOTOROLA,ITR-EDU},
+  Projects                 = {AL,SRL},
+  Url                      = {http://cogcomp.org/papers/RothSm06a.pdf}
+}
+
+@Other{RothSm06a,
+  Title                    = {Active Learning with Perceptron for Structured Output},
+  Author                   = {D. Roth and K. Small},
+  Booktitle                = {Proc. of the International Conference on Machine Learning (ICML)},
+  Comment                  = {Earlier Version of an ECML'06 paper},
+  Funding                  = {MOTOROLA,ITR-EDU},
+  Month                    = {6},
+  Projects                 = {AL},
+  Url                      = {http://cogcomp.org/papers/RothSm06.pdf},
+  Year                     = {2006}
+}
+
+@InProceedings{RothSmTi09,
+  Title                    = {Sequential Learning of Classifiers for Structured Prediction Problems},
+  Author                   = {D. Roth and K. Small and I. Titov},
+  Booktitle                = {Proc. of the International Workshop on Artificial Intelligence and Statistics (AISTATS)},
+  Year                     = {2009},
+  Month                    = {4},
+  Pages                    = {440--447},
+
+  Acceptance               = {84/210 (40.0 \%)},
+  Comment                  = {Structured prediction; Learning algorithm; Pipelines; An alternative both to joint and to independent learning of classifiers},
+  Funding                  = {BL, SoD},
+  Url                      = {http://cogcomp.org/papers/RothSmTi09.pdf}
+}
+
+@InProceedings{RothTu09,
+  Title                    = {Aspect Guided Text Categorization with Unobserved Labels},
+  Author                   = {D. Roth and Y. Tu},
+  Booktitle                = {Proc. of the IEEE International Conference on Data Mining (ICDM)},
+  Year                     = {2009},
+
+  Comment                  = {multiclass classification; Text classification, short text snippet, structure learning, Constrained optimization; constrained conditional models},
+  Funding                  = {Honda,MIAS},
+  Projects                 = {CCM,Honda},
+  Url                      = {http://cogcomp.org/papers/RothTu09.pdf}
+}
+
+@Article{RothYaAh02,
+  Title                    = {Learning to Recognize 3D Objects},
+  Author                   = {D. Roth and M. Yang and N. Ahuja},
+  Journal                  = {Neural Computation},
+  Year                     = {2002},
+  Number                   = {5},
+  Pages                    = {1071--1104},
+  Volume                   = {14},
+
+  Acceptance               = {NSF98,ITR-MIT},
+  Funding                  = {LT,LV},
+  Url                      = {http://cogcomp.org/papers/objectsJ.pdf}
+}
+
+@InProceedings{RothYaAh00,
+  Title                    = {Learning to Recognize Objects},
+  Author                   = {D. Roth and M. Yang and N. Ahuja},
+  Booktitle                = {Proc. of the IEEE Conference on Computer Vision and Pattern Recognition (CVPR)},
+  Year                     = {2000},
+  Pages                    = {724--731},
+
+  Acceptance               = {200/466 (43\%)},
+  Funding                  = {NSF98},
+  Url                      = {http://cogcomp.org/papers/cvpr00.pdf}
+}
+
+@Article{RothYi07,
+  Title                    = {Global Inference for Entity and Relation Identification via a Linear Programming Formulation},
+  Author                   = {D. Roth and W. Yih},
+  Year                     = {2007},
+
+  Booktitle                = {Introduction to Statistical Relational Learning},
+  Comment                  = {Learning and Inference with Constraints; Integer Linear Programming for Information extraction; Simultaneous recognition of entities and Relations},
+  Editor                   = {Lise Getoor and Ben Taskar},
+  Funding                  = {ITR-BI,ARDA,XPRESSMP},
+  Projects                 = {LT,LINL,ILP,CCM,NER,PL},
+  Publisher                = {MIT Press},
+  Url                      = {http://cogcomp.org/papers/RothYi07.pdf}
+}
+
+@InProceedings{RothYi04,
+  Title                    = {A Linear Programming Formulation for Global Inference in Natural Language Tasks},
+  Author                   = {D. Roth and W. Yih},
+  Booktitle                = {Proc. of the Conference on Computational Natural Language Learning (CoNLL)},
+  Year                     = {2004},
+  Editor                   = {Hwee Tou Ng and Ellen Riloff},
+  Pages                    = {1--8},
+  Publisher                = {Association for Computational Linguistics},
+
+  Acceptance               = {11/23 (48\%)},
+  Comment                  = {Simultaneous recognition of Named Entities and Relations between them. Learning and Inference via an Integer Linear Programming framework; Structure Learning; Avoiding Pipeline Processing},
+  Funding                  = {ITR-BI,MURI,XPRESSMP},
+  Projects                 = {IE,LnI,CCM,NER,PL},
+  Url                      = {http://cogcomp.org/papers/RothYi04.pdf}
+}
+
+@InProceedings{RothYi05,
+  Title                    = {Integer Linear Programming Inference for Conditional Random Fields},
+  Author                   = {D. Roth and W. Yih},
+  Booktitle                = {Proc. of the International Conference on Machine Learning (ICML)},
+  Year                     = {2005},
+  Pages                    = {737--744},
+
+  Acceptance               = {143/491 (29\%)},
+  Comment                  = {Extending Conditional Random Fields with expressive, non-sequential, constraints. Comparing multiple joint inference training paradigms for structure learning in the context of SRL.},
+  Funding                  = {MURI,ITR-BI,ITR-MIT,ARDA,XPRESSMP},
+  Projects                 = {LT,LINL,ILP,CCM},
+  Url                      = {http://cogcomp.org/papers/RothYi05.pdf}
+}
+
+@Unpublished{RothYi04a,
+  Title                    = {A Linear Programming Formulation for Global Inference in Natural Language Tasks},
+  Author                   = {D. Roth and W. Yih},
+  Year                     = {2004},
+
+  Booktitle                = {Proc. of the International Symposium on Artificial Intelligence and Mathematics (AIM)},
+  Comment                  = {An early version of the CoNLL paper},
+  Funding                  = {ITR-BI,MURI,CLUSTER,XPRESSMP},
+  Invisible                = {true},
+  Pages                    = {1--8},
+  Projects                 = {IE,LnI,CCM},
+  Url                      = {http://cogcomp.org/papers/RothYi04a.pdf}
+}
+
+@InProceedings{RothYi02,
+  Title                    = {Probabilistic Reasoning for Entity and Relation Recognition},
+  Author                   = {D. Roth and W. Yih},
+  Booktitle                = {Proc. of the International Conference on Computational Linguistics (COLING)},
+  Year                     = {2002},
+  Pages                    = {835--841},
+
+  Acceptance               = {198-435 (45\%)},
+  Comment                  = {Entity And Relation Recognition. Simultaneous Identification of Entities and Relations.},
+  Funding                  = {MURI,ITR-MIT},
+  Projects                 = {IE,NE,LnI,NER},
+  Url                      = {http://cogcomp.org/papers/er-coling02.pdf}
+}
+
+@InProceedings{RothYi01,
+  Title                    = {Relational Learning via Propositional Algorithms: An Information Extraction Case Study},
+  Author                   = {D. Roth and W. Yih},
+  Booktitle                = {Proc. of the International Joint Conference on Artificial Intelligence (IJCAI)},
+  Year                     = {2001},
+  Pages                    = {1257--1263},
+
+  Acceptance               = {197/796 (25\%)},
+  Comment                  = {Expressive, Relational Features for Information Extraction},
+  Funding                  = {ITR-MIT NSF98 MURI},
+  Projects                 = {KR,IE,NE},
+  Url                      = {http://cogcomp.org/papers/ijcai01.pdf}
+}
+
+@TechReport{RothYi01a,
+  Title                    = {Propositionalization of Relational Learning: An Information Extraction Case Study},
+  Author                   = {D. Roth and W. Yih},
+  Institution              = {UIUC Computer Science Department},
+  Year                     = {2001},
+  Month                    = {3},
+  Number                   = {UIUCDCS-R-2001-2206},
+
+  Funding                  = {NSF98,MURI,ITR-MIT},
+  Projects                 = {KR,IE,NE},
+  Url                      = {http://cogcomp.org/papers/RothYi01a.pdf}
+}
+
+@InCollection{RothZe99,
+  Title                    = {Coherent Concepts, Robust Learning Invited},
+  Author                   = {D. Roth and D. Zelenko},
+  Booktitle                = {Proc. of the Conference on Current Trends in Theory and Practice of Informatics (SOFSEM)},
+  Publisher                = {Springer-verlag},
+  Year                     = {1999},
+  Editor                   = {J. Pavelka and G. Tel and M. Bartosek},
+  Pages                    = {260--272},
+
+  Comment                  = {Lecture notes in Artificial Intelligence, vol. 1725},
+  Url                      = {http://cogcomp.org/papers/RothZe99.pdf}
+}
+
+@InProceedings{RothZe00,
+  Title                    = {Towards a theory of Coherent Concepts},
+  Author                   = {D. Roth and D. Zelenko},
+  Booktitle                = {Proc. of the Conference on Artificial Intelligence (AAAI)},
+  Year                     = {2000},
+  Pages                    = {639--644},
+
+  Acceptance               = {141/430 (33\%)},
+  Url                      = {http://cogcomp.org/papers/aaai00.pdf}
+}
+
+@InProceedings{RothZe98,
+  Title                    = {Part of Speech Tagging Using a Network of Linear Separators},
+  Author                   = {D. Roth and D. Zelenko},
+  Booktitle                = {Coling-Acl, The 17th International Conference on Computational Linguistics},
+  Year                     = {1998},
+  Pages                    = {1136--1142},
+
+  Acceptance               = {137/550 (25\%)},
+  Funding                  = {NSF98,KDI},
+  Projects                 = {SI,NLP},
+  Url                      = {http://cogcomp.org/papers/pos.pdf}
+}
+
+@Other{Roy17,
+  Title                    = {Reasoning about Quantities in Natural Language},
+  Author                   = {Subhro Roy},
+  Booktitle                = {UIUC PhD Thesis},
+  Url                      = {http://cogcomp.org/papers/ROY-DISSERTATION-2017.pdf},
+  Year                     = {2017}
+}
+
+@InProceedings{RoyRo17,
+  Title                    = {Unit Dependency Graph and its Application to Arithmetic Word Problem Solving},
+  Author                   = {Subhro Roy and Dan Roth},
+  Booktitle                = {Proc. of the Conference on Artificial Intelligence (AAAI)},
+  Year                     = {2017},
+
+  Url                      = {http://cogcomp.org/papers/14764-64645-1-SM.pdf}
+}
+
+@InProceedings{RoyRo16,
+  Title                    = {ILLINOIS MATH SOLVER: Math Reasoning on the Web},
+  Author                   = {Subhro Roy and Dan Roth},
+  Booktitle                = {Proc. of the Annual Conference of the North American Chapter of the Association for Computational Linguistics (NAACL) Demonstrations},
+  Year                     = {2016},
+
+  Url                      = {http://cogcomp.org/papers/IMS.pdf}
+}
+
+@InProceedings{RoyRo15,
+  Title                    = {Solving General Arithmetic Word Problems},
+  Author                   = {Subhro Roy and Dan Roth},
+  Booktitle                = {Proc. of the Conference on Empirical Methods in Natural Language Processing (EMNLP)},
+  Year                     = {2015},
+
+  Url                      = {http://cogcomp.org/papers/arithmetic.pdf}
+}
+
+@InProceedings{RoyUpRo16,
+  Title                    = {EQUATION PARSING : Mapping Sentences to Grounded Equations},
+  Author                   = {Subhro Roy and Shyam Upadhyay and Dan Roth},
+  Booktitle                = {Proc. of the Conference on Empirical Methods in Natural Language Processing (EMNLP)},
+  Year                     = {2016},
+
+  Url                      = {http://cogcomp.org/papers/1609.08824v1.pdf}
+}
+
+@Article{RoyViRo15,
+  Title                    = {Reasoning about Quantities in Natural Language},
+  Author                   = {Subhro Roy and Tim Vieira and Dan Roth},
+  Journal                  = {Transactions of the Association for Computational Linguistics (TACL)},
+  Year                     = {2015},
+  Volume                   = {3},
+
+  Booktitle                = {TACL},
+  Url                      = {http://cogcomp.org/papers/RoyViRo15.pdf}
+}
+
+@Other{Rozovskay13,
+  Title                    = {Automated Methods for Text Correction},
+  Author                   = {Alla Rozovskaya},
+  Booktitle                = {UIUC PhD Thesis},
+  Url                      = {http://cogcomp.org/papers/Rozovskaya13.pdf},
+  Year                     = {2013}
+}
+
+@InProceedings{RCSR13,
+  Title                    = {The University of Illinois System in the CoNLL-2013 Shared Task},
+  Author                   = {Alla Rozovskaya and Kai-Wei Chang and Mark Sammons and Dan Roth},
+  Booktitle                = {Proc. of the Conference on Computational Natural Language Learning (CoNLL)},
+  Year                     = {2013},
+
+  Funding                  = {MR, DEFT},
+  Url                      = {http://cogcomp.org/papers/RCSR13.pdf}
+}
+
+@InProceedings{RCSRH14,
+  Title                    = {The Illinois-Columbia System in the CoNLL-2014 Shared Task},
+  Author                   = {Alla Rozovskaya and Kai-Wei Chang and Mark Sammons and Dan Roth and Nizar Habash},
+  Booktitle                = {Proc. of the Conference on Computational Natural Language Learning (CoNLL)},
+  Year                     = {2014},
+
+  Url                      = {http://cogcomp.org/papers/RCSRH14.pdf}
+}
+
+@InProceedings{RozovskayaRo16,
+  Title                    = {Grammatical Error Correction: Machine Translation and Classifiers},
+  Author                   = {Alla Rozovskaya and Dan Roth},
+  Booktitle                = {Proc. of the Annual Meeting of the Association for Computational Linguistics (ACL)},
+  Year                     = {2016},
+  Publisher                = {ACL},
+
+  Url                      = {http://cogcomp.org/papers/RozovskayaRo16.pdf}
 }
+
+@Article{RozovskayaRo14,
+  Title                    = {Building a State-of-the-Art Grammatical Error Correction System},
+  Author                   = {Alla Rozovskaya and Dan Roth},
+  Year                     = {2014},
+
+  Booktitle                = {TACL},
+  Url                      = {http://cogcomp.org/papers/RozovskayaRo14.pdf}
+}
+
+@InProceedings{RozovskayaRo13,
+  Title                    = {Joint Learning and Inference for Grammatical Error Correction},
+  Author                   = {Alla Rozovskaya and Dan Roth},
+  Booktitle                = {Proc. of the Conference on Empirical Methods in Natural Language Processing (EMNLP)},
+  Year                     = {2013},
+  Month                    = {10},
+
+  Url                      = {http://cogcomp.org/papers/RozovskayaRo13.pdf}
+}
+
+@InProceedings{RozovskayaRo11,
+  Title                    = {Algorithm Selection and Model Adaptation for ESL Correction Tasks},
+  Author                   = {A. Rozovskaya and D. Roth},
+  Booktitle                = {Proc. of the Annual Meeting of the Association for Computational Linguistics (ACL)},
+  Year                     = {2011},
+
+  Address                  = {Portland, Oregon},
+  Month                    = {6},
+  Publisher                = {Association for Computational Linguistics},
+
+  Funding                  = {EDU},
+  Url                      = {http://cogcomp.org/papers/RozovskayaRo11(1).pdf}
+}
+
+@InProceedings{RozovskayaRo10,
+  Title                    = {Generating Confusion Sets for Context-Sensitive Error Correction},
+  Author                   = {A. Rozovskaya and D. Roth},
+  Booktitle                = {Proc. of the Conference on Empirical Methods in Natural Language Processing (EMNLP)},
+  Year                     = {2010},
+
+  Funding                  = {EDU},
+  Url                      = {http://cogcomp.org/papers/RozovskayaRo10b.pdf}
+}
+
+@InProceedings{RozovskayaRo10a,
+  Title                    = {Training Paradigms for Correcting Errors in Grammar and Usage},
+  Author                   = {A. Rozovskaya and D. Roth},
+  Booktitle                = {Proc. of the Annual Conference of the North American Chapter of the Association for Computational Linguistics (NAACL)},
+  Year                     = {2010},
+  Month                    = {6},
+
+  Comment                  = {Text correction; Error Detection and Correction; ESL Error Detection; ESL Proofing Tools; Errors in Article Usage; training classifiers for detecting and correcting mistakes by selectively introducing mistakes into the training data},
+  Funding                  = {EDU},
+  Projects                 = {CSTC},
+  Url                      = {http://cogcomp.org/papers/RozovskayaRo10.pdf}
+}
+
+@Other{RozovskayaRo10b,
+  Title                    = {Annotating ESL Errors: Challenges and Rewards},
+  Author                   = {A. Rozovskaya and D. Roth},
+  Booktitle                = {Proc. of the Annual Conference of the North American Chapter of the Association for Computational Linguistics (NAACL)},
+  Comment                  = {Text correction; Error Detection and Correction; ESL Error Detection; Annotation of ESL Errors; Annotation Tool; Annotation of Article and Preposition Errors; Learner Corpus; Inter-annotator Agreement; ESL Error Statistics},
+  Funding                  = {EDU},
+  Month                    = {6},
+  Projects                 = {CSTC},
+  Url                      = {http://cogcomp.org/papers/RozovskayaRo10a.pdf},
+  Year                     = {2010}
+}
+
+@Article{RozovskayaRoSa17,
+  Title                    = {Adapting to Learner Errors with Minimal Supervision},
+  Author                   = {Alla Rozovskaya and Dan Roth and Mark Sammons},
+  Journal                  = {Computational Linguistics},
+  Year                     = {2017},
+
+  Url                      = {http://cogcomp.org/papers/CL-adaptation.pdf}
+}
+
+@InProceedings{RozovskayaRoSr14,
+  Title                    = {Correcting Grammatical Verb Errors},
+  Author                   = {Alla Rozovskaya and Dan Roth and Vivek Srikumar},
+  Booktitle                = {EACL},
+  Year                     = {2014},
+  Month                    = {4},
+
+  Url                      = {http://cogcomp.org/papers/RozovskayaRoSr14.pdf}
+}
+
+@Other{RSGR11,
+  Title                    = {University of Illinois System in HOO Text Correction Shared Task},
+  Author                   = {A. Rozovskaya and M. Sammons and J. Gioja and D. Roth},
+  Booktitle                = {Proc. of the European Workshop on Natural Language Generation (ENLG)},
+  Funding                  = {EDU,MR},
+  Url                      = {http://cogcomp.org/papers/RSGR11.pdf},
+  Year                     = {2011}
+}
+
+@Other{RozovskayaSaRo12,
+  Title                    = {The UI System in the HOO 2012 Shared Task on Error Correction},
+  Author                   = {Alla Rozovskaya and Mark Sammons and Dan Roth},
+  Booktitle                = {Proc. of the Annual Conference of the North American Chapter of the Association for Computational Linguistics (NAACL)},
+  Month                    = {6},
+  Publisher                = {Association for Computational Linguistics},
+  Url                      = {http://cogcomp.org/papers/RozovskayaSaRo12.pdf},
+  Year                     = {2012}
+}
+
+@Other{Salvo07,
+  Title                    = {Lifted First-Order Probabilistic Inference},
+  Author                   = {R. de Salvo Braz},
+  Booktitle                = {UIUC PhD Thesis},
+  Url                      = {http://cogcomp.org/papers/Braz07.pdf},
+  Year                     = {2007}
+}
+
+@InCollection{SalvoAmRo07,
+  Title                    = {Lifted First-Order Probabilistic Inference},
+  Author                   = {R. de Salvo Braz and E. Amir and D. Roth},
+  Booktitle                = {Introduction to Statistical Relational Learning},
+  Publisher                = {MIT Press},
+  Year                     = {2007},
+  Editor                   = {Lise Getoor and Ben Taskar},
+
+  Comment                  = {Relational Inference; Probabilistic Relational (first order) Models; First-order probabilistic inference without propositionalization; Lifted Probabilistic Inference},
+  Funding                  = {ARDA, ITR-BI, SoD},
+  Projects                 = {FOPI},
+  Url                      = {http://cogcomp.org/papers/BrazAmRo07.pdf}
+}
+
+@InCollection{SalvoAmRo08,
+  Title                    = {A Survey of First-Order Probabilistic Models},
+  Author                   = {R. de Salvo Braz and E. Amir and D. Roth},
+  Booktitle                = {Innovations in Bayesian Networks},
+  Publisher                = {Springer-Verlag},
+  Year                     = {2008},
+  Editor                   = {D.E. Holmes and L.C. Jain},
+  Pages                    = {289--317},
+
+  Comment                  = {Lifted Probabilistic Inference},
+  Funding                  = {ARDA, ITR-BI, SoD},
+  Projects                 = {FOPI},
+  Url                      = {http://cogcomp.org/papers/BrazAmRo08.pdf}
+}
+
+@Other{SalvoAmRo06,
+  Title                    = {MPE and Partial Inversion in Lifted Probabilistic Variable Elimination},
+  Author                   = {R. de Salvo Braz and E. Amir and D. Roth},
+  Booktitle                = {Proc. of the Conference on Artificial Intelligence (AAAI)},
+  Comment                  = {Relational Inference; Probabilistic Relational (first order) Models; First-order probabilistic inference without propositionalization; Lifted Probabilistic Inference},
+  Funding                  = {ARDA,ITR-BI},
+  Month                    = {7},
+  Projects                 = {FOPI},
+  Url                      = {http://cogcomp.org/papers/BrazAmRo06a.pdf},
+  Year                     = {2006}
+}
+
+@Other{SalvoAmRo06a,
+  Title                    = {MPE and Partial Inversion in Lifted Probabilistic Variable Elimination},
+  Author                   = {R. de Salvo Braz and E. Amir and D. Roth},
+  Booktitle                = {Proc. of the International Conference on Machine Learning (ICML)},
+  Comment                  = {Earlier Version of a AAAI'06 paper.},
+  Funding                  = {ARDA},
+  Month                    = {6},
+  Projects                 = {FOPI},
+  Url                      = {http://cogcomp.org/papers/BrazAmRo06.pdf},
+  Year                     = {2006}
+}
+
+@InProceedings{SalvoAmRo05,
+  Title                    = {Lifted First-order Probabilistic Inference},
+  Author                   = {R. de Salvo Braz and E. Amir and D. Roth},
+  Booktitle                = {Proc. of the International Joint Conference on Artificial Intelligence (IJCAI)},
+  Year                     = {2005},
+  Pages                    = {1319--1125},
+
+  Acceptance               = {240/1329 (18\%)},
+  Comment                  = {Relational Inference; Probabilistic Relational (first order) Models; First-order probabilistic inference without propositionalization},
+  Funding                  = {ITR-BI, CAREER},
+  Url                      = {http://cogcomp.org/papers/BrazAmRo05.pdf}
+}
+
+@InCollection{SGPRS06,
+  Title                    = {An Inference Model for Semantic Entailment in Natural Language},
+  Author                   = {R. de Salvo Braz and R. Girju and V. Punyakanok and D. Roth and M. Sammons},
+  Publisher                = {Springer},
+  Year                     = {2006},
+  Editor                   = {J. Quinonero Candela and I. Dagan and B. Magnini and F. d'Alche-Buc},
+  Pages                    = {261--286},
+  Volume                   = {3944},
+
+  Comment                  = {Revised version of PASCAL RTE Challenge. Textual Entailment, integrating NLP text analyis, shallow semantic inference},
+  Funding                  = {ARDA,ITR-BI,TRECC,CLUSTER,XPRESSMP},
+  Journal                  = {Machine Learning Challenges, Evaluating Predictive Uncertainty, Visual Object Classification and Recognizing Textual Entailment, First PASCAL Machine Learning Challenges Workshop, Revised Selected Papers},
+  Projects                 = {KINDLE,TE,KRNLP},
+  Url                      = {http://cogcomp.org/papers/BGPRS06.pdf}
+}
+
+@InProceedings{SGPRS05,
+  Title                    = {An Inference Model for Semantic Entailment in Natural Language},
+  Author                   = {R. de Salvo Braz and R. Girju and V. Punyakanok and D. Roth and M. Sammons},
+  Booktitle                = {Proc. of the Conference on Artificial Intelligence (AAAI)},
+  Year                     = {2005},
+  Pages                    = {1678--1679},
+
+  Acceptance               = {223/803 (28\%)},
+  Comment                  = {Textual Entailment; Mapping sentences to a description logic based representation, Pascal Entailment Task},
+  Funding                  = {ARDA,ITR-BI,TRECC,CLUSTER,XPRESSMP},
+  Projects                 = {KINDLE,TE,KRNLP},
+  Url                      = {http://cogcomp.org/papers/BGPRS05.pdf}
+}
+
+@Other{SGPRS05a,
+  Title                    = {Knowledge Representation for Semantic Entailment and Question-Answering},
+  Author                   = {R. de Salvo Braz and R. Girju and V. Punyakanok and D. Roth and M. Sammons},
+  Booktitle                = {Proc. of the International Joint Conference on Artificial Intelligence (IJCAI)},
+  Comment                  = {Analysis of our Textual Entailment system},
+  Funding                  = {ARDA,ITR-BI,TRECC,CLUSTER,XPRESSMP,TE},
+  Projects                 = {KINDLE},
+  Url                      = {http://cogcomp.org/papers/BGPRS05a.pdf},
+  Year                     = {2005}
+}
+
+@InProceedings{SGPRS05b,
+  Title                    = {An Inference Model for Semantic Entailment in Natural Language},
+  Author                   = {R. de Salvo Braz and R. Girju and V. Punyakanok and D. Roth and M. Sammons},
+  Booktitle                = {Proc. of the International Joint Conference on Artificial Intelligence (IJCAI)},
+  Year                     = {2005},
+
+  Acceptance               = {112/450 (25\%)},
+  Comment                  = {Textual Entailment; Mapping sentences to a description logic based representation},
+  Funding                  = {ARDA,ITR-BI,TRECC,CLUSTER,XPRESSMP},
+  Projects                 = {KINDLE,TE},
+  Url                      = {http://cogcomp.org/papers/BGPRS05b.pdf}
+}
+
+@TechReport{SalvoRo04,
+  Title                    = {Functional Subsumption in Feature Description Logic},
+  Author                   = {R. de Salvo Braz and D. Roth},
+  Institution              = {UIUC Computer Science Department},
+  Year                     = {2004},
+  Number                   = {UIUCDCS-R-2004-2423},
+
+  Funding                  = {ITR-BI,CAREER},
+  Invisible                = {true},
+  Projects                 = {KINDLE,KR}
+}
+
+@InProceedings{SalvoRo03,
+  Title                    = {Functional subsumption in Description Logics},
+  Author                   = {R. de Salvo Braz and D. Roth},
+  Booktitle                = {Proc. of the Conference on Neural Information Processing Systems (NIPS) Workshop on Feature Extraction and Selection},
+  Year                     = {2003},
+
+  Comment                  = {Relational Feature Extraction; Feature Description Logic},
+  Funding                  = {ITR-BI,CAREER},
+  Projects                 = {KR,KINDLE}
+}
+
+@TechReport{SalvoRoAm04,
+  Title                    = {First-order probabilistic inference revisited},
+  Author                   = {R. de Salvo Braz and D. Roth and E. Amir},
+  Institution              = {UIUC Computer Science Department},
+  Year                     = {2004},
+  Month                    = {6},
+  Number                   = {UIUCDCS-R-2004-2443},
+
+  Comment                  = {First order Probabilistic Inference without grounding.},
+  Funding                  = {ITR-BI},
+  Invisible                = {true},
+  Projects                 = {KR,FOPI}
+}
+
+@Other{Samdani13,
+  Title                    = {Algorithms for Structural Learning with Decompositions},
+  Author                   = {Rajhans Samdani},
+  Booktitle                = {UIUC PhD Thesis},
+  Url                      = {http://cogcomp.org/papers/Samdani13.pdf},
+  Year                     = {2013}
+}
+
+@InProceedings{SamdaniChRo14,
+  Title                    = {A Discriminative Latent Variable Model for Online Clustering},
+  Author                   = {Rajhans Samdani and Kai-Wei Chang and Dan Roth},
+  Booktitle                = {Proc. of the International Conference on Machine Learning (ICML)},
+  Year                     = {2014},
+
+  Acceptance               = {14.7\%},
+  Url                      = {http://cogcomp.org/papers/l3m.icml.pdf}
+}
+
+@Other{SamdaniChRo12,
+  Title                    = {A Framework for Tuning Posterior Entropy in Unsupervised Learning},
+  Author                   = {Rajhans Samdani and Ming-Wei Chang and Dan Roth},
+  Booktitle                = {Proc. of the International Conference on Machine Learning (ICML)},
+  Funding                  = {ONR, ARL, AFRL},
+  Month                    = {6},
+  Url                      = {http://cogcomp.org/papers/SamdaniChRo12b.pdf},
+  Year                     = {2012}
+}
+
+@InProceedings{SamdaniChRo12a,
+  Title                    = {Unified Expectation Maximization},
+  Author                   = {Rajhans Samdani and Ming-Wei Chang and Dan Roth},
+  Booktitle                = {Proc. of the Annual Conference of the North American Chapter of the Association for Computational Linguistics (NAACL)},
+  Year                     = {2012},
+  Month                    = {6},
+
+  Url                      = {http://cogcomp.org/papers/SamdaniChRo12.pdf}
+}
+
+@InProceedings{SamdaniRo12,
+  Title                    = {Efficient Decomposed Learning for Structured Prediction},
+  Author                   = {Rajhans Samdani and Dan Roth},
+  Booktitle                = {Proc. of the International Conference on Machine Learning (ICML)},
+  Year                     = {2012},
+  Month                    = {6},
+
+  Acceptance               = {27\%},
+  Funding                  = {ONR, AFRL, ARL},
+  Url                      = {http://cogcomp.org/papers/SamdaniRo12.pdf}
+}
+
+@InProceedings{SCKKSVBWR16,
+  Title                    = {EDISON: Feature Extraction for NLP, Simplified},
+  Author                   = {Mark Sammons and Christos Christodoulopoulos and Parisa Kordjamshidi and Daniel Khashabi and Vivek Srikumar and Paul Vijayakumar and Mazin Bokhari and Xinbo Wu and Dan Roth},
+  Booktitle                = {Proc. of the International Conference on Language Resources and Evaluation (LREC) },
+  Year                     = {2016},
+  Editor                   = {Nicoletta Calzolari (Conference Chair) and Khalid Choukri and Thierry Declerck and Marko Grobelnik and Bente Maegaard and Joseph Mariani and Asuncion Moreno and Jan Odijk and Stelios Piperidis},
+  Publisher                = {European Language Resources Association (ELRA)},
+
+  Url                      = {http://cogcomp.org/papers/SCKKSVBWR16.pdf}
+}
+
+@Other{SPSUTRRR15,
+  Title                    = {Illinois CCG TAC 2015 Event Nugget, Entity Discovery and Linking, and Slot Filler Validation Systems},
+  Author                   = {Mark Sammons and Haoruo Peng and Yangqiu Song and Shyam Upadhyay and Chen-Tse Tsai and Pavankumar Reddy and Subhro Roy and Dan Roth},
+  Booktitle                = {Text Analysis Conference},
+  Institution              = {National Institute of Standards and Technology},
+  Url                      = {http://cogcomp.org/papers/SPSUTRRR15.pdf},
+  Year                     = {2015}
+}
+
+@InProceedings{SPSUTRRR15a,
+  Title                    = {Illinois CCG TAC 2015 Event Nugget, Entity Discovery and Linking, and Slot Filler Validation Systems},
+  Author                   = {Mark Sammons and Haoruo Peng and Yangqiu Song and Shyam Upadhyay and Chen-Tse Tsai and Pavankumar Reddy and Subhro Roy and Dan Roth},
+  Booktitle                = {Proc. of the Text Analysis Conference (TAC)},
+  Year                     = {2015},
+
+  Url                      = {http://cogcomp.org/papers/TAC15.pdf}
+}
+
+@InProceedings{SSWKTUAM14,
+  Title                    = {Overview of UI-CCG Systems for Event Argument Extraction, Entity Discovery and Linking, and Slot Filler Validation},
+  Author                   = {Mark Sammons and Yangqiu Song and Ruichen Wang and Gourab Kundu and Chen-Tse Tsai and Shyam Upadhyay and Siddarth Ancha and Stephen Mayhew},
+  Booktitle                = {Proc. of the Text Analysis Conference (TAC)},
+  Year                     = {2014},
+
+  Institution              = {NIST},
+  Url                      = {http://cogcomp.org/papers/SSWKTUMRA14.pdf}
+}
+
+@InCollection{SammonsVyRo12,
+  Title                    = {Recognizing Textual Entailment },
+  Author                   = {Mark Sammons and V.G.Vinod Vydiswaran and Dan Roth},
+  Booktitle                = {Multilingual Natural Language Applications: From Theory to Practice},
+  Publisher                = {Prentice Hall},
+  Year                     = {2012},
+  Editor                   = {Daniel M. Bikel and Imed Zitouni},
+  Month                    = {5},
+  Pages                    = {209-258}
+}
+
+@InProceedings{SammonsVyRo10,
+  Title                    = {Ask not what Textual Entailment can do for You...},
+  Author                   = {M. Sammons and V. Vydiswaran and D. Roth},
+  Booktitle                = {Proc. of the Annual Meeting of the Association for Computational Linguistics (ACL)},
+  Year                     = {2010},
+
+  Address                  = {Uppsala, Sweden},
+  Month                    = {7},
+  Publisher                = {Association for Computational Linguistics},
+
+  Comment                  = {Annotation, explanation, Recognizing Textual Entailment, evaluating textual entailment, data ablation},
+  Funding                  = {DARPA,Boeing, DHS},
+  Projects                 = {TE},
+  Url                      = {http://cogcomp.org/papers/SammonsVyRo10.pdf}
+}
+
+@InProceedings{SVVJCGSKTSRDR09,
+  Title                    = {Relation Alignment for Textual Entailment Recognition},
+  Author                   = {M. Sammons and V. Vydiswaran and T. Vieira and N. Johri and M. Chang and D. Goldwasser and V. Srikumar and G. Kundu and Y. Tu and K. Small and J. Rule and Q. Do and D. Roth},
+  Booktitle                = {Proc. of the Text Analysis Conference (TAC)},
+  Year                     = {2009},
+
+  Comment                  = {Recognizing Textual Entailment, textual entailment system, alignment, multi-view representation},
+  Funding                  = {DARPA,Boeing},
+  Projects                 = {TE,KRNLP},
+  Url                      = {http://cogcomp.org/papers/SVVJCGSKTSRDR09(1).pdf}
+}
+
+@InProceedings{ShenLiDo05,
+  Title                    = {Constraint-Based Entity Matching},
+  Author                   = {W. Shen and X. Li and A. Doan},
+  Booktitle                = {Proc. of the Conference on Artificial Intelligence (AAAI)},
+  Year                     = {2005},
+
+  Acceptance               = {223/803 (28\%)},
+  Comment                  = {Entity Identification, Generative Model, Record Linkage, Constraint, Relaxation Labeling},
+  Funding                  = {MURI,ITR-MIT},
+  Projects                 = {MIRROR,NER,COREF},
+  Url                      = {http://cogcomp.org/papers/ShenLiDn05.pdf}
+}
+
+@Other{Small09,
+  Title                    = {Interactive Learning Protocols for Natural Language Applications},
+  Author                   = {K. Small},
+  Booktitle                = {UIUC PhD Thesis},
+  Url                      = {http://cogcomp.org/papers/Small09.pdf},
+  Year                     = {2009}
+}
+
+@Article{SmallRo10,
+  Title                    = {Margin-based Active Learning for Structured Predictions},
+  Author                   = {K. Small and D. Roth},
+  Year                     = {2010},
+  Pages                    = {3-25},
+  Volume                   = {1},
+
+  Booktitle                = {IJMLC},
+  Url                      = {http://cogcomp.org/papers/SmallRo10.pdf}
+}
+
+@InProceedings{SondhiVyZh12,
+  Title                    = {Reliability Prediction of Webpages in the Medical Domain},
+  Author                   = {Parikshit Sondhi and V.G. Vinod Vydiswaran and ChengXiang Zhai},
+  Booktitle                = {Proc. of the European Conference on Information Retrieval},
+  Year                     = {2012},
+  Month                    = {4},
+  Pages                    = {219--231},
+  Volume                   = {7224},
+
+  Url                      = {http://cogcomp.org/papers/SondhiVyZh12.pdf}
+}
+
+@InCollection{SongMaRo16,
+  Title                    = {Cross-lingual Dataless Classification for Languages with Small Wikipedia Presence},
+  Author                   = {Yangqiu Song and Stephen Mayhew and Dan Roth},
+  Booktitle                = {arXiv},
+  Year                     = {2016},
+  Month                    = {11},
+  Number                   = {arXiv:1611.04122},
+  Pages                    = {17},
+
+  Url                      = {http://cogcomp.org/papers/SongMR16.pdf}
+}
+
+@InProceedings{SPKSR15,
+  Title                    = {Improving a Pipeline Architecture for Shallow Discourse Parsing},
+  Author                   = {Yangqiu Song and Haoruo Peng and Parisa Kordjamshidi and Mark Sammons and Dan Roth},
+  Booktitle                = {Proc. of the Conference on Computational Natural Language Learning (CoNLL)},
+  Year                     = {2015},
+
+  Url                      = {http://cogcomp.org/papers/SPKSR15.pdf}
+}
+
+@InProceedings{SongRo15,
+  Title                    = {Unsupervised Sparse Vector Densification for Short Text Similarity},
+  Author                   = {Yangqiu Song and Dan Roth},
+  Booktitle                = {Proc. of the Annual Conference of the North American Chapter of the Association for Computational Linguistics (NAACL)},
+  Year                     = {2015},
+  Month                    = {5},
+
+  Url                      = {http://cogcomp.org/papers/SongRo15.pdf}
+}
+
+@InProceedings{SongRo14,
+  Title                    = {On Dataless Hierarchical Text Classification},
+  Author                   = {Yangqiu Song and Dan Roth},
+  Booktitle                = {Proc. of the Conference on Artificial Intelligence (AAAI)},
+  Year                     = {2014},
+  Month                    = {7},
+
+  Url                      = {http://cogcomp.org/papers/SongRo14.pdf}
+}
+
+@InProceedings{SUPR16,
+  Title                    = {Cross-lingual Dataless Classification for Many Languages},
+  Author                   = {Yangqiu Song and Shyam Upadhyay and Haoruo Peng and Dan Roth},
+  Booktitle                = {Proc. of the International Joint Conference on Artificial Intelligence (IJCAI)},
+  Year                     = {2016},
+
+  Url                      = {http://cogcomp.org/papers/SUPR16.pdf}
+}
+
+@Other{Srikumar13,
+  Title                    = {The Semantics of Role Labeling},
+  Author                   = {Vivek Srikumar},
+  Booktitle                = {UIUC PhD Thesis},
+  Url                      = {http://cogcomp.org/papers/Srikumar13.pdf},
+  Year                     = {2013}
+}
+
+@InProceedings{SrikumarKuRo12,
+  Title                    = {On Amortizing Inference Cost for Structured Prediction},
+  Author                   = {Vivek Srikumar and Gourab Kundu and Dan Roth},
+  Booktitle                = {Proc. of the Conference on Empirical Methods in Natural Language Processing (EMNLP)},
+  Year                     = {2012},
+  Month                    = {7},
+
+  Url                      = {http://cogcomp.org/papers/SrikumarKuRo12.pdf}
+}
+
+@InProceedings{SRSRR08,
+  Title                    = {Extraction of Entailed Semantic Relations Through Syntax-based Comma Resolution},
+  Author                   = {V. Srikumar and R. Reichart and M. Sammons and A. Rappoport and D. Roth},
+  Booktitle                = {Proc. of the Annual Meeting of the Association for Computational Linguistics (ACL)},
+  Year                     = {2008},
+
+  Address                  = {Columbus, OH, USA},
+  Month                    = {6},
+  Publisher                = {Association for Computational Linguistics},
+
+  Funding                  = {SoD,Boeing},
+  Projects                 = {TE},
+  Url                      = {http://cogcomp.org/papers/SRSRR08.pdf}
+}
+
+@Article{SrikumarRo13,
+  Title                    = {Modeling Semantic Relations Expressed by Prepositions},
+  Author                   = {Vivek Srikumar and Dan Roth},
+  Year                     = {2013},
+  Pages                    = {231-242},
+  Volume                   = {1},
+
+  Booktitle                = {TACL},
+  Url                      = {http://cogcomp.org/papers/SrikumarRo13.pdf}
+}
+
+@InProceedings{SrikumarRo11,
+  Title                    = {A Joint Model for Extended Semantic Role Labeling},
+  Author                   = {V. Srikumar and D. Roth},
+  Booktitle                = {Proc. of the Conference on Empirical Methods in Natural Language Processing (EMNLP)},
+  Year                     = {2011},
+
+  Address                  = {Edinburgh, Scotland},
+
+  Url                      = {http://cogcomp.org/papers/SrikumarRo11.pdf}
+}
+
+@InProceedings{TKSR10,
+  Title                    = {Unsupervised Aggregation for Classification Problems with Large Numbers of Categories},
+  Author                   = {I. Titov and A. Klementiev and K. Small and D. Roth},
+  Booktitle                = {Proc. of the International Workshop on Artificial Intelligence and Statistics (AISTATS)},
+  Year                     = {2010},
+  Month                    = {5},
+
+  Comment                  = {Structured prediction; Unsupervised Learning; Aggregation},
+  Funding                  = {BL, DHS},
+  Url                      = {http://cogcomp.org/papers/TKSR10.pdf}
+}
+
+@Other{Tsai17,
+  Title                    = {Concept and Entity Grounding Using Indirect Supervision},
+  Author                   = {Chen-Tse Tsai},
+  Booktitle                = {UIUC PhD Thesis},
+  Url                      = {http://cogcomp.org/papers/Tsai17.pdf},
+  Year                     = {2017}
+}
+
+@InProceedings{TsaiKuRo13,
+  Title                    = {Concept-Based Analysis of Scientific Literature},
+  Author                   = {Chen-Tse Tsai and Gourab Kundu and Dan Roth},
+  Booktitle                = {Proc. of the ACM Conference on Information and Knowledge Management (CIKM)},
+  Year                     = {2013},
+
+  Url                      = {http://cogcomp.org/papers/TsaiKuRo13.pdf}
+}
+
+@Other{TMPSMRR16,
+  Title                    = {Illinois CCG Entity Discovery and Linking, Event Nugget Detection and Co-reference, and Slot Filler Validation Systems for TAC 2016},
+  Author                   = {Chen-Tse Tsai and Stephen Mayhew and Haoruo Peng and Mark Sammons and Bhargav Mangipundi and Pavankumar Reddy and Dan Roth},
+  Booktitle                = {Text Analysis Conference (Proc. of the Text Analysis Conference (TAC) 2016)},
+  Institution              = {National Institute of Standards and Technology},
+  Year                     = {2016}
+}
+
+@InProceedings{TsaiMaRo16,
+  Title                    = {Cross-Lingual Named Entity Recognition via Wikification},
+  Author                   = {Chen-Tse Tsai and Stephen Mayhew and Dan Roth},
+  Booktitle                = {Proc. of the Conference on Computational Natural Language Learning (CoNLL)},
+  Year                     = {2016},
+
+  Url                      = {http://cogcomp.org/papers/TsaiMaRo16.pdf}
+}
+
+@InProceedings{TsaiRo16,
+  Title                    = {Illinois Cross-Lingual Wikifier: Grounding Entities in Many Languages to the English Wikipedia},
+  Author                   = {Chen-Tse Tsai and Dan Roth},
+  Booktitle                = {Proc. of the International Conference on Computational Linguistics (COLING) Demonstrations},
+  Year                     = {2016},
+  Month                    = {12},
+
+  Url                      = {http://cogcomp.org/papers/TsaiRo16c.pdf}
+}
+
+@InProceedings{TsaiRo16a,
+  Title                    = {Cross-lingual Wikification Using Multilingual Embeddings},
+  Author                   = {Chen-Tse Tsai and Dan Roth},
+  Booktitle                = {Proc. of the Annual Conference of the North American Chapter of the Association for Computational Linguistics (NAACL)},
+  Year                     = {2016},
+  Month                    = {6},
+
+  Url                      = {http://cogcomp.org/papers/TsaiRo16b.pdf}
+}
+
+@Article{TsaiRo16b,
+  Title                    = {Concept Grounding to Multiple Knowledge Bases via Indirect Supervision},
+  Author                   = {Chen-Tse Tsai and Dan Roth},
+  Year                     = {2016},
+
+  Month                    = {2},
+
+  Booktitle                = {TACL},
+  Url                      = {http://cogcomp.org/papers/TsaiRo16.pdf}
+}
+
+@InProceedings{TSMSR16,
+  Title                    = {Illinois CCG LoReHLT 2016 Named Entity Recognition and Situation Frame Systems},
+  Author                   = {Chen-Tse Tsai and Yangqiu Song and Stephen Mayhew and Mark Sammons and Dan Roth},
+  Booktitle                = {Low Resource Human Language Technologies (LoReHLT)},
+  Year                     = {2016},
+
+  Url                      = {http://cogcomp.org/papers/CYSMD16.pdf}
+}
+
+@Other{Tu12,
+  Title                    = {English Complex Verb Constructions: Identification and Inference},
+  Author                   = {Yuancheng Tu},
+  Booktitle                = {UIUC PhD Thesis},
+  Url                      = {http://cogcomp.org/papers/Tu12.pdf},
+  Year                     = {2012}
+}
+
+@InProceedings{TJRH10,
+  Title                    = {Citation Author Topic Model in Expert Search},
+  Author                   = {Y. Tu and N. Johri and D. Roth and J. Hockenmaier},
+  Booktitle                = {Proc. of the International Conference on Computational Linguistics (COLING)},
+  Year                     = {2010},
+
+  Comment                  = {author topic model, expert search, semantic search, information retrieval},
+  Funding                  = {MIAS},
+  Projects                 = {search},
+  Url                      = {http://cogcomp.org/papers/TJRH10(2).pdf}
+}
+
+@InProceedings{TuRo12,
+  Title                    = {Sorting out the Most Confusing English Phrasal Verbs},
+  Author                   = {Yuancheng Tu and Dan Roth},
+  Booktitle                = {Proc. of the Joint Conference on Lexical and Computational Sematics},
+  Year                     = {2012},
+
+  Address                  = {Montreal, Canada},
+  Publisher                = {Association for Computational Linguistics},
+
+  Funding                  = {DHS},
+  Projects                 = {LS},
+  Url                      = {http://cogcomp.org/papers/TuRoth12.pdf}
+}
+
+@Other{TuRo11,
+  Title                    = {Learning English Light Verb Constructions: Contextual or Statistical},
+  Author                   = {Y. Tu and D. Roth},
+  Booktitle                = {Proc. of the Annual Meeting of the Association for Computational Linguistics (ACL)},
+  Funding                  = {MIAS},
+  Projects                 = {LS},
+  Url                      = {http://cogcomp.org/papers/TuRo11.pdf},
+  Year                     = {2011}
+}
+
+@InProceedings{TurianRaBe10,
+  Title                    = {Word representations: A simple and general method for semi-supervised learning},
+  Author                   = {J. Turian and L. Ratinov and Y. Bengio},
+  Booktitle                = {Proc. of the Annual Meeting of the Association for Computational Linguistics (ACL)},
+  Year                     = {2010},
+
+  Url                      = {http://cogcomp.org/papers/TurianRaBe2010.pdf}
+}
+
+@Other{UpadhyayChRo16,
+  Title                    = {Making the News - Identifying Noteworthy Events in News Articles},
+  Author                   = {Shyam Upadhyay and Christos Christodoulopoulos and Dan Roth},
+  Booktitle                = {The 4th Workshop on EVENTS, Proc. of the Annual Conference of the North American Chapter of the Association for Computational Linguistics (NAACL)},
+  Url                      = {http://cogcomp.org/papers/W16-1001.pdf},
+  Year                     = {2016}
+}
+
+@InProceedings{UFDR16,
+  Title                    = {Cross-lingual Models of Word Embeddings: An Empirical Comparison},
+  Author                   = {Shyam Upadhyay and Manaal Faruqui and Chris Dyer and Dan Roth},
+  Booktitle                = {Proc. of the Annual Meeting of the Association for Computational Linguistics (ACL)},
+  Year                     = {2016},
+
+  Url                      = {http://cogcomp.org/papers/acl2016.pdf}
+}
+
+@InProceedings{UGCR16,
+  Title                    = {Revisiting the Evaluation for Cross Document Event Coreference},
+  Author                   = {Shyam Upadhyay and Nitish Gupta and Christos Christodoulopoulos and Dan Roth},
+  Booktitle                = {Proc. of the International Conference on Computational Linguistics (COLING)},
+  Year                     = {2016},
+
+  Url                      = {http://cogcomp.org/papers/revisiting-evaluation-cross.pdf}
+}
+
+@Other{Vydiswar13,
+  Title                    = {Modeling and Predicting Trustworthiness of Online Textual Information},
+  Author                   = {V.G.Vinod Vydiswaran},
+  Booktitle                = {UIUC PhD Thesis},
+  Url                      = {http://cogcomp.org/papers/Vydiswaran13.pdf},
+  Year                     = {2013}
+}
+
+@Other{VydiswaranZhRo11,
+  Title                    = {Gauging the Internet Doctor: Ranking Medical Claims based on Community Knowledge},
+  Author                   = {V. Vydiswaran and C. Zhai and D. Roth},
+  Booktitle                = {Proc. of the ACM SIGKDD Conference on Knowledge Discovery and Data Mining (KDD) Workshop on Data Mining for Medicine and HealthCare},
+  Funding                  = {MIAS, CCICADA, ARL},
+  Month                    = {8},
+  Projects                 = {Trustworthiness},
+  Url                      = {http://cogcomp.org/papers/VydiswaranZhRo11b.pdf},
+  Year                     = {2011}
+}
+
+@InProceedings{VydiswaranZhRo11a,
+  Title                    = {Content-driven Trust Propagation Framework},
+  Author                   = {V. Vydiswaran and C. Zhai and D. Roth},
+  Booktitle                = {Proc. of the ACM SIGKDD Conference on Knowledge Discovery and Data Mining (KDD)},
+  Year                     = {2011},
+  Month                    = {8},
+  Pages                    = {974--982},
+
+  Acceptance               = {17.5\%},
+  Funding                  = {MIAS, CCICADA, ARL},
+  Projects                 = {Trustworthiness},
+  Url                      = {http://cogcomp.org/papers/VydiswaranZhRo11.pdf}
+}
+
+@Article{VZRP14,
+  Title                    = {Overcoming bias to learn about controversial topics},
+  Author                   = {V.G.Vinod Vydiswaran and Chengxiang Zhai and Dan Roth and Peter Pirolli},
+  Journal                  = {Journal of the American Society for Information Science and Technology (JASIST)},
+  Year                     = {2014},
+
+  Projects                 = {Trustworthiness},
+  Publisher                = {Wiley},
+  Url                      = {http://cogcomp.org/papers/VZRP14.pdf}
+}
+
+@InProceedings{VZRP12,
+  Title                    = {BiasTrust: Teaching biased users about controversial topics},
+  Author                   = {V.G.Vinod Vydiswaran and ChengXiang Zhai and Dan Roth and Peter Pirolli},
+  Booktitle                = {Proc. of the ACM Conference on Information and Knowledge Management (CIKM)},
+  Year                     = {2012},
+  Month                    = {10},
+  Pages                    = {1205--1209},
+
+  Funding                  = {MIAS, ITI, ARL},
+  Projects                 = {Trustworthiness},
+  Url                      = {http://cogcomp.org/papers/VZRP12b.pdf}
+}
+
+@InProceedings{VZRP12a,
+  Title                    = {Unbiased Learning of Controversial Topics},
+  Author                   = {V.G.Vinod Vydiswaran and ChengXiang Zhai and Dan Roth and Peter Pirolli},
+  Booktitle                = {Proc. of the Annual Meeting of the American Society for Information Science and Technology},
+  Year                     = {2012},
+  Month                    = {10},
+
+  Funding                  = {MIAS, ITI, ARL},
+  Projects                 = {Trustworthiness},
+  Url                      = {http://cogcomp.org/papers/VZRP12.pdf}
+}
+
+@InProceedings{WSERZH15,
+  Title                    = {Incorporating World Knowledge to Document Clustering via Heterogeneous Information Networks},
+  Author                   = {Chenguang Wang and Yangqiu Song and Ahmed El-Kishky and Dan Roth and Ming Zhang and Jiawei Han},
+  Booktitle                = {Proc. of the ACM SIGKDD Conference on Knowledge Discovery and Data Mining (KDD)},
+  Year                     = {2015},
+
+  Url                      = {http://cogcomp.org/papers/WSERZH15.pdf}
+}
+
+@InProceedings{WSRWHJZ15,
+  Title                    = {Constrained Information-Theoretic Tripartite Graph Clustering to Identify Semantically Similar Relations},
+  Author                   = {Chenguang Wang and Yangqiu Song and Dan Roth and Chi Wang and Jiawei Han and Heng Ji and Ming Zhang},
+  Booktitle                = {Proc. of the International Joint Conference on Artificial Intelligence (IJCAI)},
+  Year                     = {2015},
+
+  Url                      = {http://cogcomp.org/papers/WSRWHJZ15.pdf}
+}
+
+@Article{WSRZH16,
+  Title                    = {World Knowledge as Indirect Supervision for Document Clustering},
+  Author                   = {Chenguang Wang and Yangqiu Song and Dan Roth and Ming Zhang and Jiawei Han},
+  Year                     = {2016},
+
+  Booktitle                = {ACM TKDD},
+  Url                      = {http://cogcomp.org/papers/WSRZH16.pdf}
+}
+
+@Other{WAAPRGHFLA11,
+  Title                    = {On Bayesian Interpretation of Fact-finding in Information Networks},
+  Author                   = {D. Wang and T. Abdelzaher and H. Ahmadi and J. Pasternack and D. Roth and M. Gupta and J. Han and O. Fatemieh and H. Le and C. Aggarwal},
+  Booktitle                = {Proc. of the International Conference on Information Fusion},
+  Url                      = {http://cogcomp.org/papers/WAAPRGHFLA11.pdf},
+  Year                     = {2011}
+}
+
+@Article{WBGLR15,
+  Title                    = {From Paraphrase Database to Compositional Paraphrase Model and Back},
+  Author                   = {John Wieting and Mohit Bansal and Kevin Gimpel and Karen Livescu and Dan Roth},
+  Year                     = {2015},
+
+  Booktitle                = {TACL},
+  Url                      = {http://cogcomp.org/papers/WietingBaGiLiRo15.pdf}
+}
+
+@InProceedings{WSSASURCGD17,
+  Title                    = {A Consolidated Open Knowledge Representation for Multiple Texts},
+  Author                   = {Rachel Wities and Vered Shwartz and Gabriel Stanovsky and Meni Adler and Ori Shapira and Shyam Upadhyay and Dan Roth and Eugenio Martinez Camara and Iryna Gurevych and Ido Dagan},
+  Booktitle                = {Proceedings of the 2nd LSDSem Workshop, in EACL},
+  Year                     = {2017},
+
+  Url                      = {http://cogcomp.org/papers/paper.pdf}
+}
+
+@InProceedings{WFDMSR14,
+  Title                    = {IllinoisCloudNLP: Text Analytics Services in the Cloud},
+  Author                   = {Hao Wu and Zhiye Fei and Aaron Dai and Stephen Mayhew and Mark Sammons and Dan Roth},
+  Booktitle                = {Proc. of the International Conference on Language Resources and Evaluation (LREC)},
+  Year                     = {2014},
+  Month                    = {5},
+
+  Funding                  = {MIAS, ARL, DARPA, NSF},
+  Url                      = {http://cogcomp.org/papers/WFDMSR14.pdf}
+}
+
+@InProceedings{YangRoAh02,
+  Title                    = {A Tale of Two Classifiers: SNoW vs. SVM in Visual Recognition},
+  Author                   = {M. Yang and D. Roth and N. Ahuja},
+  Booktitle                = {Proc. of the European Conference on Computer Vision (ECCV)},
+  Year                     = {2002},
+  Pages                    = {685--700},
+
+  Acceptance               = {45/600 (7.5\%) Oral Presentations; 225/600 (37\%) overall},
+  Funding                  = {NSF98,ITR-MIT},
+  Projects                 = {LT,LV},
+  Url                      = {http://cogcomp.org/papers/YangRoAh02.pdf}
+}
+
+@InProceedings{YangRoAh01,
+  Title                    = {Face Detection Using Large Margin Classifiers},
+  Author                   = {M. Yang and D. Roth and N. Ahuja},
+  Booktitle                = {Proc. of the IEEE International Conference on Image Processing (ICIP)},
+  Year                     = {2001},
+  Pages                    = {665--668},
+
+  Funding                  = {NSF98,ITR-MIT,CAREER},
+  Projects                 = {LV,LT},
+  Url                      = {http://cogcomp.org/papers/YangRoAh01.pdf}
+}
+
+@InProceedings{YangRoAh00,
+  Title                    = {A SNoW-based Face Detector},
+  Author                   = {M. Yang and D. Roth and N. Ahuja},
+  Booktitle                = {Proc. of the Conference on Neural Information Processing Systems (NIPS)},
+  Year                     = {2000},
+  Pages                    = {855--861},
+  Publisher                = {MIT Press},
+
+  Acceptance               = {151/467 (32\%)},
+  Funding                  = {NSF98},
+  Url                      = {http://cogcomp.org/papers/nips00.pdf}
+}
+
+@InProceedings{YangRoAh00a,
+  Title                    = {Learning To Recognize 3D Objects With SNoW},
+  Author                   = {M. Yang and D. Roth and N. Ahuja},
+  Booktitle                = {Proc. of the European Conference on Computer Vision (ECCV)},
+  Year                     = {2000},
+  Month                    = {6},
+
+  Acceptance               = {43/266 (16\%) Oral Presentations; 115/266 (43\%) overall},
+  Url                      = {http://cogcomp.org/papers/YangRoAh00a.pdf}
+}
+
+@InProceedings{YangRoAh00b,
+  Title                    = {View-Based 3D Object Recognition Using SNoW},
+  Author                   = {M. Yang and D. Roth and N. Ahuja},
+  Booktitle                = {Proc. of the Asian Conference on Computer Vision (ACCV)},
+  Year                     = {2000},
+  Month                    = {1},
+  Pages                    = {830--835},
+  Volume                   = {2},
+
+  Acceptance               = {172/268 (64\%)},
+  Url                      = {http://cogcomp.org/papers/accv00.pdf}
+}
+
+@Other{Yih05,
+  Title                    = {Learning and Inference for Information Extraction},
+  Author                   = {W. Yih},
+  Booktitle                = {UIUC PhD thesis},
+  Url                      = {http://cogcomp.org/papers/Yih05.pdf},
+  Year                     = {2005}
+}
+
+@InProceedings{YihChKi04,
+  Title                    = {Mining Online Deal Forums for Hot Deals},
+  Author                   = {W. Yih and P. Chang and W. Kim},
+  Booktitle                = {Proc. of the IEEE/WIC/ACM International Conference on Web Intelligence (WI)},
+  Year                     = {2004},
+  Pages                    = {384--390},
+  Publisher                = {IEEE Computer Society},
+
+  Comment                  = {Applying topic and sentiment text classification to online web forums},
+  Funding                  = {ITR-BI,MURI},
+  Projects                 = {IIA},
+  Url                      = {http://scottyih.org/YihChKi-wi04.pdf}
+}
+
+@Article{ZTLHPRL07,
+  Title                    = {Audio-Visual Affect Recognition},
+  Author                   = {Z. Zeng and J. Tu and M. Liu and T. Huang and B. Pianfetti and D. Roth and S. Levinson},
+  Journal                  = {IEEE Transactions on Multimedia},
+  Year                     = {2007},
+  Number                   = {2},
+  Pages                    = {424-428},
+  Volume                   = {9},
+
+  Funding                  = {ITR-BI},
+  Url                      = {http://cogcomp.org/papers/ZTLHPRL07.pdf}
+}
+
+@InProceedings{ZTLZRZHRL04,
+  Title                    = {Bimodal HCI-related Affect Recognition},
+  Author                   = {Z. Zeng and J. Tu and M. Liu and T. Zhang and N. Rizzolo and Z. Zhang and T. Huang and D. Roth and S. Levinson},
+  Booktitle                = {Proc. of the International Conference on Multimodal Interfaces (ICMI)},
+  Year                     = {2004},
+  Month                    = {10},
+  Pages                    = {137--143},
+
+  Acceptance               = {56/257 (28\%)},
+  Funding                  = {TRECC,ITR-BI},
+  Url                      = {http://cogcomp.org/papers/ZTKZRZHRL04.pdf}
+}
+
+@InProceedings{ZhaoDoRo12,
+  Title                    = {A Robust Shallow Temporal Reasoning System},
+  Author                   = {Ran Zhao and Quang Do and Dan Roth},
+  Booktitle                = {Proc. of the Annual Conference of the North American Chapter of the Association for Computational Linguistics (NAACL)},
+  Year                     = {2012},
+  Month                    = {6},
+
+  Url                      = {http://cogcomp.org/papers/ZhaoDoRo12.pdf}
+}
+
+@InProceedings{ZDCR05,
+  Title                    = {Learning Automation Policies for Pervasive Computing Environments},
+  Author                   = {B. Ziebart and A. Dey and R. Campbell and D. Roth},
+  Booktitle                = {Proc. of the International Conference on Autonomic Computing (ICAC)},
+  Year                     = {2005},
+  Pages                    = {204-215},
+
+  Acceptance               = {64/150 (43\%)},
+  Funding                  = {ITR-BI},
+  Projects                 = {LBP},
+  Url                      = {http://cogcomp.org/papers/ZDRC05.pdf}
+}
+
+@Other{Zimak06,
+  Title                    = {Algorithms and Analysis for Multi-Category Classification},
+  Author                   = {D. Zimak},
+  Booktitle                = {UIUC PhD Thesis},
+  Url                      = {http://cogcomp.org/papers/Zimak06.pdf},
+  Year                     = {2006}
+}
+
+@comment{jabref-meta: keypatterndefault:[authRoth][shortyear];}
 

--- a/cited-compact.bib
+++ b/cited-compact.bib
@@ -81724,3 +81724,539 @@ Build a Lexicon},
   Year                     = {2011}
 }
 
+@Book{AhoUl72,
+  Title                    = {The Theory of Parsing, Translation and Compiling},
+  Author                   = {Alfred V. Aho and Jeffrey D. Ullman},
+Publisher-omit = {Prentice-Hall},
+  Year                     = {1972},
+
+Address-omit = {Englewood Cliffs, NJ},
+Volume-omit = {1}
+}
+
+@Article{Allen84,
+  Title                    = {Towards a general theory of action and time},
+  Author                   = {Allen, James F},
+  Journal                  = {Artificial intelligence},
+  Year                     = {1984},
+Number-omit = {2},
+Pages-omit = {123--154},
+Volume-omit = {23},
+
+Publisher-omit = {Elsevier}
+}
+
+@Article{Allen83,
+  Title                    = {Maintaining knowledge about temporal intervals},
+  Author                   = {Allen, James F},
+  Journal                  = {Communications of the ACM},
+  Year                     = {1983},
+Number-omit = {11},
+Pages-omit = {832--843},
+Volume-omit = {26},
+
+Publisher-omit = {ACM}
+}
+
+@Book{APA83,
+  Title                    = {Publications Manual},
+  Author                   = {{American Psychological Association}},
+Publisher-omit = {American Psychological Association},
+  Year                     = {1983},
+
+Address-omit = {Washington, DC}
+}
+
+@InProceedings{Bethard13,
+  Title                    = {{ClearTK}-{TimeML}: A minimalist approach to {TempEval} 2013},
+  Author                   = {Bethard, Steven},
+  Booktitle                = {Second Joint Conference on Lexical and Computational Semantics (* SEM)},
+  Year                     = {2013},
+Pages-omit = {10--14},
+Volume-omit = {2}
+}
+
+@InProceedings{BDSPV15,
+  Title                    = {{SemEval}-2015 {Task} 6: {Clinical TempEval}},
+  Author                   = {Bethard, Steven and Derczynski, Leon and Savova, Guergana and Pustejovsky, James and Verhagen, Marc},
+  Booktitle                = {Proceedings of the 9th International Workshop on Semantic Evaluation (SemEval 2015)},
+  Year                     = {2015},
+
+Address-omit = {Denver, Colorado},
+Month-omit = {June},
+Pages-omit = {806--814},
+Publisher-omit = {Association for Computational Linguistics},
+
+Url-omit = {http://www.aclweb.org/anthology/S15-2136}
+}
+
+@InProceedings{BethardMa07,
+  Title                    = {{CU-TMP}: Temporal relation classification using syntactic and semantic features},
+  Author                   = {Bethard, Steven and Martin, James H},
+  Booktitle                = {Proceedings of the 4th International Workshop on Semantic Evaluations},
+  Year                     = {2007},
+  Organization             = {Association for Computational Linguistics},
+Pages-omit = {129--132}
+}
+
+@InProceedings{BethardMaKl07,
+  Title                    = {Timelines from text: Identification of syntactic temporal relations},
+  Author                   = {Bethard, Steven and Martin, James H and Klingenstein, Sara},
+  Booktitle                = {Semantic Computing, 2007. ICSC 2007. International Conference on},
+  Year                     = {2007},
+  Organization             = {IEEE},
+Pages-omit = {11--18}
+}
+
+@InProceedings{BSCDPV16,
+  Title                    = {{SemEval}-2016 {Task} 12: {Clinical TempEval}},
+  Author                   = {Bethard, Steven and Savova, Guergana and Chen, Wei-Te and Derczynski, Leon and Pustejovsky, James and Verhagen, Marc},
+  Booktitle                = {Proceedings of the 10th International Workshop on Semantic Evaluation (SemEval-2016)},
+  Year                     = {2016},
+
+Address-omit = {San Diego, California},
+Month-omit = {June},
+Pages-omit = {1052--1062},
+Publisher-omit = {Association for Computational Linguistics},
+
+Url-omit = {http://www.aclweb.org/anthology/S16-1165}
+}
+
+@InProceedings{CMCB14,
+  Title                    = {An annotation framework for dense event ordering},
+  Author                   = {Cassidy, Taylor and McDowell, Bill and Chambers, Nathanel and Bethard, Steven},
+  Booktitle                = ACL,
+  Year                     = {2014},
+Pages-omit = {501--506}
+}
+
+@TechReport{Chambers13,
+  Title                    = {{NavyTime}: Event and Time Ordering from Raw Text.},
+  Author                   = {Chambers, Nathanael},
+  Institution              = {DTIC Document},
+  Year                     = {2013}
+}
+
+@Article{CCMB14,
+  Title                    = {Dense event ordering with a multi-pass architecture},
+  Author                   = {Chambers, Nathanael and Cassidy, Taylor and McDowell, Bill and Bethard, Steven},
+  Journal                  = {Transactions of the Association for Computational Linguistics},
+  Year                     = {2014},
+Pages-omit = {273--284},
+Volume-omit = {2}
+}
+
+@InProceedings{ChambersWaJu07,
+  Title                    = {Classifying temporal relations between events},
+  Author                   = {Chambers, Nathanael and Wang, Shan and Jurafsky, Dan},
+  Booktitle                = {Proceedings of the 45th Annual Meeting of the ACL on Interactive Poster and Demonstration Sessions},
+  Year                     = {2007},
+  Organization             = {Association for Computational Linguistics},
+Pages-omit = {173--176}
+}
+
+@Article{ChandraKoSt81,
+  Title                    = {Alternation},
+  Author                   = {Ashok K. Chandra and Dexter C. Kozen and Larry J. Stockmeyer},
+  Journal                  = {Journal of the Association for Computing Machinery},
+  Year                     = {1981},
+Number-omit = {1},
+Pages-omit = {114--133},
+Volume-omit = {28}
+}
+
+@InProceedings{ChangMa12,
+  Title                    = {{SUTIME}: A Library for Recognizing and Normalizing Time Expressions.},
+  Author                   = {Chang, Angel X and Manning, Christopher D},
+  Booktitle                = {LREC},
+  Year                     = {2012},
+Pages-omit = {3735--3740},
+Volume-omit = {2012}
+}
+
+@Article{Computing83,
+  Author                   = {Association for Computing Machinery},
+  Journal                  = {Computing Reviews},
+  Year                     = {1983},
+Number-omit = {11},
+Pages-omit = {503--512},
+Volume-omit = {24}
+}
+
+@InProceedings{DenisMu11,
+  Title                    = {Predicting globally-coherent temporal structures from texts via endpoint inference and graph decomposition},
+  Author                   = {Denis, Pascal and Muller, Philippe},
+  Booktitle                = IJCAI,
+  Year                     = {2011},
+Number-omit = {3},
+Pages-omit = {1788},
+Volume-omit = {22}
+}
+
+@Article{Dietterich98,
+  Title                    = {Approximate statistical tests for comparing supervised classification learning algorithms},
+  Author                   = {Dietterich, Thomas G},
+  Journal                  = {Neural computation},
+  Year                     = {1998},
+Number-omit = {7},
+Pages-omit = {1895--1923},
+Volume-omit = {10},
+
+Publisher-omit = {MIT Press}
+}
+
+@Article{DunietzLeCa17,
+  Title                    = {Automatically Tagging Constructions of Causation and Their Slot-Fillers},
+  Author                   = {Dunietz, Jesse and Levin, Lori and Carbonell, Jaime},
+  Journal                  = {Transactions of the Association for Computational Linguistics},
+  Year                     = {2017},
+Pages-omit = {117--133},
+Volume-omit = {5}
+}
+
+@Book{Everitt92,
+  Title                    = {The analysis of contingency tables},
+  Author                   = {Everitt, Brian S},
+Publisher-omit = {CRC Press},
+  Year                     = {1992}
+}
+
+@InProceedings{GuelerYeSw16,
+  Title                    = {Learning causal information flow structures in multi-layer networks},
+  Author                   = {G{\"u}ler, Ba{\c{s}}ak and Yener, Aylin and Swami, Ananthram},
+  Booktitle                = {IEEE Global Conference on Signal and Information Processing (GlobalSIP)},
+  Year                     = {2016},
+Pages-omit = {1340--1344}
+}
+
+@InProceedings{GDYC16,
+  Title                    = {Physical Causality of Action Verbs in Grounded Language Understanding.},
+  Author                   = {Gao, Qiaozi and Doering, Malcolm and Yang, Shaohua and Chai, Joyce Yue},
+  Booktitle                = ACL,
+  Year                     = {2016}
+}
+
+@InProceedings{GoodmanVlNa16,
+  Title                    = {Noise reduction and targeted exploration in imitation learning for Abstract Meaning Representation parsing },
+  Author                   = {Goodman, James
+ and Vlachos, Andreas
+ and Naradowsky, Jason},
+  Booktitle                = {Proceedings of the 54th Annual Meeting of the Association for Computational Linguistics (Volume 1: Long Papers) },
+  Year                     = {2016},
+Pages-omit = {1--11},
+Publisher-omit = {Association for Computational Linguistics},
+
+Location-omit = {Berlin, Germany}
+}
+
+@Article{Graff02,
+  Title                    = {The {AQUAINT} corpus of English news text},
+  Author                   = {Graff, David},
+  Journal                  = {Linguistic Data Consortium, Philadelphia},
+  Year                     = {2002}
+}
+
+@Book{Gusfield97,
+  Title                    = {Algorithms on Strings, Trees and Sequences},
+  Author                   = {Dan Gusfield},
+Publisher-omit = {Cambridge University Press},
+  Year                     = {1997},
+
+Address-omit = {Cambridge, UK}
+}
+
+@InProceedings{Harper14,
+  Title                    = {Learning from 26 Languages: Program Management and Science in the Babel Program},
+  Author                   = {Harper, Mary},
+  Booktitle                = {Proceedings of COLING 2014, the 25th International Conference on Computational Linguistics: Technical Papers},
+  Year                     = {2014},
+Pages-omit = {1},
+Publisher-omit = {Dublin City University and Association for Computational Linguistics},
+
+Location-omit = {Dublin, Ireland}
+}
+
+@InProceedings{HideyMc16,
+  Title                    = {Identifying Causal Relations Using Parallel Wikipedia Articles},
+  Author                   = {Hidey, Christopher and McKeown, Kathy},
+  Booktitle                = {Proceedings of the 54th Annual Meeting of the Association for Computational Linguistics (Volume 1: Long Papers)},
+  Year                     = {2016},
+
+Address-omit = {Berlin, Germany},
+Month-omit = {August},
+Pages-omit = {1424--1433},
+Publisher-omit = {Association for Computational Linguistics},
+
+Url-omit = {http://www.aclweb.org/anthology/P16-1135}
+}
+
+@Article{JCLT14,
+  Title                    = {Tackling representation, annotation and classification challenges for temporal knowledge base population},
+  Author                   = {Ji, Heng and Cassidy, Taylor and Li, Qi and Tamang, Suzanne},
+  Journal                  = {Knowledge and Information Systems},
+  Year                     = {2014},
+Number-omit = {3},
+Pages-omit = {611--646},
+Volume-omit = {41},
+
+Publisher-omit = {Springer}
+}
+
+@InProceedings{JLGSCLS16,
+  Title                    = {Towards Time-Aware Knowledge Graph Completion},
+  Author                   = {Jiang, Tingsong and Liu, Tianyu and Ge, Tao and Sha, Lei and Chang, Baobao and Li, Sujian and Sui, Zhifang},
+  Booktitle                = {Proceedings of COLING 2016, the 26th International Conference on Computational Linguistics: Technical Papers},
+  Year                     = {2016},
+
+Address-omit = {Osaka, Japan},
+Month-omit = {December},
+Pages-omit = {1715--1724},
+Publisher-omit = {The COLING 2016 Organizing Committee},
+
+Url-omit = {http://aclweb.org/anthology/C16-1161}
+}
+
+@InProceedings{KneserNe95,
+  Title                    = {Improved backing-off for {M}-gram language modeling},
+  Author                   = {Kneser, Reinhard and Ney, Hermann},
+  Booktitle                = {Acoustics, Speech, and Signal Processing, 1995. ICASSP-95., 1995 International Conference on},
+  Year                     = {1995},
+  Organization             = {IEEE},
+Pages-omit = {181--184},
+Volume-omit = {1}
+}
+
+@InProceedings{LMTC13,
+  Title                    = {{UTTime}: Temporal relation classification using deep syntactic features},
+  Author                   = {Laokulrat, Natsuda and Miwa, Makoto and Tsuruoka, Yoshimasa and Chikayama, Takashi},
+  Booktitle                = {Second Joint Conference on Lexical and Computational Semantics (* SEM)},
+  Year                     = {2013},
+Pages-omit = {88--92},
+Volume-omit = {2}
+}
+
+@InProceedings{LADZ14,
+  Title                    = {Context-dependent Semantic Parsing for Time Expressions.},
+  Author                   = {Lee, Kenton and Artzi, Yoav and Dodge, Jesse and Zettlemoyer, Luke},
+  Booktitle                = {ACL (1)},
+  Year                     = {2014},
+Pages-omit = {1437--1447}
+}
+
+@InProceedings{LeeuwenbergMo17,
+  Title                    = {Structured learning for temporal relation extraction from clinical records},
+  Author                   = {Leeuwenberg, Tuur and Moens, Marie-Francine},
+  Booktitle                = {Proceedings of the 15th Conference of the European Chapter of the Association for Computational Linguistics},
+  Year                     = {2017}
+}
+
+@InProceedings{LCUMAP15,
+  Title                    = {{SemEval}-2015 {Task} 5: {QA} {TEMPEVAL} - Evaluating Temporal Information Understanding with Question Answering},
+  Author                   = {Llorens, Hector and Chambers, Nathanael and UzZaman, Naushad and Mostafazadeh, Nasrin and Allen, James and Pustejovsky, James},
+  Booktitle                = {Proceedings of the 9th International Workshop on Semantic Evaluation (SemEval 2015)},
+  Year                     = {2015},
+Pages-omit = {792--800}
+}
+
+@InProceedings{MVWLP06,
+  Title                    = {Machine learning of temporal relations},
+  Author                   = {Mani, Inderjeet and Verhagen, Marc and Wellner, Ben and Lee, Chong Min and Pustejovsky, James},
+  Booktitle                = {Proceedings of the 21st International Conference on Computational Linguistics and the 44th annual meeting of the Association for Computational Linguistics},
+  Year                     = {2006},
+  Organization             = {Association for Computational Linguistics},
+Pages-omit = {753--760}
+}
+
+@Article{MWVP07,
+  Title                    = {Three approaches to learning {TLINKs} in {TimeML}},
+  Author                   = {Mani, Inderjeet and Wellner, Ben and Verhagen, Marc and Pustejovsky, James},
+  Journal                  = {Technical Report CS-07--268, Computer Science Department},
+  Year                     = {2007}
+}
+
+@InProceedings{MSAAEMRUK15,
+  Title                    = {{SemEval}-2015 {Task} 4: {TimeLine}: Cross-Document Event Ordering},
+  Author                   = {Minard, Anne-Lyse and Speranza, Manuela and Agirre, Eneko and Aldabe, Itziar and van Erp, Marieke and Magnini, Bernardo and Rigau, German and Urizar, Ruben and Kessler, Fondazione Bruno},
+  Booktitle                = {Proceedings of the 9th International Workshop on Semantic Evaluation (SemEval 2015)},
+  Year                     = {2015},
+Pages-omit = {778--786}
+}
+
+@InProceedings{MirzaTo16,
+  Title                    = {{CATENA}: {CA}usal and {TE}mporal relation extraction from {NA}tural language texts},
+  Author                   = {Mirza, Paramita and Tonelli, Sara},
+  Booktitle                = {The 26th International Conference on Computational Linguistics},
+  Year                     = {2016},
+Pages-omit = {64--75}
+}
+
+@InProceedings{MirzaTo14,
+  Title                    = {An Analysis of Causality between Events and its Relation to Temporal Information.},
+  Author                   = {Mirza, Paramita and Tonelli, Sara},
+  Booktitle                = COLING,
+  Year                     = {2014},
+Pages-omit = {2097--2106}
+}
+
+@InProceedings{MCHPBVKA16,
+  Title                    = {A Corpus and Cloze Evaluation for Deeper Understanding of Commonsense Stories},
+  Author                   = {Mostafazadeh, Nasrin and Chambers, Nathanael and He, Xiaodong and Parikh, Devi and Batra, Dhruv and Vanderwende, Lucy and Kohli, Pushmeet and Allen, James},
+  Booktitle                = NAACL,
+  Year                     = {2016},
+Pages-omit = {839--849},
+
+Url-omit = {http://www.aclweb.org/anthology/N16-1098}
+}
+
+@InProceedings{MGCAV16,
+  Title                    = {{CaTeRS}: Causal and temporal relation scheme for semantic annotation of event structures},
+  Author                   = {Mostafazadeh, Nasrin and Grealish, Alyson and Chambers, Nathanael and Allen, James and Vanderwende, Lucy},
+  Booktitle                = {Proceedings of the 4th Workshop on Events: Definition, Detection, Coreference, and Representation},
+  Year                     = {2016},
+Pages-omit = {51--61}
+}
+
+@Article{PCISGSKR03,
+  Title                    = {{TimeML}: Robust specification of event and temporal expressions in text.},
+  Author                   = {Pustejovsky, James and Castano, Jos{\'e} M and Ingria, Robert and Sauri, Roser and Gaizauskas, Robert J and Setzer, Andrea and Katz, Graham and Radev, Dragomir R},
+  Journal                  = {New directions in question answering},
+  Year                     = {2003},
+Pages-omit = {28--34},
+Volume-omit = {3}
+}
+
+@InProceedings{PHSSGSRSDFo03,
+  Title                    = {The {TIMEBANK} corpus},
+  Author                   = {Pustejovsky, James and Hanks, Patrick and Sauri, Roser and See, Andrew and Gaizauskas, Robert and Setzer, Andrea and Radev, Dragomir and Sundheim, Beth and Day, David and Ferro, Lisa and others},
+  Booktitle                = {Corpus linguistics},
+  Year                     = {2003},
+Pages-omit = {40},
+Volume-omit = {2003}
+}
+
+@InProceedings{RiazGi10,
+  Title                    = {Another look at causality: {D}iscovering scenario-specific contingency relationships with no supervision},
+  Author                   = {Riaz, Mehwish and Girju, Roxana},
+  Booktitle                = {Semantic Computing (ICSC), 2010 IEEE Fourth International Conference on},
+  Year                     = {2010},
+Pages-omit = {361--368}
+}
+
+@InProceedings{SSJCH16,
+  Title                    = {Creating Causal Embeddings for Question Answering with Minimal Supervision},
+  Author                   = {Sharp, Rebecca and Surdeanu, Mihai and Jansen, Peter and Clark, Peter and Hammond, Michael},
+  Booktitle                = {Proceedings of the 2016 Conference on Empirical Methods in Natural Language Processing},
+  Year                     = {2016},
+
+Address-omit = {Austin, Texas},
+Month-omit = {November},
+Pages-omit = {138--148},
+Publisher-omit = {Association for Computational Linguistics},
+
+Url-omit = {https://aclweb.org/anthology/D16-1014}
+}
+
+@InProceedings{SBSRMEWKRM15,
+  Title                    = {From Light to Rich ERE: Annotation of Entities, Relations, and Events},
+  Author                   = {Song, Zhiyi and Bies, Ann and Strassel, Stephanie and Riese, Tom and Mott, Justin and Ellis, Joe and Wright, Jonathan and Kulick, Seth and Ryant, Neville and Ma, Xiaoyi},
+  Booktitle                = {Proceedings of the The 3rd Workshop on EVENTS: Definition, Detection, Coreference, and Representation},
+  Year                     = {2015},
+
+Address-omit = {Denver, Colorado},
+Month-omit = {June},
+Pages-omit = {89--98},
+Publisher-omit = {Association for Computational Linguistics},
+
+Url-omit = {http://www.aclweb.org/anthology/W15-0812}
+}
+
+@InProceedings{SpiliopoulouHoMi17,
+  Title                    = {Event Detection Using Frame-Semantic Parser},
+  Author                   = {Spiliopoulou, Evangelia and Hovy, Eduard and Mitamura, Teruko},
+  Booktitle                = {Proceedings of the Events and Stories in the News Workshop},
+  Year                     = {2017},
+
+Address-omit = {Vancouver, Canada},
+Month-omit = {August},
+Pages-omit = {15--20},
+Publisher-omit = {Association for Computational Linguistics},
+
+Url-omit = {http://www.aclweb.org/anthology/W17-2703}
+}
+
+@InProceedings{StroetgenGe10,
+  Title                    = {{HeidelTime}: High Quality Rule-based Extraction and Normalization of Temporal Expressions.},
+  Author                   = {Str{\"o}tgen, Jannik and Gertz, Michael},
+  Booktitle                = {Proceedings of the 5th International Workshop on Semantic Evaluation},
+  Year                     = {2010},
+  Organization             = {Association for Computational Linguistics},
+Pages-omit = {321--324}
+}
+
+@InProceedings{SXLYZC07,
+  Title                    = {Causal relation of queries from temporal logs},
+  Author                   = {Sun, Yizhou and Xie, Kunqing and Liu, Ning and Yan, Shuicheng and Zhang, Benyu and Chen, Zheng},
+  Booktitle                = WWW,
+  Year                     = {2007},
+Pages-omit = {1141--1142}
+}
+
+@InProceedings{Surdeanu13,
+  Title                    = {Overview of the {TAC2013} Knowledge Base Population Evaluation: English Slot Filling and Temporal Slot Filling.},
+  Author                   = {Surdeanu, Mihai},
+  Booktitle                = {TAC},
+  Year                     = {2013}
+}
+
+@InProceedings{UzZamanAl11,
+  Title                    = {Temporal evaluation},
+  Author                   = {UzZaman, Naushad and Allen, James F},
+  Booktitle                = {Proceedings of the 49th Annual Meeting of the Association for Computational Linguistics: Human Language Technologies: short papers-Volume 2},
+  Year                     = {2011},
+  Organization             = {Association for Computational Linguistics},
+Pages-omit = {351--356}
+}
+
+@Article{ULADVP13,
+  Title                    = {{SemEval}-2013 {Task} 1: {TEMPEVAL}-3: Evaluating Time Expressions, Events, and Temporal Relations},
+  Author                   = {UzZaman, Naushad and Llorens, Hector and Allen, James and Derczynski, Leon and Verhagen, Marc and Pustejovsky, James},
+  Journal                  = {Second Joint Conference on Lexical and Computational Semantics},
+  Year                     = {2013},
+Pages-omit = {1--9},
+Volume-omit = {2}
+}
+
+@PhdThesis{Verhagen04,
+  Title                    = {Times Between The Lines},
+  Author                   = {Verhagen, Marc},
+  School                   = {Brandeis University},
+  Year                     = {2004}
+}
+
+@InProceedings{VGSHKP07,
+  Title                    = {{SemEval}-2007 {Task} 15: {TempEval} temporal relation identification},
+  Author                   = {Verhagen, Marc and Gaizauskas, Robert and Schilder, Frank and Hepple, Mark and Katz, Graham and Pustejovsky, James},
+  Booktitle                = {Proceedings of the 4th International Workshop on Semantic Evaluations},
+  Year                     = {2007},
+  Organization             = {Association for Computational Linguistics},
+Pages-omit = {75--80}
+}
+
+@InProceedings{VerhagenPu08,
+  Title                    = {Temporal processing with the {TARSQI} toolkit},
+  Author                   = {Verhagen, Marc and Pustejovsky, James},
+  Booktitle                = {22nd International Conference on on Computational Linguistics: Demonstration Papers},
+  Year                     = {2008},
+  Organization             = {Association for Computational Linguistics},
+Pages-omit = {189--192}
+}
+
+@InProceedings{VSCP10,
+  Title                    = {{SemEval}-2010 {Task} 13: {TempEval}-2},
+  Author                   = {Verhagen, Marc and Sauri, Roser and Caselli, Tommaso and Pustejovsky, James},
+  Booktitle                = {Proceedings of the 5th international workshop on semantic evaluation},
+  Year                     = {2010},
+  Organization             = {Association for Computational Linguistics},
+Pages-omit = {57--62}
+}
+

--- a/cited-long.bib
+++ b/cited-long.bib
@@ -246,7 +246,8 @@ Automatic Acquisition of Spoken Language by an Autonomous Robot}}
 
 @string{Cambridge = {Cambridge University Press}}
 @string{Benjamin = {Benjamin/Cummings Publishing Company, Inc.}}
-@string{MIT = {MIT Press}}@InProceedings{CannyRe,
+@string{MIT = {MIT Press}}
+@InProceedings{CannyRe,
   Title                    = {New Lower Bound Techniques for Robot Motion Planning
 Problems},
   Author                   = {Canny, J. and Reif, J.},
@@ -81879,5 +81880,541 @@ Build a Lexicon},
   Owner                    = {penghaoruo},
   Timestamp                = {2016.10.08},
   Year                     = {2011}
+}
+
+@Book{AhoUl72,
+  Title                    = {The Theory of Parsing, Translation and Compiling},
+  Author                   = {Alfred V. Aho and Jeffrey D. Ullman},
+  Publisher                = {Prentice-Hall},
+  Year                     = {1972},
+
+  Address                  = {Englewood Cliffs, NJ},
+  Volume                   = {1}
+}
+
+@Article{Allen84,
+  Title                    = {Towards a general theory of action and time},
+  Author                   = {Allen, James F},
+  Journal                  = {Artificial intelligence},
+  Year                     = {1984},
+  Number                   = {2},
+  Pages                    = {123--154},
+  Volume                   = {23},
+
+  Publisher                = {Elsevier}
+}
+
+@Article{Allen83,
+  Title                    = {Maintaining knowledge about temporal intervals},
+  Author                   = {Allen, James F},
+  Journal                  = {Communications of the ACM},
+  Year                     = {1983},
+  Number                   = {11},
+  Pages                    = {832--843},
+  Volume                   = {26},
+
+  Publisher                = {ACM}
+}
+
+@Book{APA83,
+  Title                    = {Publications Manual},
+  Author                   = {{American Psychological Association}},
+  Publisher                = {American Psychological Association},
+  Year                     = {1983},
+
+  Address                  = {Washington, DC}
+}
+
+@InProceedings{Bethard13,
+  Title                    = {{ClearTK}-{TimeML}: A minimalist approach to {TempEval} 2013},
+  Author                   = {Bethard, Steven},
+  Booktitle                = {Second Joint Conference on Lexical and Computational Semantics (* SEM)},
+  Year                     = {2013},
+  Pages                    = {10--14},
+  Volume                   = {2}
+}
+
+@InProceedings{BDSPV15,
+  Title                    = {{SemEval}-2015 {Task} 6: {Clinical TempEval}},
+  Author                   = {Bethard, Steven and Derczynski, Leon and Savova, Guergana and Pustejovsky, James and Verhagen, Marc},
+  Booktitle                = {Proceedings of the 9th International Workshop on Semantic Evaluation (SemEval 2015)},
+  Year                     = {2015},
+
+  Address                  = {Denver, Colorado},
+  Month                    = {June},
+  Pages                    = {806--814},
+  Publisher                = {Association for Computational Linguistics},
+
+  Url                      = {http://www.aclweb.org/anthology/S15-2136}
+}
+
+@InProceedings{BethardMa07,
+  Title                    = {{CU-TMP}: Temporal relation classification using syntactic and semantic features},
+  Author                   = {Bethard, Steven and Martin, James H},
+  Booktitle                = {Proceedings of the 4th International Workshop on Semantic Evaluations},
+  Year                     = {2007},
+  Organization             = {Association for Computational Linguistics},
+  Pages                    = {129--132}
+}
+
+@InProceedings{BethardMaKl07,
+  Title                    = {Timelines from text: Identification of syntactic temporal relations},
+  Author                   = {Bethard, Steven and Martin, James H and Klingenstein, Sara},
+  Booktitle                = {Semantic Computing, 2007. ICSC 2007. International Conference on},
+  Year                     = {2007},
+  Organization             = {IEEE},
+  Pages                    = {11--18}
+}
+
+@InProceedings{BSCDPV16,
+  Title                    = {{SemEval}-2016 {Task} 12: {Clinical TempEval}},
+  Author                   = {Bethard, Steven and Savova, Guergana and Chen, Wei-Te and Derczynski, Leon and Pustejovsky, James and Verhagen, Marc},
+  Booktitle                = {Proceedings of the 10th International Workshop on Semantic Evaluation (SemEval-2016)},
+  Year                     = {2016},
+
+  Address                  = {San Diego, California},
+  Month                    = {June},
+  Pages                    = {1052--1062},
+  Publisher                = {Association for Computational Linguistics},
+
+  Url                      = {http://www.aclweb.org/anthology/S16-1165}
+}
+
+@InProceedings{CMCB14,
+  Title                    = {An annotation framework for dense event ordering},
+  Author                   = {Cassidy, Taylor and McDowell, Bill and Chambers, Nathanel and Bethard, Steven},
+  Booktitle                = ACL,
+  Year                     = {2014},
+  Pages                    = {501--506}
+}
+
+@TechReport{Chambers13,
+  Title                    = {{NavyTime}: Event and Time Ordering from Raw Text.},
+  Author                   = {Chambers, Nathanael},
+  Institution              = {DTIC Document},
+  Year                     = {2013}
+}
+
+@Article{CCMB14,
+  Title                    = {Dense event ordering with a multi-pass architecture},
+  Author                   = {Chambers, Nathanael and Cassidy, Taylor and McDowell, Bill and Bethard, Steven},
+  Journal                  = {Transactions of the Association for Computational Linguistics},
+  Year                     = {2014},
+  Pages                    = {273--284},
+  Volume                   = {2}
+}
+
+@InProceedings{ChambersWaJu07,
+  Title                    = {Classifying temporal relations between events},
+  Author                   = {Chambers, Nathanael and Wang, Shan and Jurafsky, Dan},
+  Booktitle                = {Proceedings of the 45th Annual Meeting of the ACL on Interactive Poster and Demonstration Sessions},
+  Year                     = {2007},
+  Organization             = {Association for Computational Linguistics},
+  Pages                    = {173--176}
+}
+
+@Article{ChandraKoSt81,
+  Title                    = {Alternation},
+  Author                   = {Ashok K. Chandra and Dexter C. Kozen and Larry J. Stockmeyer},
+  Journal                  = {Journal of the Association for Computing Machinery},
+  Year                     = {1981},
+  Number                   = {1},
+  Pages                    = {114--133},
+  Volume                   = {28}
+}
+
+@InProceedings{ChangMa12,
+  Title                    = {{SUTIME}: A Library for Recognizing and Normalizing Time Expressions.},
+  Author                   = {Chang, Angel X and Manning, Christopher D},
+  Booktitle                = {LREC},
+  Year                     = {2012},
+  Pages                    = {3735--3740},
+  Volume                   = {2012}
+}
+
+@Article{Computing83,
+  Author                   = {Association for Computing Machinery},
+  Journal                  = {Computing Reviews},
+  Year                     = {1983},
+  Number                   = {11},
+  Pages                    = {503--512},
+  Volume                   = {24}
+}
+
+@InProceedings{DenisMu11,
+  Title                    = {Predicting globally-coherent temporal structures from texts via endpoint inference and graph decomposition},
+  Author                   = {Denis, Pascal and Muller, Philippe},
+  Booktitle                = IJCAI,
+  Year                     = {2011},
+  Number                   = {3},
+  Pages                    = {1788},
+  Volume                   = {22}
+}
+
+@Article{Dietterich98,
+  Title                    = {Approximate statistical tests for comparing supervised classification learning algorithms},
+  Author                   = {Dietterich, Thomas G},
+  Journal                  = {Neural computation},
+  Year                     = {1998},
+  Number                   = {7},
+  Pages                    = {1895--1923},
+  Volume                   = {10},
+
+  Publisher                = {MIT Press}
+}
+
+@Article{DunietzLeCa17,
+  Title                    = {Automatically Tagging Constructions of Causation and Their Slot-Fillers},
+  Author                   = {Dunietz, Jesse and Levin, Lori and Carbonell, Jaime},
+  Journal                  = {Transactions of the Association for Computational Linguistics},
+  Year                     = {2017},
+  Pages                    = {117--133},
+  Volume                   = {5}
+}
+
+@Book{Everitt92,
+  Title                    = {The analysis of contingency tables},
+  Author                   = {Everitt, Brian S},
+  Publisher                = {CRC Press},
+  Year                     = {1992}
+}
+
+@InProceedings{GuelerYeSw16,
+  Title                    = {Learning causal information flow structures in multi-layer networks},
+  Author                   = {G{\"u}ler, Ba{\c{s}}ak and Yener, Aylin and Swami, Ananthram},
+  Booktitle                = {IEEE Global Conference on Signal and Information Processing (GlobalSIP)},
+  Year                     = {2016},
+  Pages                    = {1340--1344}
+}
+
+@InProceedings{GDYC16,
+  Title                    = {Physical Causality of Action Verbs in Grounded Language Understanding.},
+  Author                   = {Gao, Qiaozi and Doering, Malcolm and Yang, Shaohua and Chai, Joyce Yue},
+  Booktitle                = ACL,
+  Year                     = {2016}
+}
+
+@InProceedings{GoodmanVlNa16,
+  Title                    = {Noise reduction and targeted exploration in imitation learning for Abstract Meaning Representation parsing },
+  Author                   = {Goodman, James
+ and Vlachos, Andreas
+ and Naradowsky, Jason},
+  Booktitle                = {Proceedings of the 54th Annual Meeting of the Association for Computational Linguistics (Volume 1: Long Papers) },
+  Year                     = {2016},
+  Pages                    = {1--11},
+  Publisher                = {Association for Computational Linguistics},
+
+  Location                 = {Berlin, Germany}
+}
+
+@Article{Graff02,
+  Title                    = {The {AQUAINT} corpus of English news text},
+  Author                   = {Graff, David},
+  Journal                  = {Linguistic Data Consortium, Philadelphia},
+  Year                     = {2002}
+}
+
+@Book{Gusfield97,
+  Title                    = {Algorithms on Strings, Trees and Sequences},
+  Author                   = {Dan Gusfield},
+  Publisher                = {Cambridge University Press},
+  Year                     = {1997},
+
+  Address                  = {Cambridge, UK}
+}
+
+@InProceedings{Harper14,
+  Title                    = {Learning from 26 Languages: Program Management and Science in the Babel Program},
+  Author                   = {Harper, Mary},
+  Booktitle                = {Proceedings of COLING 2014, the 25th International Conference on Computational Linguistics: Technical Papers},
+  Year                     = {2014},
+  Pages                    = {1},
+  Publisher                = {Dublin City University and Association for Computational Linguistics},
+
+  Location                 = {Dublin, Ireland}
+}
+
+@InProceedings{HideyMc16,
+  Title                    = {Identifying Causal Relations Using Parallel Wikipedia Articles},
+  Author                   = {Hidey, Christopher and McKeown, Kathy},
+  Booktitle                = {Proceedings of the 54th Annual Meeting of the Association for Computational Linguistics (Volume 1: Long Papers)},
+  Year                     = {2016},
+
+  Address                  = {Berlin, Germany},
+  Month                    = {August},
+  Pages                    = {1424--1433},
+  Publisher                = {Association for Computational Linguistics},
+
+  Url                      = {http://www.aclweb.org/anthology/P16-1135}
+}
+
+@Article{JCLT14,
+  Title                    = {Tackling representation, annotation and classification challenges for temporal knowledge base population},
+  Author                   = {Ji, Heng and Cassidy, Taylor and Li, Qi and Tamang, Suzanne},
+  Journal                  = {Knowledge and Information Systems},
+  Year                     = {2014},
+  Number                   = {3},
+  Pages                    = {611--646},
+  Volume                   = {41},
+
+  Publisher                = {Springer}
+}
+
+@InProceedings{JLGSCLS16,
+  Title                    = {Towards Time-Aware Knowledge Graph Completion},
+  Author                   = {Jiang, Tingsong and Liu, Tianyu and Ge, Tao and Sha, Lei and Chang, Baobao and Li, Sujian and Sui, Zhifang},
+  Booktitle                = {Proceedings of COLING 2016, the 26th International Conference on Computational Linguistics: Technical Papers},
+  Year                     = {2016},
+
+  Address                  = {Osaka, Japan},
+  Month                    = {December},
+  Pages                    = {1715--1724},
+  Publisher                = {The COLING 2016 Organizing Committee},
+
+  Url                      = {http://aclweb.org/anthology/C16-1161}
+}
+
+@InProceedings{KneserNe95,
+  Title                    = {Improved backing-off for {M}-gram language modeling},
+  Author                   = {Kneser, Reinhard and Ney, Hermann},
+  Booktitle                = {Acoustics, Speech, and Signal Processing, 1995. ICASSP-95., 1995 International Conference on},
+  Year                     = {1995},
+  Organization             = {IEEE},
+  Pages                    = {181--184},
+  Volume                   = {1}
+}
+
+@InProceedings{LMTC13,
+  Title                    = {{UTTime}: Temporal relation classification using deep syntactic features},
+  Author                   = {Laokulrat, Natsuda and Miwa, Makoto and Tsuruoka, Yoshimasa and Chikayama, Takashi},
+  Booktitle                = {Second Joint Conference on Lexical and Computational Semantics (* SEM)},
+  Year                     = {2013},
+  Pages                    = {88--92},
+  Volume                   = {2}
+}
+
+@InProceedings{LADZ14,
+  Title                    = {Context-dependent Semantic Parsing for Time Expressions.},
+  Author                   = {Lee, Kenton and Artzi, Yoav and Dodge, Jesse and Zettlemoyer, Luke},
+  Booktitle                = {ACL (1)},
+  Year                     = {2014},
+  Pages                    = {1437--1447}
+}
+
+@InProceedings{LeeuwenbergMo17,
+  Title                    = {Structured learning for temporal relation extraction from clinical records},
+  Author                   = {Leeuwenberg, Tuur and Moens, Marie-Francine},
+  Booktitle                = {Proceedings of the 15th Conference of the European Chapter of the Association for Computational Linguistics},
+  Year                     = {2017}
+}
+
+@InProceedings{LCUMAP15,
+  Title                    = {{SemEval}-2015 {Task} 5: {QA} {TEMPEVAL} - Evaluating Temporal Information Understanding with Question Answering},
+  Author                   = {Llorens, Hector and Chambers, Nathanael and UzZaman, Naushad and Mostafazadeh, Nasrin and Allen, James and Pustejovsky, James},
+  Booktitle                = {Proceedings of the 9th International Workshop on Semantic Evaluation (SemEval 2015)},
+  Year                     = {2015},
+  Pages                    = {792--800}
+}
+
+@InProceedings{MVWLP06,
+  Title                    = {Machine learning of temporal relations},
+  Author                   = {Mani, Inderjeet and Verhagen, Marc and Wellner, Ben and Lee, Chong Min and Pustejovsky, James},
+  Booktitle                = {Proceedings of the 21st International Conference on Computational Linguistics and the 44th annual meeting of the Association for Computational Linguistics},
+  Year                     = {2006},
+  Organization             = {Association for Computational Linguistics},
+  Pages                    = {753--760}
+}
+
+@Article{MWVP07,
+  Title                    = {Three approaches to learning {TLINKs} in {TimeML}},
+  Author                   = {Mani, Inderjeet and Wellner, Ben and Verhagen, Marc and Pustejovsky, James},
+  Journal                  = {Technical Report CS-07--268, Computer Science Department},
+  Year                     = {2007}
+}
+
+@InProceedings{MSAAEMRUK15,
+  Title                    = {{SemEval}-2015 {Task} 4: {TimeLine}: Cross-Document Event Ordering},
+  Author                   = {Minard, Anne-Lyse and Speranza, Manuela and Agirre, Eneko and Aldabe, Itziar and van Erp, Marieke and Magnini, Bernardo and Rigau, German and Urizar, Ruben and Kessler, Fondazione Bruno},
+  Booktitle                = {Proceedings of the 9th International Workshop on Semantic Evaluation (SemEval 2015)},
+  Year                     = {2015},
+  Pages                    = {778--786}
+}
+
+@InProceedings{MirzaTo16,
+  Title                    = {{CATENA}: {CA}usal and {TE}mporal relation extraction from {NA}tural language texts},
+  Author                   = {Mirza, Paramita and Tonelli, Sara},
+  Booktitle                = {The 26th International Conference on Computational Linguistics},
+  Year                     = {2016},
+  Pages                    = {64--75}
+}
+
+@InProceedings{MirzaTo14,
+  Title                    = {An Analysis of Causality between Events and its Relation to Temporal Information.},
+  Author                   = {Mirza, Paramita and Tonelli, Sara},
+  Booktitle                = COLING,
+  Year                     = {2014},
+  Pages                    = {2097--2106}
+}
+
+@InProceedings{MCHPBVKA16,
+  Title                    = {A Corpus and Cloze Evaluation for Deeper Understanding of Commonsense Stories},
+  Author                   = {Mostafazadeh, Nasrin and Chambers, Nathanael and He, Xiaodong and Parikh, Devi and Batra, Dhruv and Vanderwende, Lucy and Kohli, Pushmeet and Allen, James},
+  Booktitle                = NAACL,
+  Year                     = {2016},
+  Pages                    = {839--849},
+
+  Url                      = {http://www.aclweb.org/anthology/N16-1098}
+}
+
+@InProceedings{MGCAV16,
+  Title                    = {{CaTeRS}: Causal and temporal relation scheme for semantic annotation of event structures},
+  Author                   = {Mostafazadeh, Nasrin and Grealish, Alyson and Chambers, Nathanael and Allen, James and Vanderwende, Lucy},
+  Booktitle                = {Proceedings of the 4th Workshop on Events: Definition, Detection, Coreference, and Representation},
+  Year                     = {2016},
+  Pages                    = {51--61}
+}
+
+@Article{PCISGSKR03,
+  Title                    = {{TimeML}: Robust specification of event and temporal expressions in text.},
+  Author                   = {Pustejovsky, James and Castano, Jos{\'e} M and Ingria, Robert and Sauri, Roser and Gaizauskas, Robert J and Setzer, Andrea and Katz, Graham and Radev, Dragomir R},
+  Journal                  = {New directions in question answering},
+  Year                     = {2003},
+  Pages                    = {28--34},
+  Volume                   = {3}
+}
+
+@InProceedings{PHSSGSRSDFo03,
+  Title                    = {The {TIMEBANK} corpus},
+  Author                   = {Pustejovsky, James and Hanks, Patrick and Sauri, Roser and See, Andrew and Gaizauskas, Robert and Setzer, Andrea and Radev, Dragomir and Sundheim, Beth and Day, David and Ferro, Lisa and others},
+  Booktitle                = {Corpus linguistics},
+  Year                     = {2003},
+  Pages                    = {40},
+  Volume                   = {2003}
+}
+
+@InProceedings{RiazGi10,
+  Title                    = {Another look at causality: {D}iscovering scenario-specific contingency relationships with no supervision},
+  Author                   = {Riaz, Mehwish and Girju, Roxana},
+  Booktitle                = {Semantic Computing (ICSC), 2010 IEEE Fourth International Conference on},
+  Year                     = {2010},
+  Pages                    = {361--368}
+}
+
+@InProceedings{SSJCH16,
+  Title                    = {Creating Causal Embeddings for Question Answering with Minimal Supervision},
+  Author                   = {Sharp, Rebecca and Surdeanu, Mihai and Jansen, Peter and Clark, Peter and Hammond, Michael},
+  Booktitle                = {Proceedings of the 2016 Conference on Empirical Methods in Natural Language Processing},
+  Year                     = {2016},
+
+  Address                  = {Austin, Texas},
+  Month                    = {November},
+  Pages                    = {138--148},
+  Publisher                = {Association for Computational Linguistics},
+
+  Url                      = {https://aclweb.org/anthology/D16-1014}
+}
+
+@InProceedings{SBSRMEWKRM15,
+  Title                    = {From Light to Rich ERE: Annotation of Entities, Relations, and Events},
+  Author                   = {Song, Zhiyi and Bies, Ann and Strassel, Stephanie and Riese, Tom and Mott, Justin and Ellis, Joe and Wright, Jonathan and Kulick, Seth and Ryant, Neville and Ma, Xiaoyi},
+  Booktitle                = {Proceedings of the The 3rd Workshop on EVENTS: Definition, Detection, Coreference, and Representation},
+  Year                     = {2015},
+
+  Address                  = {Denver, Colorado},
+  Month                    = {June},
+  Pages                    = {89--98},
+  Publisher                = {Association for Computational Linguistics},
+
+  Url                      = {http://www.aclweb.org/anthology/W15-0812}
+}
+
+@InProceedings{SpiliopoulouHoMi17,
+  Title                    = {Event Detection Using Frame-Semantic Parser},
+  Author                   = {Spiliopoulou, Evangelia and Hovy, Eduard and Mitamura, Teruko},
+  Booktitle                = {Proceedings of the Events and Stories in the News Workshop},
+  Year                     = {2017},
+
+  Address                  = {Vancouver, Canada},
+  Month                    = {August},
+  Pages                    = {15--20},
+  Publisher                = {Association for Computational Linguistics},
+
+  Url                      = {http://www.aclweb.org/anthology/W17-2703}
+}
+
+@InProceedings{StroetgenGe10,
+  Title                    = {{HeidelTime}: High Quality Rule-based Extraction and Normalization of Temporal Expressions.},
+  Author                   = {Str{\"o}tgen, Jannik and Gertz, Michael},
+  Booktitle                = {Proceedings of the 5th International Workshop on Semantic Evaluation},
+  Year                     = {2010},
+  Organization             = {Association for Computational Linguistics},
+  Pages                    = {321--324}
+}
+
+@InProceedings{SXLYZC07,
+  Title                    = {Causal relation of queries from temporal logs},
+  Author                   = {Sun, Yizhou and Xie, Kunqing and Liu, Ning and Yan, Shuicheng and Zhang, Benyu and Chen, Zheng},
+  Booktitle                = WWW,
+  Year                     = {2007},
+  Pages                    = {1141--1142}
+}
+
+@InProceedings{Surdeanu13,
+  Title                    = {Overview of the {TAC2013} Knowledge Base Population Evaluation: English Slot Filling and Temporal Slot Filling.},
+  Author                   = {Surdeanu, Mihai},
+  Booktitle                = {TAC},
+  Year                     = {2013}
+}
+
+@InProceedings{UzZamanAl11,
+  Title                    = {Temporal evaluation},
+  Author                   = {UzZaman, Naushad and Allen, James F},
+  Booktitle                = {Proceedings of the 49th Annual Meeting of the Association for Computational Linguistics: Human Language Technologies: short papers-Volume 2},
+  Year                     = {2011},
+  Organization             = {Association for Computational Linguistics},
+  Pages                    = {351--356}
+}
+
+@Article{ULADVP13,
+  Title                    = {{SemEval}-2013 {Task} 1: {TEMPEVAL}-3: Evaluating Time Expressions, Events, and Temporal Relations},
+  Author                   = {UzZaman, Naushad and Llorens, Hector and Allen, James and Derczynski, Leon and Verhagen, Marc and Pustejovsky, James},
+  Journal                  = {Second Joint Conference on Lexical and Computational Semantics},
+  Year                     = {2013},
+  Pages                    = {1--9},
+  Volume                   = {2}
+}
+
+@PhdThesis{Verhagen04,
+  Title                    = {Times Between The Lines},
+  Author                   = {Verhagen, Marc},
+  School                   = {Brandeis University},
+  Year                     = {2004}
+}
+
+@InProceedings{VGSHKP07,
+  Title                    = {{SemEval}-2007 {Task} 15: {TempEval} temporal relation identification},
+  Author                   = {Verhagen, Marc and Gaizauskas, Robert and Schilder, Frank and Hepple, Mark and Katz, Graham and Pustejovsky, James},
+  Booktitle                = {Proceedings of the 4th International Workshop on Semantic Evaluations},
+  Year                     = {2007},
+  Organization             = {Association for Computational Linguistics},
+  Pages                    = {75--80}
+}
+
+@InProceedings{VerhagenPu08,
+  Title                    = {Temporal processing with the {TARSQI} toolkit},
+  Author                   = {Verhagen, Marc and Pustejovsky, James},
+  Booktitle                = {22nd International Conference on on Computational Linguistics: Demonstration Papers},
+  Year                     = {2008},
+  Organization             = {Association for Computational Linguistics},
+  Pages                    = {189--192}
+}
+
+@InProceedings{VSCP10,
+  Title                    = {{SemEval}-2010 {Task} 13: {TempEval}-2},
+  Author                   = {Verhagen, Marc and Sauri, Roser and Caselli, Tommaso and Pustejovsky, James},
+  Booktitle                = {Proceedings of the 5th international workshop on semantic evaluation},
+  Year                     = {2010},
+  Organization             = {Association for Computational Linguistics},
+  Pages                    = {57--62}
 }
 

--- a/cited.bib
+++ b/cited.bib
@@ -81633,3 +81633,539 @@ Build a Lexicon},
   Year                     = {2011}
 }
 
+@Book{AhoUl72,
+  Title                    = {The Theory of Parsing, Translation and Compiling},
+  Author                   = {Alfred V. Aho and Jeffrey D. Ullman},
+  Publisher                = {Prentice-Hall},
+  Year                     = {1972},
+
+  Address                  = {Englewood Cliffs, NJ},
+  Volume                   = {1}
+}
+
+@Article{Allen84,
+  Title                    = {Towards a general theory of action and time},
+  Author                   = {Allen, James F},
+  Journal                  = {Artificial intelligence},
+  Year                     = {1984},
+  Number                   = {2},
+  Pages                    = {123--154},
+  Volume                   = {23},
+
+  Publisher                = {Elsevier}
+}
+
+@Article{Allen83,
+  Title                    = {Maintaining knowledge about temporal intervals},
+  Author                   = {Allen, James F},
+  Journal                  = {Communications of the ACM},
+  Year                     = {1983},
+  Number                   = {11},
+  Pages                    = {832--843},
+  Volume                   = {26},
+
+  Publisher                = {ACM}
+}
+
+@Book{APA83,
+  Title                    = {Publications Manual},
+  Author                   = {{American Psychological Association}},
+  Publisher                = {American Psychological Association},
+  Year                     = {1983},
+
+  Address                  = {Washington, DC}
+}
+
+@InProceedings{Bethard13,
+  Title                    = {{ClearTK}-{TimeML}: A minimalist approach to {TempEval} 2013},
+  Author                   = {Bethard, Steven},
+  Booktitle                = {Second Joint Conference on Lexical and Computational Semantics (* SEM)},
+  Year                     = {2013},
+  Pages                    = {10--14},
+  Volume                   = {2}
+}
+
+@InProceedings{BDSPV15,
+  Title                    = {{SemEval}-2015 {Task} 6: {Clinical TempEval}},
+  Author                   = {Bethard, Steven and Derczynski, Leon and Savova, Guergana and Pustejovsky, James and Verhagen, Marc},
+  Booktitle                = {Proceedings of the 9th International Workshop on Semantic Evaluation (SemEval 2015)},
+  Year                     = {2015},
+
+  Address                  = {Denver, Colorado},
+  Month                    = {June},
+  Pages                    = {806--814},
+  Publisher                = {Association for Computational Linguistics},
+
+  Url                      = {http://www.aclweb.org/anthology/S15-2136}
+}
+
+@InProceedings{BethardMa07,
+  Title                    = {{CU-TMP}: Temporal relation classification using syntactic and semantic features},
+  Author                   = {Bethard, Steven and Martin, James H},
+  Booktitle                = {Proceedings of the 4th International Workshop on Semantic Evaluations},
+  Year                     = {2007},
+  Organization             = {Association for Computational Linguistics},
+  Pages                    = {129--132}
+}
+
+@InProceedings{BethardMaKl07,
+  Title                    = {Timelines from text: Identification of syntactic temporal relations},
+  Author                   = {Bethard, Steven and Martin, James H and Klingenstein, Sara},
+  Booktitle                = {Semantic Computing, 2007. ICSC 2007. International Conference on},
+  Year                     = {2007},
+  Organization             = {IEEE},
+  Pages                    = {11--18}
+}
+
+@InProceedings{BSCDPV16,
+  Title                    = {{SemEval}-2016 {Task} 12: {Clinical TempEval}},
+  Author                   = {Bethard, Steven and Savova, Guergana and Chen, Wei-Te and Derczynski, Leon and Pustejovsky, James and Verhagen, Marc},
+  Booktitle                = {Proceedings of the 10th International Workshop on Semantic Evaluation (SemEval-2016)},
+  Year                     = {2016},
+
+  Address                  = {San Diego, California},
+  Month                    = {June},
+  Pages                    = {1052--1062},
+  Publisher                = {Association for Computational Linguistics},
+
+  Url                      = {http://www.aclweb.org/anthology/S16-1165}
+}
+
+@InProceedings{CMCB14,
+  Title                    = {An annotation framework for dense event ordering},
+  Author                   = {Cassidy, Taylor and McDowell, Bill and Chambers, Nathanel and Bethard, Steven},
+  Booktitle                = ACL,
+  Year                     = {2014},
+  Pages                    = {501--506}
+}
+
+@TechReport{Chambers13,
+  Title                    = {{NavyTime}: Event and Time Ordering from Raw Text.},
+  Author                   = {Chambers, Nathanael},
+  Institution              = {DTIC Document},
+  Year                     = {2013}
+}
+
+@Article{CCMB14,
+  Title                    = {Dense event ordering with a multi-pass architecture},
+  Author                   = {Chambers, Nathanael and Cassidy, Taylor and McDowell, Bill and Bethard, Steven},
+  Journal                  = {Transactions of the Association for Computational Linguistics},
+  Year                     = {2014},
+  Pages                    = {273--284},
+  Volume                   = {2}
+}
+
+@InProceedings{ChambersWaJu07,
+  Title                    = {Classifying temporal relations between events},
+  Author                   = {Chambers, Nathanael and Wang, Shan and Jurafsky, Dan},
+  Booktitle                = {Proceedings of the 45th Annual Meeting of the ACL on Interactive Poster and Demonstration Sessions},
+  Year                     = {2007},
+  Organization             = {Association for Computational Linguistics},
+  Pages                    = {173--176}
+}
+
+@Article{ChandraKoSt81,
+  Title                    = {Alternation},
+  Author                   = {Ashok K. Chandra and Dexter C. Kozen and Larry J. Stockmeyer},
+  Journal                  = {Journal of the Association for Computing Machinery},
+  Year                     = {1981},
+  Number                   = {1},
+  Pages                    = {114--133},
+  Volume                   = {28}
+}
+
+@InProceedings{ChangMa12,
+  Title                    = {{SUTIME}: A Library for Recognizing and Normalizing Time Expressions.},
+  Author                   = {Chang, Angel X and Manning, Christopher D},
+  Booktitle                = {LREC},
+  Year                     = {2012},
+  Pages                    = {3735--3740},
+  Volume                   = {2012}
+}
+
+@Article{Computing83,
+  Author                   = {Association for Computing Machinery},
+  Journal                  = {Computing Reviews},
+  Year                     = {1983},
+  Number                   = {11},
+  Pages                    = {503--512},
+  Volume                   = {24}
+}
+
+@InProceedings{DenisMu11,
+  Title                    = {Predicting globally-coherent temporal structures from texts via endpoint inference and graph decomposition},
+  Author                   = {Denis, Pascal and Muller, Philippe},
+  Booktitle                = IJCAI,
+  Year                     = {2011},
+  Number                   = {3},
+  Pages                    = {1788},
+  Volume                   = {22}
+}
+
+@Article{Dietterich98,
+  Title                    = {Approximate statistical tests for comparing supervised classification learning algorithms},
+  Author                   = {Dietterich, Thomas G},
+  Journal                  = {Neural computation},
+  Year                     = {1998},
+  Number                   = {7},
+  Pages                    = {1895--1923},
+  Volume                   = {10},
+
+  Publisher                = {MIT Press}
+}
+
+@Article{DunietzLeCa17,
+  Title                    = {Automatically Tagging Constructions of Causation and Their Slot-Fillers},
+  Author                   = {Dunietz, Jesse and Levin, Lori and Carbonell, Jaime},
+  Journal                  = {Transactions of the Association for Computational Linguistics},
+  Year                     = {2017},
+  Pages                    = {117--133},
+  Volume                   = {5}
+}
+
+@Book{Everitt92,
+  Title                    = {The analysis of contingency tables},
+  Author                   = {Everitt, Brian S},
+  Publisher                = {CRC Press},
+  Year                     = {1992}
+}
+
+@InProceedings{GuelerYeSw16,
+  Title                    = {Learning causal information flow structures in multi-layer networks},
+  Author                   = {G{\"u}ler, Ba{\c{s}}ak and Yener, Aylin and Swami, Ananthram},
+  Booktitle                = {IEEE Global Conference on Signal and Information Processing (GlobalSIP)},
+  Year                     = {2016},
+  Pages                    = {1340--1344}
+}
+
+@InProceedings{GDYC16,
+  Title                    = {Physical Causality of Action Verbs in Grounded Language Understanding.},
+  Author                   = {Gao, Qiaozi and Doering, Malcolm and Yang, Shaohua and Chai, Joyce Yue},
+  Booktitle                = ACL,
+  Year                     = {2016}
+}
+
+@InProceedings{GoodmanVlNa16,
+  Title                    = {Noise reduction and targeted exploration in imitation learning for Abstract Meaning Representation parsing },
+  Author                   = {Goodman, James
+ and Vlachos, Andreas
+ and Naradowsky, Jason},
+  Booktitle                = {Proceedings of the 54th Annual Meeting of the Association for Computational Linguistics (Volume 1: Long Papers) },
+  Year                     = {2016},
+  Pages                    = {1--11},
+  Publisher                = {Association for Computational Linguistics},
+
+  Location                 = {Berlin, Germany}
+}
+
+@Article{Graff02,
+  Title                    = {The {AQUAINT} corpus of English news text},
+  Author                   = {Graff, David},
+  Journal                  = {Linguistic Data Consortium, Philadelphia},
+  Year                     = {2002}
+}
+
+@Book{Gusfield97,
+  Title                    = {Algorithms on Strings, Trees and Sequences},
+  Author                   = {Dan Gusfield},
+  Publisher                = {Cambridge University Press},
+  Year                     = {1997},
+
+  Address                  = {Cambridge, UK}
+}
+
+@InProceedings{Harper14,
+  Title                    = {Learning from 26 Languages: Program Management and Science in the Babel Program},
+  Author                   = {Harper, Mary},
+  Booktitle                = {Proceedings of COLING 2014, the 25th International Conference on Computational Linguistics: Technical Papers},
+  Year                     = {2014},
+  Pages                    = {1},
+  Publisher                = {Dublin City University and Association for Computational Linguistics},
+
+  Location                 = {Dublin, Ireland}
+}
+
+@InProceedings{HideyMc16,
+  Title                    = {Identifying Causal Relations Using Parallel Wikipedia Articles},
+  Author                   = {Hidey, Christopher and McKeown, Kathy},
+  Booktitle                = {Proceedings of the 54th Annual Meeting of the Association for Computational Linguistics (Volume 1: Long Papers)},
+  Year                     = {2016},
+
+  Address                  = {Berlin, Germany},
+  Month                    = {August},
+  Pages                    = {1424--1433},
+  Publisher                = {Association for Computational Linguistics},
+
+  Url                      = {http://www.aclweb.org/anthology/P16-1135}
+}
+
+@Article{JCLT14,
+  Title                    = {Tackling representation, annotation and classification challenges for temporal knowledge base population},
+  Author                   = {Ji, Heng and Cassidy, Taylor and Li, Qi and Tamang, Suzanne},
+  Journal                  = {Knowledge and Information Systems},
+  Year                     = {2014},
+  Number                   = {3},
+  Pages                    = {611--646},
+  Volume                   = {41},
+
+  Publisher                = {Springer}
+}
+
+@InProceedings{JLGSCLS16,
+  Title                    = {Towards Time-Aware Knowledge Graph Completion},
+  Author                   = {Jiang, Tingsong and Liu, Tianyu and Ge, Tao and Sha, Lei and Chang, Baobao and Li, Sujian and Sui, Zhifang},
+  Booktitle                = {Proceedings of COLING 2016, the 26th International Conference on Computational Linguistics: Technical Papers},
+  Year                     = {2016},
+
+  Address                  = {Osaka, Japan},
+  Month                    = {December},
+  Pages                    = {1715--1724},
+  Publisher                = {The COLING 2016 Organizing Committee},
+
+  Url                      = {http://aclweb.org/anthology/C16-1161}
+}
+
+@InProceedings{KneserNe95,
+  Title                    = {Improved backing-off for {M}-gram language modeling},
+  Author                   = {Kneser, Reinhard and Ney, Hermann},
+  Booktitle                = {Acoustics, Speech, and Signal Processing, 1995. ICASSP-95., 1995 International Conference on},
+  Year                     = {1995},
+  Organization             = {IEEE},
+  Pages                    = {181--184},
+  Volume                   = {1}
+}
+
+@InProceedings{LMTC13,
+  Title                    = {{UTTime}: Temporal relation classification using deep syntactic features},
+  Author                   = {Laokulrat, Natsuda and Miwa, Makoto and Tsuruoka, Yoshimasa and Chikayama, Takashi},
+  Booktitle                = {Second Joint Conference on Lexical and Computational Semantics (* SEM)},
+  Year                     = {2013},
+  Pages                    = {88--92},
+  Volume                   = {2}
+}
+
+@InProceedings{LADZ14,
+  Title                    = {Context-dependent Semantic Parsing for Time Expressions.},
+  Author                   = {Lee, Kenton and Artzi, Yoav and Dodge, Jesse and Zettlemoyer, Luke},
+  Booktitle                = {ACL (1)},
+  Year                     = {2014},
+  Pages                    = {1437--1447}
+}
+
+@InProceedings{LeeuwenbergMo17,
+  Title                    = {Structured learning for temporal relation extraction from clinical records},
+  Author                   = {Leeuwenberg, Tuur and Moens, Marie-Francine},
+  Booktitle                = {Proceedings of the 15th Conference of the European Chapter of the Association for Computational Linguistics},
+  Year                     = {2017}
+}
+
+@InProceedings{LCUMAP15,
+  Title                    = {{SemEval}-2015 {Task} 5: {QA} {TEMPEVAL} - Evaluating Temporal Information Understanding with Question Answering},
+  Author                   = {Llorens, Hector and Chambers, Nathanael and UzZaman, Naushad and Mostafazadeh, Nasrin and Allen, James and Pustejovsky, James},
+  Booktitle                = {Proceedings of the 9th International Workshop on Semantic Evaluation (SemEval 2015)},
+  Year                     = {2015},
+  Pages                    = {792--800}
+}
+
+@InProceedings{MVWLP06,
+  Title                    = {Machine learning of temporal relations},
+  Author                   = {Mani, Inderjeet and Verhagen, Marc and Wellner, Ben and Lee, Chong Min and Pustejovsky, James},
+  Booktitle                = {Proceedings of the 21st International Conference on Computational Linguistics and the 44th annual meeting of the Association for Computational Linguistics},
+  Year                     = {2006},
+  Organization             = {Association for Computational Linguistics},
+  Pages                    = {753--760}
+}
+
+@Article{MWVP07,
+  Title                    = {Three approaches to learning {TLINKs} in {TimeML}},
+  Author                   = {Mani, Inderjeet and Wellner, Ben and Verhagen, Marc and Pustejovsky, James},
+  Journal                  = {Technical Report CS-07--268, Computer Science Department},
+  Year                     = {2007}
+}
+
+@InProceedings{MSAAEMRUK15,
+  Title                    = {{SemEval}-2015 {Task} 4: {TimeLine}: Cross-Document Event Ordering},
+  Author                   = {Minard, Anne-Lyse and Speranza, Manuela and Agirre, Eneko and Aldabe, Itziar and van Erp, Marieke and Magnini, Bernardo and Rigau, German and Urizar, Ruben and Kessler, Fondazione Bruno},
+  Booktitle                = {Proceedings of the 9th International Workshop on Semantic Evaluation (SemEval 2015)},
+  Year                     = {2015},
+  Pages                    = {778--786}
+}
+
+@InProceedings{MirzaTo16,
+  Title                    = {{CATENA}: {CA}usal and {TE}mporal relation extraction from {NA}tural language texts},
+  Author                   = {Mirza, Paramita and Tonelli, Sara},
+  Booktitle                = {The 26th International Conference on Computational Linguistics},
+  Year                     = {2016},
+  Pages                    = {64--75}
+}
+
+@InProceedings{MirzaTo14,
+  Title                    = {An Analysis of Causality between Events and its Relation to Temporal Information.},
+  Author                   = {Mirza, Paramita and Tonelli, Sara},
+  Booktitle                = COLING,
+  Year                     = {2014},
+  Pages                    = {2097--2106}
+}
+
+@InProceedings{MCHPBVKA16,
+  Title                    = {A Corpus and Cloze Evaluation for Deeper Understanding of Commonsense Stories},
+  Author                   = {Mostafazadeh, Nasrin and Chambers, Nathanael and He, Xiaodong and Parikh, Devi and Batra, Dhruv and Vanderwende, Lucy and Kohli, Pushmeet and Allen, James},
+  Booktitle                = NAACL,
+  Year                     = {2016},
+  Pages                    = {839--849},
+
+  Url                      = {http://www.aclweb.org/anthology/N16-1098}
+}
+
+@InProceedings{MGCAV16,
+  Title                    = {{CaTeRS}: Causal and temporal relation scheme for semantic annotation of event structures},
+  Author                   = {Mostafazadeh, Nasrin and Grealish, Alyson and Chambers, Nathanael and Allen, James and Vanderwende, Lucy},
+  Booktitle                = {Proceedings of the 4th Workshop on Events: Definition, Detection, Coreference, and Representation},
+  Year                     = {2016},
+  Pages                    = {51--61}
+}
+
+@Article{PCISGSKR03,
+  Title                    = {{TimeML}: Robust specification of event and temporal expressions in text.},
+  Author                   = {Pustejovsky, James and Castano, Jos{\'e} M and Ingria, Robert and Sauri, Roser and Gaizauskas, Robert J and Setzer, Andrea and Katz, Graham and Radev, Dragomir R},
+  Journal                  = {New directions in question answering},
+  Year                     = {2003},
+  Pages                    = {28--34},
+  Volume                   = {3}
+}
+
+@InProceedings{PHSSGSRSDFo03,
+  Title                    = {The {TIMEBANK} corpus},
+  Author                   = {Pustejovsky, James and Hanks, Patrick and Sauri, Roser and See, Andrew and Gaizauskas, Robert and Setzer, Andrea and Radev, Dragomir and Sundheim, Beth and Day, David and Ferro, Lisa and others},
+  Booktitle                = {Corpus linguistics},
+  Year                     = {2003},
+  Pages                    = {40},
+  Volume                   = {2003}
+}
+
+@InProceedings{RiazGi10,
+  Title                    = {Another look at causality: {D}iscovering scenario-specific contingency relationships with no supervision},
+  Author                   = {Riaz, Mehwish and Girju, Roxana},
+  Booktitle                = {Semantic Computing (ICSC), 2010 IEEE Fourth International Conference on},
+  Year                     = {2010},
+  Pages                    = {361--368}
+}
+
+@InProceedings{SSJCH16,
+  Title                    = {Creating Causal Embeddings for Question Answering with Minimal Supervision},
+  Author                   = {Sharp, Rebecca and Surdeanu, Mihai and Jansen, Peter and Clark, Peter and Hammond, Michael},
+  Booktitle                = {Proceedings of the 2016 Conference on Empirical Methods in Natural Language Processing},
+  Year                     = {2016},
+
+  Address                  = {Austin, Texas},
+  Month                    = {November},
+  Pages                    = {138--148},
+  Publisher                = {Association for Computational Linguistics},
+
+  Url                      = {https://aclweb.org/anthology/D16-1014}
+}
+
+@InProceedings{SBSRMEWKRM15,
+  Title                    = {From Light to Rich ERE: Annotation of Entities, Relations, and Events},
+  Author                   = {Song, Zhiyi and Bies, Ann and Strassel, Stephanie and Riese, Tom and Mott, Justin and Ellis, Joe and Wright, Jonathan and Kulick, Seth and Ryant, Neville and Ma, Xiaoyi},
+  Booktitle                = {Proceedings of the The 3rd Workshop on EVENTS: Definition, Detection, Coreference, and Representation},
+  Year                     = {2015},
+
+  Address                  = {Denver, Colorado},
+  Month                    = {June},
+  Pages                    = {89--98},
+  Publisher                = {Association for Computational Linguistics},
+
+  Url                      = {http://www.aclweb.org/anthology/W15-0812}
+}
+
+@InProceedings{SpiliopoulouHoMi17,
+  Title                    = {Event Detection Using Frame-Semantic Parser},
+  Author                   = {Spiliopoulou, Evangelia and Hovy, Eduard and Mitamura, Teruko},
+  Booktitle                = {Proceedings of the Events and Stories in the News Workshop},
+  Year                     = {2017},
+
+  Address                  = {Vancouver, Canada},
+  Month                    = {August},
+  Pages                    = {15--20},
+  Publisher                = {Association for Computational Linguistics},
+
+  Url                      = {http://www.aclweb.org/anthology/W17-2703}
+}
+
+@InProceedings{StroetgenGe10,
+  Title                    = {{HeidelTime}: High Quality Rule-based Extraction and Normalization of Temporal Expressions.},
+  Author                   = {Str{\"o}tgen, Jannik and Gertz, Michael},
+  Booktitle                = {Proceedings of the 5th International Workshop on Semantic Evaluation},
+  Year                     = {2010},
+  Organization             = {Association for Computational Linguistics},
+  Pages                    = {321--324}
+}
+
+@InProceedings{SXLYZC07,
+  Title                    = {Causal relation of queries from temporal logs},
+  Author                   = {Sun, Yizhou and Xie, Kunqing and Liu, Ning and Yan, Shuicheng and Zhang, Benyu and Chen, Zheng},
+  Booktitle                = WWW,
+  Year                     = {2007},
+  Pages                    = {1141--1142}
+}
+
+@InProceedings{Surdeanu13,
+  Title                    = {Overview of the {TAC2013} Knowledge Base Population Evaluation: English Slot Filling and Temporal Slot Filling.},
+  Author                   = {Surdeanu, Mihai},
+  Booktitle                = {TAC},
+  Year                     = {2013}
+}
+
+@InProceedings{UzZamanAl11,
+  Title                    = {Temporal evaluation},
+  Author                   = {UzZaman, Naushad and Allen, James F},
+  Booktitle                = {Proceedings of the 49th Annual Meeting of the Association for Computational Linguistics: Human Language Technologies: short papers-Volume 2},
+  Year                     = {2011},
+  Organization             = {Association for Computational Linguistics},
+  Pages                    = {351--356}
+}
+
+@Article{ULADVP13,
+  Title                    = {{SemEval}-2013 {Task} 1: {TEMPEVAL}-3: Evaluating Time Expressions, Events, and Temporal Relations},
+  Author                   = {UzZaman, Naushad and Llorens, Hector and Allen, James and Derczynski, Leon and Verhagen, Marc and Pustejovsky, James},
+  Journal                  = {Second Joint Conference on Lexical and Computational Semantics},
+  Year                     = {2013},
+  Pages                    = {1--9},
+  Volume                   = {2}
+}
+
+@PhdThesis{Verhagen04,
+  Title                    = {Times Between The Lines},
+  Author                   = {Verhagen, Marc},
+  School                   = {Brandeis University},
+  Year                     = {2004}
+}
+
+@InProceedings{VGSHKP07,
+  Title                    = {{SemEval}-2007 {Task} 15: {TempEval} temporal relation identification},
+  Author                   = {Verhagen, Marc and Gaizauskas, Robert and Schilder, Frank and Hepple, Mark and Katz, Graham and Pustejovsky, James},
+  Booktitle                = {Proceedings of the 4th International Workshop on Semantic Evaluations},
+  Year                     = {2007},
+  Organization             = {Association for Computational Linguistics},
+  Pages                    = {75--80}
+}
+
+@InProceedings{VerhagenPu08,
+  Title                    = {Temporal processing with the {TARSQI} toolkit},
+  Author                   = {Verhagen, Marc and Pustejovsky, James},
+  Booktitle                = {22nd International Conference on on Computational Linguistics: Demonstration Papers},
+  Year                     = {2008},
+  Organization             = {Association for Computational Linguistics},
+  Pages                    = {189--192}
+}
+
+@InProceedings{VSCP10,
+  Title                    = {{SemEval}-2010 {Task} 13: {TempEval}-2},
+  Author                   = {Verhagen, Marc and Sauri, Roser and Caselli, Tommaso and Pustejovsky, James},
+  Booktitle                = {Proceedings of the 5th international workshop on semantic evaluation},
+  Year                     = {2010},
+  Organization             = {Association for Computational Linguistics},
+  Pages                    = {57--62}
+}
+

--- a/compact_head.bib
+++ b/compact_head.bib
@@ -1,0 +1,91 @@
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%        JOURNALS           %%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+@string{AI = {Artificial Intelligence}}
+@string{CACM = {Communications of the ACM}}
+@string{CSL = {Computer Speech and Language}}
+@string{CL = {Computational Linguistics}}
+@string{InfCtrl = {Information and Control}}
+@string{IT = {IEEE Transactions on information theory}}
+@string{JACM = {Journal of the ACM}}
+@string{JAIR = {Journal of AI Research}}
+@string{JMLR = {Journal of Machine Learning Research}}
+@string{ML = {Machine Learning}}
+@string{NLE = {Journal of Natural Language Engineering}}
+@string{MM = {IEEE Transactions on Multimedia}}
+@string{PAMI = {IEEE Transactions on Pattern Analysis and Machine Intelligence}}
+@string{SIJAD = {SIAM Journal of Algebraic and Discrete Methods}}
+@string{SIJC = {SIAM Journal of Computing}}
+@string{TASSP = {IEEE Transactions on Acoustics, speech, and Signal Processing}}
+@string{TASSP = {IEEE Transactions on Acoustics, speech, and Signal Processing}}
+@string{TCS = {Theoretical Computer Science}}
+@string{DCG = {Discrete and Computational Geometry}}
+@string{CGTA = {Computational Geometry: Theory and Applications}}
+@string{JALG = {Journal of Algorithms}}
+@string{IJCGA = {The International Journal of Computational Geometry and Applications }}
+@string{MLJ = {Machine Learning Journal}}
+@string{jnle = {Journal for Natural Language Engineering"}}
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%       CONFERENCES         %%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+
+@STRING{WWW = {WWW}}
+@string{AAAI= {AAAI}}
+@string{ANLP = {ANLP}}
+@string{ARPA = {ARPA}}
+@string{ACCV = {ACCV}}
+@string{AISTAT = {AISTAT}}
+@string{ALT = {ALT}}
+@string{COLING = {COLING}}
+@string{ACL = {ACL}}
+@string{EACL = {EACL}}
+@string{COLT = {COLT}}
+@string{CoNLL = {CoNLL}}
+@string{CVPR = {CVPR}}
+@string{DARPA = {DARPA Workshop}}
+@string{ECML = {ECML}}
+@string{FOCS = {IEEE Symp. of Foundation of Computer Science}}
+@string{ECCV = {ECCV}}
+@string{ECIR = {ECIR}}
+@string{IAAI= {IAAI}}
+@string{ICML = {ICML}}
+@string{ICASSP = {ICASSP}}
+@string{IJCAI = {IJCAI}}
+@string{IJCNLP = {IJCNLP}}
+@string{ILP =  {Proc. of the International Conference Inductive Logic Programming}}
+@string{IPW = {Proc. of the International Parsing Workshop}}
+@string{IWPT = {IWPT}}
+@string{IT = {IEEE Transactions on Information Theory}}
+@string{ISMB = {The International Conference on Intelligent Systems for Molecular Biology}}
+@string{LREC = {LREC}}
+@string{KR = {KR}}
+@string{NAACL = {NAACL}}
+@string{NIPS = {NIPS}}
+@string{SIGIR = {SIGIR}}
+@string{SIGDAT = {EMNLP}}
+@string{EMNLP = {EMNLP}}
+@string{STOC = {ACM Symp. of the Theory of Computing}}
+@string{TMI = {Proc. of the International Conference on Theoretical and Methodological Issues in Machine Translation}}
+@string{UWOED = {Proc. of the Annual Conference of the UW Center for the New OED and Text Research}}
+@string{JACM = {Journal of the ACM}}
+@string{WWW = {WWW}}
+@string{HLT-EMNLP = {HLT-EMNLP}}
+@string{UAI = {UAI}}
+@string{CIKM = {CIKM}}
+@string{KDD = {KDD}} 
+@string{ICDM = {ICDM}}
+@string{SODA = {SODA}}
+@string{SOCG = {SOCG}}
+@string{WADS = {WADS}}
+@string{SWAT = {SWAT}}
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%       PUBLISHERS          %%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+@string{Cambridge = {Cambridge University Press}}
+@string{Benjamin = {Benjamin/Cummings Publishing Company, Inc.}}
+@string{MIT = {MIT Press}}
+

--- a/full_head.bib
+++ b/full_head.bib
@@ -1,0 +1,249 @@
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%        PROJECTS           %%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+@comment{FLKR = {Foundations: Learning, Knowledge Representations, Reasoning}}
+@comment{ML = {Machine Learning}}
+@comment{KR = {Knowledge Representation and Inference}}
+@comment{LnI = {Learning and Inference}}
+@comment{NLP = {Natural Language Processing}}
+@comment{IIA = {Intelligent Information Access}}
+%%
+%%                 FLKR
+%%                 |
+%%                 DPL MCR LCC LT LP KR
+%%
+%%                 LnI
+%%                 |
+%%                 SI ILP SM
+%%
+%%                 IIA
+%%                 |
+%%                 IE LV MIRROR NE QA KINDLE
+%%
+%%                 NLP
+%%                 |
+%%                 LNLP CSD SP
+@comment{CSD = {Context Sensitive Disambiguation}}
+@comment{DPL = {Discriminative and Probabilistic Learning}}
+@comment{LNLP = {Learning in NLP}}
+@comment{IE = {Information Extraction}}
+@comment{ILP = {Integer Linear Programming Inference}}
+@comment{KR = {Relational Knowledge Representations and Kernels}}
+@comment{LBP = {Learning Based Programming}}
+@comment{LCC = {Learning Coherent Concepts}}
+@comment{LINL = {Learning and Inference in Natural Language}}
+@comment{LV = {Learning for Visual Recognition}}
+@comment{LP = {Learning Protocols}}
+@comment{LT = {Learning Theory}}
+@comment{KINDLE = {Knowledge Representation and Inference for Natural Language using Feature Description Logic}}
+@comment{MCR = {Multiclass Classification and Ranking}}
+@comment{MIRROR = {Mirroring Entities: Name Identification and Tracing}}
+@comment{NE = {Named Entity Recognition}}
+@comment{NLP = {Natural Language Processing}}
+@comment{QA = {Question Answering Systems}}
+@comment{SI = {Sequential Inference}}
+@comment{SM = {Structural Mapping}}
+@comment{SP = {Semantic Parsing}}
+@comment{PHRASENET = {PhraseNet}}
+%% NEW PROJECTS (2008)
+@comment{CSTC = {Context Sensitive Text Correction}}
+@comment{USS = {Unsupervised and Semi-supervised Learning}}
+@comment{DC = {Dataless Classification}}
+@comment{AL = {Active and Interactive Learning}}
+@comment{RANK = {Learning to Rank}}
+@comment{ADAPT = {Adaptation}}
+@comment{PL = {Pipeline Models}}
+@comment{MC = {Multiclass Classification}}
+@comment{PASTML = {Past Projects}}
+@comment{FOPI = {First-order Probabilistic Inference}}
+@comment{KRNLP = {Knowledge Representation for Natural Language}}
+@comment{CCM = {Constrained Conditional Models}}
+@comment{LBP = {Learning Based Programming}}
+@comment{SRL = {Semantic Parsing (Semantic Role Labeling)}}
+@comment{TE = {Semantic Entailment and Question Answering}}
+@comment{COREF = {Cofereference Within and Across Documents}}
+@comment{DP = {Dependency Parsing}}
+@comment{COMP = {Natural Language Comprehension in Context}}
+@comment{PSYCHO = {Psycholinguistics}}
+@comment{TL = {Transliteration}}
+@comment{LS = {Lexical Semantics}}
+@comment{PASTNLP = {Past Projects}}
+@comment{IE = {Information Extraction}}
+@comment{NER = {Named Entities and Relations}}
+@comment{SEARCH = {NLP Based Search}}
+@comment{TRUST = {Trustworthiness}}
+
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%         GRANTS            %%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%%% The key of a past projects is prefiexed by p-
+
+%%% NSF
+
+@comment{Psych = {Verb Learning and The Early Development of Sentence Comprehension:
+Experimental and Computational Studies}}
+% ACTIVE: NSF BCS-0620257
+% ACTIVE NIH grant R01-HD054448.
+@comment{SoD = {Learning Based Programming}}
+% ACTIVE: NSF SoD-HCER-0613885
+
+%%% EDU
+@comment{EDU = {Asses As you Go}}
+
+@comment{ITR-EDU = {Natural Language Processing Technology for Guided Study of Bioinformatics}}
+% NSF ITR IIS-0428472
+@comment{p-ITR-BI = {Multimodal Human Computer Interaction: Toward a Proactive Computer}}
+% NSF IIS -- 0085980
+@comment{p-ITR-MIT = {From Bits to Information: Statistical Learning Technologies for
+Digital Information Management and Search}}
+% NSF ITR IIS 0085836
+@comment{NSF-REU = (research experience for undergraduates)}
+@comment{p-CAREER = {Learning Coherent Concepts: Theory and Applications to Natural Language}}
+% NSF IIS 9984168
+@comment{p-KDI = {The Role of Experience in Natural Language}}
+% NSF SBR 9872450
+@comment{p-NSF98 = {Learning to Perform Knowledge Intensive Inferences}}
+% NSF IIS 9801638
+@comment{CLUSTER = {Programming Environments and Applications for Clusters and Grids}}
+%
+% Library of Congress ECHO Depository Index code: A60754 FOPAL: 490167-434040-191100
+@comment{Library = {Meta-Data}}
+
+
+%%%%
+%%% DOI
+@comment{p-KINDLE = {Knowledge and Inference via Description Logics for Natural Language}}
+%Advanced Research and Development Activity (ARDA)'s Advanced Question Answering for Intelligence (AQUAINT)
+@comment{p-REFLEX = {Named Entity Recognition and Transliteration for 50 Languages.}}
+@comment{p-LbR = {DARPA seedling for Learning by Reading.}}
+
+%
+%Index code: A28981
+%FOPAL: 488889-434040-191100
+% Title: AF Sub SRI 2009-02926
+@comment{MR = {DARPA funding under the Machine Reading Program.}}
+%% ACTIVE:
+
+@comment{MIAS = {DHS-IDS-Center for Multimodal Information Access and Synthesis.}}
+%% ACTIVE:
+% Index code: A46411
+% CFOP: 491233-434040-191100
+% Title: Navy N00014-07-1-0151
+@comment{BL = {DARPA funding under the Bootstrap Learning Program.}}
+%% ACTIVE:
+
+%%% ONR
+@comment{ONR = {Guiding Learning and Decision Making in the
+    Presence of Multiple Forms of Information}}
+%% ACTIVE:
+@comment{p-MURI = {Decision Making Under Uncertainty}}
+@comment{p-TRECC = {Cross-Document Entity Identification \& Tracing.}}
+
+%%% Industry
+@comment{p-BOEING = {Machine Learning for Security: Digital Guards for Insider Threat Detection}}
+@comment{BOEING-L = {Focused Textual Entailment}}
+%% ACTIVE
+
+@comment{GOOGLE = {Textual Entailment}}
+%% ACTIVE: GIft
+
+@comment{MSR = {Textual Entailment}}
+%% ACTIVE: Gift
+%% Index code: 434U8K
+%% Title: Microsoft-Roth
+%% FOPAL: 630246-434028-191100
+
+
+@comment{p-MOTOROLA = {Business Intelligence Systems}}
+@comment{XPRESSMP = {XPress-MP Optimization Suite}}
+%Dash Optimization for the free academic use of Xpress-MP.
+@comment{p-IBM = {Context-Sensitive Natural Language Inferences}}
+
+%%% UIUC
+@comment{p-CRI = {The Role of Sensorimotor Function, Associative Memory and Reinforcement Learning in
+Automatic Acquisition of Spoken Language by an Autonomous Robot}}
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%        PACKAGES           %%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+@comment{SNOW = {SNoW}}
+@comment{FEX = {FEX}}
+@comment{POS = {POS Tagger}}
+@comment{NE = {NE Tagger}}
+@comment{SP = {Shallow Parser}}
+@comment{SRL = {Semantic Role labeling}}
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%        JOURNALS           %%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+@string{AI = {Artificial Intelligence}}
+@string{CACM = {Communications of the ACM}}
+@string{CSL = {Computer Speech and Language}}
+@string{CL = {Computational Linguistics}}
+@string{InfCtrl = {Information and Control}}
+@string{IT = {IEEE Transactions on information theory}}
+@string{JACM = {Journal of the ACM}}
+@string{JAIR = {Journal of AI Research}}
+@string{JMLR = {Journal of Machine Learning Research}}
+@string{ML = {Machine Learning}}
+@string{NLE = {Journal of Natural Language Engineering}}
+@string{MM = {IEEE Transactions on Multimedia}}
+@string{PAMI = {IEEE Transactions on Pattern Analysis and Machine Intelligence}}
+@string{SIJAD = {SIAM Journal of Algebraic and Discrete Methods}}
+@string{SIJC = {SIAM Journal of Computing}}
+@string{TASSP = {IEEE Transactions on Acoustics, speech, and Signal Processing}}
+@string{TASSP = {IEEE Transactions on Acoustics, speech, and Signal Processing}}
+@string{TCS = {Theoretical Computer Science}}
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%       CONFERENCES         %%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+@string{AAAI= {Proceedings of the National Conference on Artificial Intelligence (AAAI)}}
+@string{ANLP = {Proc. of ACL Conference on Applied Natural Language Processing}}
+@string{ARPA = {Proc. of the ARPA Workshop on Human Language Technology}}
+@string{ACCV = {Proceedings of the Asian Conference on Computer Vision (ACCV)}}
+@string{AISTAT = {Proceedings of the International Workshop on Artificial Intelligence and Statistics}}
+@string{ALT = {Proc. of the International Workshop on Algorithmic Learning Theory (ALT)}}
+@string{COLING = {Proc.  the International Conference on Computational Linguistics (COLING)}}
+@string{ACL = {Proc. of the Annual Meeting of the Association of Computational Linguistics (ACL)}}
+@string{COLT = {Proc. of the Annual ACM Workshop on Computational Learning Theory (COLT)}}
+@string{CoNLL = {Proc. of the Annual Conference on Computational Natural Language Learning (CoNLL)}}
+@string{CVPR = {The IEEE Conference on Computer Vision and Pattern Recognition (CVPR)}}
+@string{DARPA = {Proc. of the DARPA Workshop on Speech and Natural Language}}
+@string{ECML = {Proc. of the European Conference on Machine Learning (ECML)}}
+@string{FOCS = {IEEE Symp. of Foundation of Computer Science}}
+@string{ECCV = {Proc. of the European Conference on Computer Vision (ECCV)}}
+@string{IAAI= {Proceedings of the National Conference on Innovative Applications of Artificial Intelligence (IAAI)}}
+@string{ICML = {Proc. of the International Conference on Machine Learning (ICML)}}
+@string{ICASSP = {Proc. of ICASSP}}
+@string{IJCAI = {Proc. of the International Joint Conference on Artificial Intelligence (IJCAI)}}
+@string{IJCNLP = {Proc. of the International Joint Conference on Natural Language Processing (IJCNLP)}}
+@string{ILP =  {Proc. of the International Conference Inductive Logic Programming}}
+@string{IPW = {Proc. of the International Parsing Workshop}}
+@string{IWPT = {Proc. of the International Workshop of Parsing Technology}}
+@string{IT = {IEEE Transactions on Information Theory}}
+@string{ISMB = {The International Conference on Intelligent Systems for Molecular Biology}}
+@string{KR = {Proc. of the International Conference on the Principles of Knowledge Representation and Reasoning}}
+@string{NAACL = {Proc. of the Annual Meeting of the North American Association of Computational Linguistics (NAACL)}}
+@string{NIPS = {The Conference on Advances in Neural Information Processing Systems (NIPS)}}
+@string{SIGIR = {Proc. of International Conference on Research and Development in Information Retrieval, SIGIR}}
+@string{SIGDAT = {Proc. of the Conference on Empirical Methods for Natural Language Processing (EMNLP)}}
+@string{EMNLP = {Proc. of the Conference on Empirical Methods for Natural Language Processing (EMNLP)}}
+@string{STOC = {ACM Symp. of the Theory of Computing}}
+@string{TMI = {Proc. of the International Conference on Theoretical and Methodological Issues in Machine Translation}}
+@string{UWOED = {Proc. of the Annual Conference of the UW Center for the New OED and Text Research}}
+@string{JACM = {Journal of the ACM}}
+@string{WWW = {The International World Wide Web Conference}}
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%       PUBLISHERS          %%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+@string{Cambridge = {Cambridge University Press}}
+@string{Benjamin = {Benjamin/Cummings Publishing Company, Inc.}}
+@string{MIT = {MIT Press}}


### PR DESCRIPTION
**What's in this pull:**
- Updated README.md
- Added full_head.bib and compact_head.bib, which were missing in our github repo. I found them in the gitlab repo.
- Merged Qiang's cited papers into cited.bib and used `genCitedConference.sh` to update corresponding files.

**In addition, I find that our cited-long.bib contains lots of omitted fields, which should only be in cited-compact.bib. For example, there're lots of entries in cited-long.bib like the following**
```
@InProceedings{OkanoharaTs07,
  Title                    = {A discriminative language model with pseudo-negative
samples},
  Author                   = {Okanohara, Daisuke and Tsujii, Jun'ichi},
  Booktitle                = ACL,
  Year                     = {2007},

  Address-omit             = {Prague, Czech Republic},
  Month-omit               = {June},
  Pages-omit               = {73--80},
  Publisher-omit           = {Association for Computational Linguistics},
  Url-omit                 = {http://www.aclweb.org/anthology/P/P07/P07-1010}
}
```
Note the `-omit` fields above, which should not be there I think.