### PR TITLE
partially fixed cited.bib.

### DIFF
--- a/cited.bib
+++ b/cited.bib
@@ -354,7 +354,7 @@ Parts I and II},
 @InProceedings{ChaturvediIyII17,
   Title                    = {{Unsupervised Learning of Evolving Relationships Between Literary Characters}},
   Author                   = {Snigdha Chaturvedi and Mohit Iyyer and Hal Daum{\'e} III},
-  Booktitle                = {Proceedings of the Thirty First AAAI Conference on Artificial Intelligence},
+  Booktitle                = AAAI,
   Year                     = {2017},
   Pages                    = {3159--3165},
   Series                   = {AAAI'17},
@@ -658,8 +658,7 @@ Key takeaways
  Shashank Srivastava and
  Hal Daum{\'{e}} III and
  Chris Dyer},
-  Booktitle                = {Proceedings of the Thirtieth AAAI Conference on Artificial Intelligence,
- February 12-17, 2016, Phoenix, Arizona, {USA.}},
+  Booktitle                = AAAI,
   Year                     = {2016},
   Pages                    = {2704--2710},
   Series                   = {AAAI'16}
@@ -697,7 +696,7 @@ Key takeaways
   Title                    = {A Unified Bayesian Model of Scripts, Frames and Language},
   Author                   = {Francis Ferraro and
  Benjamin Van Durme},
-  Booktitle                = {Proceedings of the Thirtieth AAAI Conference on Artificial Intelligence},
+  Booktitle                = AAAI,
   Year                     = {2016},
   Pages                    = {2601--2607}
 }
@@ -721,21 +720,21 @@ Key takeaways
 @InProceedings{GCYWL16,
   Title                    = {A Representation Learning Framework for Multi-Source Transfer Parsing},
   Author                   = {Guo, Jiang and Che, Wanxiang and Yarowsky, David and Wang, Haifeng and Liu, Ting},
-  Booktitle                = {Proc. of AAAI},
+  Booktitle                = AAAI,
   Year                     = {2016}
 }
 
 @InProceedings{GCYWL16a,
   Title                    = {A Representation Learning Framework for Multi-Source Transfer Parsing},
   Author                   = {Guo, Jiang and Che, Wanxiang and Yarowsky, David and Wang, Haifeng and Liu, Ting},
-  Booktitle                = {Proc. of AAAI},
+  Booktitle                = AAAI,
   Year                     = {2016}
 }
 
 @Article{GCYWL16b,
   Title                    = {A distributed representation-based framework for cross-lingual transfer parsing},
   Author                   = {Guo, Jiang and Che, Wanxiang and Yarowsky, David and Wang, Haifeng and Liu, Ting},
-  Journal                  = {Journal of Artificial Intelligence Research},
+  Journal                  = JAIR,
   Year                     = {2016},
   Pages                    = {995--1023},
   Volume                   = {55}
@@ -789,7 +788,7 @@ Key takeaways
  Model},
   Author                   = {Mark Granroth{-}Wilding and
  Stephen Clark},
-  Booktitle                = {Proceedings of the Thirtieth AAAI Conference on Artificial Intelligence},
+  Booktitle                = AAAI,
   Year                     = {2016},
   Pages                    = {2727--2733}
 }
@@ -1142,7 +1141,7 @@ Extensions : The model for entailment in context is a close cousin of this model
   Title                    = {Learning Statistical Scripts with {LSTM} Recurrent Neural Networks},
   Author                   = {Karl Pichotta and
  Raymond J. Mooney},
-  Booktitle                = {Proceedings of the Thirtieth AAAI Conference on Artificial Intelligence},
+  Booktitle                = AAAI,
   Year                     = {2016},
   Pages                    = {2800--2806}
 }
@@ -1257,8 +1256,7 @@ Extensions : The model for entailment in context is a close cousin of this model
   Author                   = {Shashank Srivastava and
  Snigdha Chaturvedi and
  Tom M. Mitchell},
-  Booktitle                = {Proceedings of the Thirtieth AAAI Conference on Artificial Intelligence,
- February 12-17, 2016, Phoenix, Arizona, {USA.}},
+  Booktitle                = AAAI,
   Year                     = {2016},
   Pages                    = {2807--2813}
 }
@@ -1549,7 +1547,7 @@ The attention mechanism also has the properties that we've discussed about - ess
 @InProceedings{AKTT15,
   Title                    = {{Budgeted Prediction With Expert Advice}},
   Author                   = {Amin, Kareem and Kale, Satyen and Tesauro, Gerald and Turaga, Deepak},
-  Booktitle                = {Proceedings of AAAI},
+  Booktitle                = AAAI,
   Year                     = {2015},
   Pages                    = {2490--2496},
 
@@ -5313,7 +5311,7 @@ Weakly Supervised Learning},
 @Article{DoppaFeTa13,
   Title                    = {{HC -Search : Learning Heuristics and Cost Functions for Structured Prediction}},
   Author                   = {Doppa, Janardhan Rao and Fern, Alan and Tadepalli, Prasad},
-  Journal                  = {Proceedings of AAAI},
+  Journal                  = AAAI,
   Year                     = {2013},
   Pages                    = {253--259},
 
@@ -10885,7 +10883,7 @@ Intelligence},
 @Article{GabrilovichMa09c,
   Title                    = {Wikipedia-based Semantic Interpretation for Natural Language Processing},
   Author                   = {Gabrilovich, Evgeniy and Markovitch, Shaul},
-  Journal                  = {Journal of Artificial Intelligence Research},
+  Journal                  = JAIR,
   Year                     = {2009},
   Number                   = {1},
   Pages                    = {443--498},
@@ -24065,7 +24063,7 @@ Uncertainty in Artificial Intelligence (UAI-03)},
 @Article{LeisinkKa03,
   Title                    = {Bound Propagation},
   Author                   = {Martijn Leisink and Bert Kappen},
-  Journal                  = {Journal of Artificial Intelligence Research},
+  Journal                  = JAIR,
   Year                     = {2003},
 
   Pages-omit               = {139--154},
@@ -49315,7 +49313,7 @@ Theory},
   Title                    = {A Semantics and Complete Algorithm for Subsumption
 in the {CLASSIC} Description Logic},
   Author                   = {Alexander Borgida and Peter F. Patel-Schneider},
-  Journal                  = {Journal of Artificial Intelligence Research},
+  Journal                  = JAIR,
   Year                     = {1994},
 
   Pages-omit               = {277-308},
@@ -49404,7 +49402,7 @@ Research and Development in Information Retrieval},
 @Article{Buntine94,
   Title                    = {Operations for Learning with Graphical Models},
   Author                   = {Wray L. Buntine},
-  Journal                  = {Journal of Artificial Intelligence Research},
+  Journal                  = JAIR,
   Year                     = {1994},
 
   Pages-omit               = {159-225},
@@ -49816,7 +49814,7 @@ Systems},
   Title                    = {Substructure Discovery Using Minimum Description
 Length and Background Knowledge},
   Author                   = {D.J. Cook and L.B. Holder},
-  Journal                  = {Journal of Artificial Intelligence Research},
+  Journal                  = JAIR,
   Year                     = {1994},
 
   Pages-omit               = {231--255},

--- a/cited.bib
+++ b/cited.bib
@@ -1,6 +1,82 @@
 % This file was created with JabRef 2.10.
 % Encoding: ISO8859_1
 
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%        JOURNALS           %%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+@string{AI = {Artificial Intelligence}}
+@string{CACM = {Communications of the ACM}}
+@string{CSL = {Computer Speech and Language}}
+@string{CL = {Computational Linguistics}}
+@string{InfCtrl = {Information and Control}}
+@string{IT = {IEEE Transactions on information theory}}
+@string{JACM = {Journal of the ACM}}
+@string{JAIR = {Journal of AI Research (JAIR)}}
+@string{JMLR = {Journal of Machine Learning Research (JMLR)}}
+@string{ML = {Machine Learning}}
+@string{NLE = {Journal of Natural Language Engineering (NLE)}}
+@string{MM = {IEEE Transactions on Multimedia}}
+@string{PAMI = {IEEE Transactions on Pattern Analysis and Machine Intelligence}}
+@string{SIJAD = {SIAM Journal of Algebraic and Discrete Methods}}
+@string{SIJC = {SIAM Journal of Computing}}
+@string{TACL = {Transactions of the Association for Computational Linguistics}}
+@string{TASSP = {IEEE Transactions on Acoustics, speech, and Signal Processing}}
+@string{TCS = {Theoretical Computer Science}}
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%       CONFERENCES         %%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+@string{AAAI= {Proceedings of the National Conference on Artificial Intelligence (AAAI)}}
+@string{ANLP = {Proc. of ACL Conference on Applied Natural Language Processing}}
+@string{ARPA = {Proc. of the ARPA Workshop on Human Language Technology}}
+@string{ACCV = {Proceedings of the Asian Conference on Computer Vision (ACCV)}}
+@string{AISTATS = {Proceedings of the International Workshop on Artificial Intelligence and Statistics (AISTATS)}}
+@string{ALT = {Proc. of the International Workshop on Algorithmic Learning Theory (ALT)}}
+@string{COLING = {Proc.  the International Conference on Computational Linguistics (COLING)}}
+@string{ACL = {Proc. of the Annual Meeting of the Association of Computational Linguistics (ACL)}}
+@string{CIKM = {{Proc. of the ACM Conference on Information and Knowledge Management (CIKM)}}}
+@string{COLT = {Proc. of the Annual ACM Workshop on Computational Learning Theory (COLT)}}
+@string{CoNLL = {Proc. of the Annual Conference on Computational Natural Language Learning (CoNLL)}}
+@string{CVPR = {The IEEE Conference on Computer Vision and Pattern Recognition (CVPR)}}
+@string{DARPA = {Proc. of the DARPA Workshop on Speech and Natural Language}}
+@string{ECML = {Proc. of the European Conference on Machine Learning (ECML)}}
+@string{ECIR = {Proc. of the European Conference on Information Retrieval (ECIR)}}
+@string{FOCS = {IEEE Symp. of Foundation of Computer Science}}
+@string{ECCV = {Proc. of the European Conference on Computer Vision (ECCV)}}
+@string{IAAI= {Proceedings of the National Conference on Innovative Applications of Artificial Intelligence (IAAI)}}
+@string{ICML = {Proc. of the International Conference on Machine Learning (ICML)}}
+@string{ICLR = {Proc. of the International Conference on Learning Representations (ICLR)}}
+@string{ICASSP = {Proc. of ICASSP}}
+@string{IJCAI = {Proc. of the International Joint Conference on Artificial Intelligence (IJCAI)}}
+@string{IJCNLP = {Proc. of the International Joint Conference on Natural Language Processing (IJCNLP)}}
+@string{ILP =  {Proc. of the International Conference Inductive Logic Programming}}
+@string{IPW = {Proc. of the International Parsing Workshop}}
+@string{IWPT = {Proc. of the International Workshop of Parsing Technology}}
+@string{IT = {IEEE Transactions on Information Theory}}
+@string{ISMB = {The International Conference on Intelligent Systems for Molecular Biology}}
+@string{KR = {Proc. of the International Conference on the Principles of Knowledge Representation and Reasoning}}
+@string{NAACL = {Proc. of the Annual Meeting of the North American Association of Computational Linguistics (NAACL)}}
+@string{NIPS = {Proc. of the Conference on Advances in Neural Information Processing Systems (NIPS)}}
+@string{SIGIR = {Proc. of International Conference on Research and Development in Information Retrieval, SIGIR}}
+@string{SIGDAT = {Proc. of the Conference on Empirical Methods for Natural Language Processing (EMNLP)}}
+@string{SIGHAN = {Proc. of the SIGHAN Workshop on Chinese Language Processing (SIGHAN)}}
+@string{EMNLP = {Proc. of the Conference on Empirical Methods for Natural Language Processing (EMNLP)}}
+@string{STOC = {ACM Symp. of the Theory of Computing}}
+@string{TMI = {Proc. of the International Conference on Theoretical and Methodological Issues in Machine Translation}}
+@string{UWOED = {Proc. of the Annual Conference of the UW Center for the New OED and Text Research}}
+@string{JACM = {Journal of the ACM}}
+@string{WWW = {The International World Wide Web Conference}}
+@string{*SEM = {Proc. of the Joint Conference on Lexical and Computational Semantics (*SEM)}}
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%       PUBLISHERS          %%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+@string{Cambridge = {Cambridge University Press}}
+@string{Benjamin = {Benjamin/Cummings Publishing Company, Inc.}}
+@string{MIT = {MIT Press}}
 
 @InProceedings{CannyRe,
   Title                    = {New Lower Bound Techniques for Robot Motion Planning
@@ -278,7 +354,7 @@ Parts I and II},
 @InProceedings{ChaturvediIyII17,
   Title                    = {{Unsupervised Learning of Evolving Relationships Between Literary Characters}},
   Author                   = {Snigdha Chaturvedi and Mohit Iyyer and Hal Daum{\'e} III},
-  Booktitle                = {Proceedings of the Thirty First {AAAI} Conference on Artificial Intelligence},
+  Booktitle                = {Proceedings of the Thirty First AAAI Conference on Artificial Intelligence},
   Year                     = {2017},
   Pages                    = {3159--3165},
   Series                   = {AAAI'17},
@@ -331,7 +407,7 @@ Parts I and II},
  Embeddings from Sentence Alignments},
   Author                   = {Levy, Omer and S{\o}gaard, Anders and Goldberg,
  Yoav},
-  Booktitle                = {Proc. of EACL},
+  Booktitle                = EACL,
   Year                     = {2017}
 }
 
@@ -407,7 +483,7 @@ Parts I and II},
 @InProceedings{Vulic17,
   Title                    = {Cross-Lingual Syntactically Informed Distributed Word Representations},
   Author                   = {Vuli\'{c}, Ivan},
-  Booktitle                = {Proc. of EACL},
+  Booktitle                = EACL,
   Year                     = {2017}
 }
 
@@ -483,7 +559,7 @@ Key takeaways
   Title                    = {Labeling the Semantic Roles of Commas},
   Author                   = {Naveen Arivazhagan and Christos Christodoulopoulos and
  Dan Roth},
-  Booktitle                = {AAAI},
+  Booktitle                = AAAI,
   Year                     = {2016},
 
   Owner                    = {penghaoruo},
@@ -494,7 +570,7 @@ Key takeaways
   Title                    = {Labeling the Semantic Roles of Commas},
   Author                   = {Naveen Arivazhagan and Christos Christodoulopoulos and
  Dan Roth},
-  Booktitle                = {AAAI},
+  Booktitle                = AAAI,
   Year                     = {2016},
 
   Owner                    = {penghaoruo},
@@ -582,7 +658,7 @@ Key takeaways
  Shashank Srivastava and
  Hal Daum{\'{e}} III and
  Chris Dyer},
-  Booktitle                = {Proceedings of the Thirtieth {AAAI} Conference on Artificial Intelligence,
+  Booktitle                = {Proceedings of the Thirtieth AAAI Conference on Artificial Intelligence,
  February 12-17, 2016, Phoenix, Arizona, {USA.}},
   Year                     = {2016},
   Pages                    = {2704--2710},
@@ -592,7 +668,7 @@ Key takeaways
 @InProceedings{CSLBH16,
   Title                    = {Representing Verbs with Rich Contexts: an Evaluation on Verb Similarity},
   Author                   = {Chersoni, Emmanuele and Santus, Enrico and Lenci, Alessandro and Blache, Philippe and Huang, Chu-Ren},
-  Booktitle                = {Proc. of EMNLP},
+  Booktitle                = EMNLP,
   Year                     = {2016}
 }
 
@@ -621,7 +697,7 @@ Key takeaways
   Title                    = {A Unified Bayesian Model of Scripts, Frames and Language},
   Author                   = {Francis Ferraro and
  Benjamin Van Durme},
-  Booktitle                = {Proceedings of the Thirtieth {AAAI} Conference on Artificial Intelligence},
+  Booktitle                = {Proceedings of the Thirtieth AAAI Conference on Artificial Intelligence},
   Year                     = {2016},
   Pages                    = {2601--2607}
 }
@@ -629,7 +705,7 @@ Key takeaways
 @InProceedings{FerraroVa16,
   Title                    = {A unified Bayesian model of scripts, frames and language},
   Author                   = {Ferraro, Francis and Van Durme, Benjamin},
-  Booktitle                = {AAAI},
+  Booktitle                = AAAI,
   Year                     = {2016}
 }
 
@@ -675,14 +751,14 @@ Key takeaways
 @InProceedings{GHPFTFSM16,
   Title                    = {Translation invariant word embeddings},
   Author                   = {Gardner, Matt and Huang, Kejun and Papalexakis, Evangelos and Fu, Xiao and Talukdar, Partha and Faloutsos, Christos and Sidiropoulos, Nicholas and Mitchell, Tom},
-  Booktitle                = {Proc. of EMNLP},
+  Booktitle                = EMNLP,
   Year                     = {2016}
 }
 
 @InProceedings{GHPFTFSM16a,
   Title                    = {Translation invariant word embeddings},
   Author                   = {Gardner, Matt and Huang, Kejun and Papalexakis, Evangelos and Fu, Xiao and Talukdar, Partha and Faloutsos, Christos and Sidiropoulos, Nicholas and Mitchell, Tom},
-  Booktitle                = {Proc. of EMNLP},
+  Booktitle                = EMNLP,
   Year                     = {2016}
 }
 
@@ -713,7 +789,7 @@ Key takeaways
  Model},
   Author                   = {Mark Granroth{-}Wilding and
  Stephen Clark},
-  Booktitle                = {Proceedings of the Thirtieth {AAAI} Conference on Artificial Intelligence},
+  Booktitle                = {Proceedings of the Thirtieth AAAI Conference on Artificial Intelligence},
   Year                     = {2016},
   Pages                    = {2727--2733}
 }
@@ -782,7 +858,7 @@ Key takeaways
  Snigdha Chaturvedi and
  Jordan L. Boyd{-}Graber and
  Hal Daum{\'{e}} III},
-  Booktitle                = {{NAACL} {HLT} 2016, The 2016 Conference of the North American Chapter
+  Booktitle                = {NAACL {HLT} 2016, The 2016 Conference of the North American Chapter
  of the Association for Computational Linguistics: Human Language Technologies},
   Year                     = {2016},
   Pages                    = {1534--1544}
@@ -872,7 +948,7 @@ Key takeaways
 @Article{LevyDa16,
   Title                    = {{Annotating Relation Inference in Context via Question Answering}},
   Author                   = {Levy, Omer and Dagan, Ido},
-  Journal                  = {Proceedings of ACL},
+  Journal                  = ACL,
   Year                     = {2016},
 
   File                     = {:Users/yogarshi/Documents/Papers/Levy, Dagan{\_}2016.pdf:pdf},
@@ -915,7 +991,7 @@ Key takeaways
 @InProceedings{MCHPBVKA16a,
   Title                    = {A Corpus and Cloze Evaluation for Deeper Understanding of Commonsense Stories},
   Author                   = {Mostafazadeh, Nasrin and Chambers, Nathanael and He, Xiaodong and Parikh, Devi and Batra, Dhruv and Vanderwende, Lucy and Kohli, Pushmeet and Allen, James},
-  Booktitle                = {NAACL},
+  Booktitle                = NAACL,
   Year                     = {2016}
 }
 
@@ -1008,7 +1084,7 @@ Extensions : The model for entailment in context is a close cousin of this model
  Pushmeet Kohli and
  James F. Allen},
   Booktitle                = {Proceedings of the 2016 Conference of the North American Chapter
- of the Association for Computational Linguistics: Human Language Technologies {NAACL} {HLT} 2016},
+ of the Association for Computational Linguistics: Human Language Technologies NAACL {HLT} 2016},
   Year                     = {2016},
   Pages                    = {839--849}
 }
@@ -1066,7 +1142,7 @@ Extensions : The model for entailment in context is a close cousin of this model
   Title                    = {Learning Statistical Scripts with {LSTM} Recurrent Neural Networks},
   Author                   = {Karl Pichotta and
  Raymond J. Mooney},
-  Booktitle                = {Proceedings of the Thirtieth {AAAI} Conference on Artificial Intelligence},
+  Booktitle                = {Proceedings of the Thirtieth AAAI Conference on Artificial Intelligence},
   Year                     = {2016},
   Pages                    = {2800--2806}
 }
@@ -1074,7 +1150,7 @@ Extensions : The model for entailment in context is a close cousin of this model
 @InProceedings{PichottaMo16a,
   Title                    = {Learning statistical scripts with LSTM recurrent neural networks},
   Author                   = {Pichotta, K. and Mooney, R. J.},
-  Booktitle                = {AAAI},
+  Booktitle                = AAAI,
   Year                     = {2016}
 }
 
@@ -1146,7 +1222,7 @@ Extensions : The model for entailment in context is a close cousin of this model
 @Article{RollerEr16,
   Title                    = {{Relations such as Hypernymy: Identifying and Exploiting Hearst Patterns in Distributional Vectors for Lexical Entailment}},
   Author                   = {Roller, Stephen and Erk, Katrin},
-  Journal                  = {Proc. of EMNLP},
+  Journal                  = EMNLP,
   Year                     = {2016},
 
   Abstract                 = {We consider the task of predicting lexical entailment using distributional vectors. We focus experiments on one previous classifier which was shown to only learn to detect prototypicality of a word pair. Analysis shows that the model single-mindedly learns to detect Hearst Patterns, which are well known to be predictive of lexical relations. We present a new model which exploits this Hearst Detector functionality, matching or outperforming prior work on multiple data sets.},
@@ -1181,7 +1257,7 @@ Extensions : The model for entailment in context is a close cousin of this model
   Author                   = {Shashank Srivastava and
  Snigdha Chaturvedi and
  Tom M. Mitchell},
-  Booktitle                = {Proceedings of the Thirtieth {AAAI} Conference on Artificial Intelligence,
+  Booktitle                = {Proceedings of the Thirtieth AAAI Conference on Artificial Intelligence,
  February 12-17, 2016, Phoenix, Arizona, {USA.}},
   Year                     = {2016},
   Pages                    = {2807--2813}
@@ -1247,14 +1323,6 @@ The attention mechanism also has the properties that we've discussed about - ess
   Keywords                 = {convolutional neural networks,ing,learning to rank,long-short term,microblog search,neural networks,question answer-,question answering,recurrent neural networks}
 }
 
-@InProceedings{SUPR16,
-  Title                    = {Cross-lingual Dataless Classification for Many Languages},
-  Author                   = {Yangqiu Song and Shyam Upadhyay and Haoruo Peng and Dan Roth},
-  Booktitle                = {IJCAI},
-  Year                     = {2016},
-  Pages                    = {2901--2907}
-}
-
 @InProceedings{SusterTiNo16,
   Title                    = {{Bilingual Learning of Multi-sense Embeddings with Discrete Autoencoders}},
   Author                   = {{\v{S}}uster, Simon and Titov, Ivan and van Noord, Gertjan},
@@ -1312,21 +1380,6 @@ The attention mechanism also has the properties that we've discussed about - ess
   Url                      = {https://www.microsoft.com/en-us/research/wp-content/uploads/2016/06/acl2016relationpaths-1.pdf}
 }
 
-@InProceedings{TsaiRo16,
-  Title                    = {Cross-lingual Wikification Using Multilingual Embeddings},
-  Author                   = {Chen-Tse Tsai and Dan Roth},
-  Booktitle                = {NAACL},
-  Year                     = {2016}
-}
-
-@InProceedings{TsaiRo16a,
-  Title                    = {Cross-lingual Wikification Using Multilingual Embeddings},
-  Author                   = {Chen-Tse Tsai and Dan Roth},
-  Booktitle                = {NAACL},
-  Year                     = {2016},
-  Month                    = {6}
-}
-
 @Article{TWRGB16,
   Title                    = {{Complex Embeddings for Simple Link Prediction}},
   Author                   = {Trouillon, Th{\'{e}}o and Welbl, Johannes and Riedel, Sebastian and Gaussier, Eric and Bouchard, Guillaume},
@@ -1351,31 +1404,9 @@ The attention mechanism also has the properties that we've discussed about - ess
  Guillaume},
   Year                     = {2016},
 
-  Booktitle                = {Proc. of ICML}
+  Booktitle                = ICML
 }
 
-@Article{UFDR16,
-  Title                    = {Cross-lingual Models of Word Embeddings: An Empirical Comparison},
-  Author                   = {Shyam Upadhyay and
- Manaal Faruqui and
- Chris Dyer and
- Dan Roth},
-  Journal                  = {ACL},
-  Year                     = {2016}
-}
-
-@InProceedings{UFDR16a,
-  Title                    = {{Cross-lingual Models of Word Embeddings: An Empirical Comparison}},
-  Author                   = {Upadhyay, Shyam and Faruqui, Manaal and Dyer, Chris and Roth, Dan},
-  Booktitle                = {ACL},
-  Year                     = {2016},
-
-  Abstract                 = {Despite interest in using cross-lingual knowledge to learn word embeddings for various tasks, a systematic comparison of the possible approaches is lacking in the literature. We perform an extensive evaluation of four popular approaches of inducing cross-lingual embeddings, each requiring a different form of supervision, on four typographically different language pairs. Our evaluation setup spans four different tasks, including intrinsic evaluation on mono-lingual and cross-lingual similarity, and extrinsic evaluation on downstream semantic and syntactic applications. We show that models which require expensive cross-lingual knowledge almost always perform better, but cheaply supervised models often prove competitive on certain tasks.},
-  Archiveprefix            = {arXiv},
-  Arxivid                  = {1604.00425},
-  Eprint                   = {1604.00425},
-  File                     = {:Users/yogarshi/Documents/Papers/Upadhyay et al.{\_}2016.pdf:pdf}
-}
 
 @InProceedings{VBSRM16,
   Title                    = {Multilingual relation extraction using compositional universal schema},
@@ -1492,7 +1523,7 @@ The attention mechanism also has the properties that we've discussed about - ess
 @InProceedings{ZPWVJKM16,
   Title                    = {Name Tagging for Low-resource Incident Languages based on Expectation-driven Learning},
   Author                   = {Boliang Zhang and Xiaoman Pan and Tianlu Wang and Ashish Vaswani and Heng Ji and Kevin Knight and Daniel Marcu},
-  Booktitle                = {NAACL},
+  Booktitle                = NAACL,
   Year                     = {2016}
 }
 
@@ -1680,21 +1711,21 @@ Analysis: * High level stats * Question behavior - Based on length, first word *
   Title                    = {Trans-gram, Fast Cross-lingual Word-embeddings},
   Author                   = {Coulmance, Jocelyn and Marty, Jean-Marc and Wenzek,
  Guillaume and Benhalloum, Amine},
-  Booktitle                = {Proc. of EMNLP},
+  Booktitle                = EMNLP,
   Year                     = {2015}
 }
 
 @InProceedings{CMWB15b,
   Title                    = {Trans-gram, Fast Cross-lingual Word-embeddings},
   Author                   = {Coulmance, Jocelyn and Marty, Jean-Marc and Wenzek, Guillaume and Benhalloum, Amine},
-  Booktitle                = {Proc. of EMNLP},
+  Booktitle                = EMNLP,
   Year                     = {2015}
 }
 
 @InProceedings{CMWB15c,
   Title                    = {Trans-gram, Fast Cross-lingual Word-embeddings},
   Author                   = {Coulmance, Jocelyn and Marty, Jean-Marc and Wenzek, Guillaume and Benhalloum, Amine},
-  Booktitle                = {Proc. of EMNLP},
+  Booktitle                = EMNLP,
   Year                     = {2015}
 }
 
@@ -1702,7 +1733,7 @@ Analysis: * High level stats * Question behavior - Based on length, first word *
   Title                    = {Trans-gram, Fast Cross-lingual Word-embeddings},
   Author                   = {Coulmance, Jocelyn and Marty, Jean-Marc and Wenzek,
  Guillaume and Benhalloum, Amine},
-  Booktitle                = {Proc. of EMNLP},
+  Booktitle                = EMNLP,
   Year                     = {2015}
 }
 
@@ -1845,7 +1876,7 @@ Notes: 1) Brain data is not infalliable -},
 @InProceedings{FTYDS15,
   Title                    = {Sparse Overcomplete Word Vector Representations},
   Author                   = {Faruqui, Manaal and Tsvetkov, Yulia and Yogatama, Dani and Dyer, Chris and Smith, Noah A.},
-  Booktitle                = {Proc. of ACL},
+  Booktitle                = ACL,
   Year                     = {2015}
 }
 
@@ -1854,20 +1885,20 @@ Notes: 1) Brain data is not infalliable -},
   Author                   = {Granroth-Wilding, M. and Clark, S. and Llano, M. T. and Hepworth, R. and Colton, S. and Gow, J. and Charnley, J. and Lavra{\v{c}}, N. and {\v{Z}}nidar{\v{s}}i{\v{c}}, M. and Perov{\v{s}}ek, M.},
   Year                     = {2015},
 
-  Booktitle                = {AAAI}
+  Booktitle                = AAAI
 }
 
 @InProceedings{GCYWL15,
   Title                    = {Cross-lingual Dependency Parsing Based on Distributed Representations},
   Author                   = {Guo, Jiang and Che, Wanxiang and Yarowsky, David and Wang, Haifeng and Liu, Ting},
-  Booktitle                = {Proc. of ACL},
+  Booktitle                = ACL,
   Year                     = {2015}
 }
 
 @InProceedings{GCYWL15a,
   Title                    = {Cross-lingual Dependency Parsing Based on Distributed Representations},
   Author                   = {Guo, Jiang and Che, Wanxiang and Yarowsky, David and Wang, Haifeng and Liu, Ting},
-  Booktitle                = {Proc. of ACL},
+  Booktitle                = ACL,
   Year                     = {2015}
 }
 
@@ -1918,7 +1949,7 @@ Notes: 1) Brain data is not infalliable -},
   Title                    = {Bilbowa: Fast bilingual distributed representations without
  word alignments},
   Author                   = {Gouws, Stephan and Bengio, Yoshua and Corrado, Greg},
-  Booktitle                = {Proc. of ICML},
+  Booktitle                = ICML,
   Year                     = {2015}
 }
 
@@ -1926,21 +1957,21 @@ Notes: 1) Brain data is not infalliable -},
   Title                    = {Bilbowa: Fast bilingual distributed representations without
  word alignments},
   Author                   = {Gouws, Stephan and Bengio, Yoshua and Corrado, Greg},
-  Booktitle                = {Proc. of ICML},
+  Booktitle                = ICML,
   Year                     = {2015}
 }
 
 @InProceedings{GouwsS15,
   Title                    = {Simple task-specific bilingual word embeddings},
   Author                   = {Gouws, Stephan and S{\o}gaard, Anders},
-  Booktitle                = {Proc. of NAACL},
+  Booktitle                = NAACL,
   Year                     = {2015}
 }
 
 @InProceedings{GouwsS15a,
   Title                    = {Simple task-specific bilingual word embeddings},
   Author                   = {Gouws, Stephan and S{\o}gaard, Anders},
-  Booktitle                = {Proc. of NAACL},
+  Booktitle                = NAACL,
   Year                     = {2015}
 }
 
@@ -1957,14 +1988,14 @@ Notes: 1) Brain data is not infalliable -},
 @InProceedings{GuuMiLi15,
   Title                    = {Traversing Knowledge Graphs in Vector Space},
   Author                   = {K. Guu and J. Miller and P. Liang},
-  Booktitle                = {Proc. of EMNLP},
+  Booktitle                = EMNLP,
   Year                     = {2015}
 }
 
 @InProceedings{GuuMiLi15a,
   Title                    = {Traversing Knowledge Graphs in Vector Space},
   Author                   = {K. Guu and J. Miller and P. Liang},
-  Booktitle                = {Proc. of EMNLP},
+  Booktitle                = EMNLP,
   Year                     = {2015}
 }
 
@@ -2005,7 +2036,7 @@ Notes: 1) Brain data is not infalliable -},
  Evangelos and Faloutsos, Christos and Sidiropoulos,
  Nikos and Mitchell, Tom and Talukdar, Partha P. and
  Fu, Xiao},
-  Booktitle                = {Proc. of EMNLP},
+  Booktitle                = EMNLP,
   Year                     = {2015}
 }
 
@@ -2015,7 +2046,7 @@ Notes: 1) Brain data is not infalliable -},
  Evangelos and Faloutsos, Christos and Sidiropoulos,
  Nikos and Mitchell, Tom and Talukdar, Partha P. and
  Fu, Xiao},
-  Booktitle                = {Proc. of EMNLP},
+  Booktitle                = EMNLP,
   Year                     = {2015}
 }
 
@@ -2095,7 +2126,7 @@ Notes: 1) Brain data is not infalliable -},
   Title                    = {Any-language frame-semantic parsing},
   Author                   = {Johannsen, Anders and Mart\'{i}nez Alonso,
  H\'{e}ctor and S{\o}gaard, Anders},
-  Booktitle                = {Proc. of EMNLP},
+  Booktitle                = EMNLP,
   Year                     = {2015}
 }
 
@@ -2103,7 +2134,7 @@ Notes: 1) Brain data is not infalliable -},
   Title                    = {Any-language frame-semantic parsing},
   Author                   = {Johannsen, Anders and Mart\'{i}nez Alonso,
  H\'{e}ctor and S{\o}gaard, Anders},
-  Booktitle                = {Proc. of EMNLP},
+  Booktitle                = EMNLP,
   Year                     = {2015}
 }
 
@@ -2133,7 +2164,7 @@ Notes: 1) Brain data is not infalliable -},
 @InProceedings{KrishnanEi15,
   Title                    = {{``{Y}ou're {M}r. {L}ebowski, {I}'m the {D}ude'': Inducing Address Term Formality in Signed Social Networks}},
   Author                   = {Vinodh Krishnan and Jacob Eisenstein},
-  Booktitle                = {Proceedings of the 2015 Conference of the North American Chapter of the Association for Computational Linguistics: Human Language Technologies, {NAACL} {HLT} 2015},
+  Booktitle                = {Proceedings of the 2015 Conference of the North American Chapter of the Association for Computational Linguistics: Human Language Technologies, NAACL {HLT} 2015},
   Year                     = {2015},
   Pages                    = {1616--1626}
 }
@@ -2268,7 +2299,7 @@ Notes: 1) Brain data is not infalliable -},
 }
 
 @Article{LingSiWe15,
-  Title                    = {Design challenges for entity linking},
+  Title                    = {{Design Challenges for Entity Linking}},
   Author                   = {Ling, Xiao and Singh, Sameer and Weld, Daniel S},
   Journal                  = TACL,
   Year                     = {2015},
@@ -2392,7 +2423,7 @@ Notes: 1) Brain data is not infalliable -},
  Embeddings},
   Author                   = {Lu, Ang and Wang, Weiran and Bansal, Mohit and
  Gimpel, Kevin and Livescu, Karen},
-  Booktitle                = {Proc. of NAACL},
+  Booktitle                = NAACL,
   Year                     = {2015}
 }
 
@@ -2401,21 +2432,21 @@ Notes: 1) Brain data is not infalliable -},
  Embeddings},
   Author                   = {Lu, Ang and Wang, Weiran and Bansal, Mohit and
  Gimpel, Kevin and Livescu, Karen},
-  Booktitle                = {Proc. of NAACL},
+  Booktitle                = NAACL,
   Year                     = {2015}
 }
 
 @InProceedings{LWBGL15b,
   Title                    = {Deep Multilingual Correlation for Improved Word Embeddings},
   Author                   = {Lu, Ang and Wang, Weiran and Bansal, Mohit and Gimpel, Kevin and Livescu, Karen},
-  Booktitle                = {Proc. of NAACL},
+  Booktitle                = NAACL,
   Year                     = {2015}
 }
 
 @InProceedings{LWBGL15c,
   Title                    = {Deep Multilingual Correlation for Improved Word Embeddings},
   Author                   = {Lu, Ang and Wang, Weiran and Bansal, Mohit and Gimpel, Kevin and Livescu, Karen},
-  Booktitle                = {Proc. of NAACL},
+  Booktitle                = NAACL,
   Year                     = {2015}
 }
 
@@ -2426,7 +2457,7 @@ Notes: 1) Brain data is not infalliable -},
  Mohit Bansal and
  Kevin Gimpel and
  Karen Livescu},
-  Booktitle                = {{NAACL}-{HLT}},
+  Booktitle                = {NAACL-{HLT}},
   Year                     = {2015},
   Pages                    = {250--256}
 }
@@ -2642,7 +2673,7 @@ Notes: 1) Brain data is not infalliable -},
  Generalized {CCA}},
   Author                   = {Rastogi,Pushpendre and {Van Durme}, Benjamin and
  Arora,Raman},
-  Booktitle                = {Proc. of NAACL},
+  Booktitle                = NAACL,
   Year                     = {2015},
 
   Keywords                 = {mvlsa,multiview lsa,mvppdb}
@@ -2669,7 +2700,7 @@ Notes: 1) Brain data is not infalliable -},
   Author                   = {S{\o}gaard, Anders and Agi\'{c}, \v{Z}eljko and
  Mart\'{i}nez Alonso, H\'{e}ctor and Plank, Barbara
  and Bohnet, Bernd and Johannsen, Anders},
-  Booktitle                = {Proc. of ACL},
+  Booktitle                = ACL,
   Year                     = {2015}
 }
 
@@ -2678,7 +2709,7 @@ Notes: 1) Brain data is not infalliable -},
   Author                   = {S{\o}gaard, Anders and Agi\'{c}, \v{Z}eljko and
  Mart\'{i}nez Alonso, H\'{e}ctor and Plank, Barbara
  and Bohnet, Bernd and Johannsen, Anders},
-  Booktitle                = {Proc. of ACL},
+  Booktitle                = ACL,
   Year                     = {2015}
 }
 
@@ -2703,7 +2734,7 @@ Notes: 1) Brain data is not infalliable -},
  Miles},
   Year                     = {2015},
 
-  Booktitle                = {NAACL},
+  Booktitle                = NAACL,
   Owner                    = {penghaoruo},
   Timestamp                = {2016.10.08}
 }
@@ -2711,19 +2742,11 @@ Notes: 1) Brain data is not infalliable -},
 @InProceedings{ShwartzDa15,
   Title                    = {{Adding Context to Semantic Data-Driven Paraphrasing}},
   Author                   = {Shwartz, Vered and Dagan, Ido},
-  Booktitle                = {Proceedings of *SEM 2016},
+  Booktitle                = *SEM,
   Year                     = {2015},
 
   Address                  = {Berlin, Germany},
-  Number                   = {2015},
   Pages                    = {108--113},
-
-  Annote                   = {Idea : Existing inference datasets mostly have out-of -context or labels, or if in context, have labels that are very coarse-grained (like similarity or relatedness). However, inference is a task that should typically be performed in context due to sense issues. The authors thus propose a method that can add context and context sensitive annotations to an existing out-of-context dataset (PPDB in this case)
-Method : The authors start from PPDB annotated entailment relationships (PPDB 2.0) - specifically they pick those phrase pairs that have been manually labelled by turkers, as opposed to phrase pairs that have been automatically labeled using a classifier. After pruning trivial pairs away, they go to a large corpus (Wikinews) and extract pairs of sentences (sx,sy) for each phrase pair (x,y) such that x occurs in sx and y occurs in sy. 
-These sentence pairs are then taken to MTurk and 5 annotations per sentence pairs are obtained - this is the final context sensitive dataset.
-Analysis and experiments: The analysis show a confusion matrix of how relations are transformed when context is added. The authors perform simple supervised entailment experiments using 1) context insensitive and 2) context sensitive features trained using a logit classifier. The context insensitive features are the PPDB features, and the context sensitive features are PPDB features + 3 addtional features that capture phrase-context and context-context similarity. It is shown that 2) outperforms 1) showing that context infromation is desirable and helpful.
-Link to dataset : http://u.cs.biu.ac.il/{\~{}}havivv/resources/context{\_}ppdb{\_}fine{\_}human.zip},
-  File                     = {:Users/yogarshi/Documents/Papers/Shwartz, Dagan{\_}2015.pdf:pdf}
 }
 
 @InProceedings{SLDG15,
@@ -2743,21 +2766,21 @@ Link to dataset : http://u.cs.biu.ac.il/{\~{}}havivv/resources/context{\_}ppdb{\
 @InProceedings{SLLS15,
   Title                    = {Learning crosslingual word embeddings via matrix co-factorization},
   Author                   = {T. Shi and Z. Liu and Y. Liu and M. Sun},
-  Booktitle                = {Proceedings of ACL},
+  Booktitle                = ACL,
   Year                     = {2015}
 }
 
 @InProceedings{SLMJ15,
   Title                    = {Evaluation methods for unsupervised word embeddings},
   Author                   = {Schnabel, Tobias and Labutov, Igor and Mimno, David and Joachims, Thorsten},
-  Booktitle                = {Proc. of EMNLP},
+  Booktitle                = EMNLP,
   Year                     = {2015}
 }
 
 @InProceedings{SLMJ15a,
   Title                    = {Evaluation methods for unsupervised word embeddings},
   Author                   = {Schnabel, Tobias and Labutov, Igor and Mimno, David and Joachims, Thorsten},
-  Booktitle                = {Proc. of EMNLP},
+  Booktitle                = EMNLP,
   Year                     = {2015}
 }
 
@@ -2770,22 +2793,6 @@ Link to dataset : http://u.cs.biu.ac.il/{\~{}}havivv/resources/context{\_}ppdb{\
   Url                      = {https://www.ijcai.org/Proceedings/15/Papers/192.pdf}
 }
 
-@InProceedings{SongRo15,
-  Title                    = {Unsupervised Sparse Vector Densification for Short Text Similarity},
-  Author                   = {Yangqiu Song and Dan Roth},
-  Booktitle                = {{NAACL}--{HLT}},
-  Year                     = {2015},
-  Pages                    = {1275--1280}
-}
-
-@InProceedings{SongRo15a,
-  Title                    = {Unsupervised Sparse Vector Densification for Short Text Similarity},
-  Author                   = {Yangqiu Song and
- Dan Roth},
-  Booktitle                = {{NAACL}-{HLT}},
-  Year                     = {2015},
-  Pages                    = {1275--1280}
-}
 
 @InProceedings{SoyerStAi15,
   Title                    = {Leveraging monolingual data for crosslingual compositional word representations},
@@ -2836,14 +2843,14 @@ Link to dataset : http://u.cs.biu.ac.il/{\~{}}havivv/resources/context{\_}ppdb{\
 @InProceedings{TFLLD15,
   Title                    = {Evaluation of Word Vector Representations by Subspace Alignment},
   Author                   = {Tsvetkov, Yulia and Faruqui, Manaal and Ling, Wang and Lample, Guillaume and Dyer, Chris},
-  Booktitle                = {Proc. of EMNLP},
+  Booktitle                = EMNLP,
   Year                     = {2015}
 }
 
 @InProceedings{TFLLD15a,
   Title                    = {Evaluation of Word Vector Representations by Subspace Alignment},
   Author                   = {Tsvetkov, Yulia and Faruqui, Manaal and Ling, Wang and Lample, Guillaume and Dyer, Chris},
-  Booktitle                = {Proc. of EMNLP},
+  Booktitle                = EMNLP,
   Year                     = {2015}
 }
 
@@ -2853,7 +2860,7 @@ Link to dataset : http://u.cs.biu.ac.il/{\~{}}havivv/resources/context{\_}ppdb{\
   Author                   = {Ivan Titov and
  Ehsan Khoddam},
   Booktitle                = {Proceedings of the 2015 Conference of the North American Chapter
- of the Association for Computational Linguistics: Human Language Technologies, {NAACL} {HLT} 2015},
+ of the Association for Computational Linguistics: Human Language Technologies, NAACL {HLT} 2015},
   Year                     = {2015},
   Pages                    = {1--10}
 }
@@ -2861,7 +2868,7 @@ Link to dataset : http://u.cs.biu.ac.il/{\~{}}havivv/resources/context{\_}ppdb{\
 @InProceedings{TitovKh15a,
   Title                    = {Unsupervised Induction of Semantic Roles within a Reconstruction-Error Minimization Framework},
   Author                   = {Titov, I. and Khoddam, E.},
-  Booktitle                = {NAACL},
+  Booktitle                = NAACL,
   Year                     = {2015}
 }
 
@@ -2953,21 +2960,21 @@ Link to dataset : http://u.cs.biu.ac.il/{\~{}}havivv/resources/context{\_}ppdb{\
 @InProceedings{VulicMo15,
   Title                    = {Bilingual word embeddings from non-parallel document-aligned data applied to bilingual lexicon induction},
   Author                   = {I. Vuli\'{c} and M.-F. Moens},
-  Booktitle                = {Proceedings of ACL},
+  Booktitle                = ACL,
   Year                     = {2015}
 }
 
 @InProceedings{VulicMo15a,
   Title                    = {Bilingual Word Embeddings from Non-Parallel Document-Aligned Data Applied to Bilingual Lexicon Induction},
   Author                   = {Vuli\'{c}, Ivan and Moens, Marie-Francine},
-  Booktitle                = {Proc. of ACL},
+  Booktitle                = ACL,
   Year                     = {2015}
 }
 
 @InProceedings{VulicMo15b,
   Title                    = {Bilingual Word Embeddings from Non-Parallel Document-Aligned Data Applied to Bilingual Lexicon Induction},
   Author                   = {Vuli\'{c}, Ivan and Moens, Marie-Francine},
-  Booktitle                = {Proc. of ACL},
+  Booktitle                = ACL,
   Year                     = {2015}
 }
 
@@ -3011,7 +3018,7 @@ Link to dataset : http://u.cs.biu.ac.il/{\~{}}havivv/resources/context{\_}ppdb{\
  Coherence Model},
   Author                   = {Wolfe, Travis and Dredze, Mark and {Van Durme},
  Benjamin},
-  Booktitle                = {NAACL},
+  Booktitle                = NAACL,
   Year                     = {2015},
 
   Owner                    = {penghaoruo},
@@ -3023,7 +3030,7 @@ Link to dataset : http://u.cs.biu.ac.il/{\~{}}havivv/resources/context{\_}ppdb{\
  Coherence Model},
   Author                   = {Wolfe, Travis and Dredze, Mark and Van Durme,
  Benjamin},
-  Booktitle                = {NAACL},
+  Booktitle                = NAACL,
   Year                     = {2015},
 
   Owner                    = {penghaoruo},
@@ -3160,7 +3167,7 @@ Link to dataset : http://u.cs.biu.ac.il/{\~{}}havivv/resources/context{\_}ppdb{\
 @InProceedings{ZhaoLiSu15,
   Title                    = {Phrase Type Sensitive Tensor Indexing Model for Semantic Composition},
   Author                   = {Yu Zhao and Zhiyuan Liu and Maosong Sun},
-  Booktitle                = {AAAI},
+  Booktitle                = AAAI,
   Year                     = {2015}
 }
 
@@ -3381,14 +3388,14 @@ and Manning, D. Christopher},
 @InProceedings{BammanDySm14,
   Title                    = {Distributed Representations of Situated Language},
   Author                   = {David Bamman and Chris Dyer and Noah A. Smith},
-  Booktitle                = {Proc. of ACL},
+  Booktitle                = ACL,
   Year                     = {2014}
 }
 
 @InProceedings{BammanDySm14a,
   Title                    = {Distributed Representations of Situated Language},
   Author                   = {David Bamman and Chris Dyer and Noah A. Smith},
-  Booktitle                = {Proc. of ACL},
+  Booktitle                = ACL,
   Year                     = {2014}
 }
 
@@ -3412,14 +3419,14 @@ and Manning, D. Christopher},
 @InProceedings{BansalGiLi14,
   Title                    = {Tailoring Continuous Word Representations for Dependency Parsing},
   Author                   = {Bansal, Mohit and Gimpel, Kevin and Livescu, Karen},
-  Booktitle                = {Proc. of ACL},
+  Booktitle                = ACL,
   Year                     = {2014}
 }
 
 @InProceedings{BansalGiLi14a,
   Title                    = {Tailoring Continuous Word Representations for Dependency Parsing},
   Author                   = {Bansal, Mohit and Gimpel, Kevin and Livescu, Karen},
-  Booktitle                = {Proc. of ACL},
+  Booktitle                = ACL,
   Year                     = {2014}
 }
 
@@ -3617,14 +3624,14 @@ and Manning, D. Christopher},
 @InProceedings{FaruquiDy14a,
   Title                    = {Improving Vector Space Word Representations Using Multilingual Correlation},
   Author                   = {Faruqui, Manaal and Dyer, Chris},
-  Booktitle                = {Proc. of EACL},
+  Booktitle                = EACL,
   Year                     = {2014}
 }
 
 @InProceedings{FaruquiDy14b,
   Title                    = {Improving Vector Space Word Representations Using Multilingual Correlation},
   Author                   = {Faruqui, Manaal and Dyer, Chris},
-  Booktitle                = {Proc. of EACL},
+  Booktitle                = EACL,
   Year                     = {2014}
 }
 
@@ -3683,7 +3690,7 @@ and Manning, D. Christopher},
   Title                    = {Learning Semantic Hierarchies via Word Embeddings},
   Author                   = {Fu, Ruiji and Guo, Jiang and Qin, Bing and Che,
  Wanxiang and Wang, Haifeng and Liu, Ting},
-  Booktitle                = {Proc. of ACL},
+  Booktitle                = ACL,
   Year                     = {2014}
 }
 
@@ -3723,14 +3730,14 @@ and Manning, D. Christopher},
 @InProceedings{GCWL14,
   Title                    = {Revisiting embedding features for simple semi-supervised learning},
   Author                   = {Guo, Jiang and Che, Wanxiang and Wang, Haifeng and Liu, Ting},
-  Booktitle                = {Proc. of EMNLP},
+  Booktitle                = EMNLP,
   Year                     = {2014}
 }
 
 @InProceedings{GCWL14a,
   Title                    = {Revisiting embedding features for simple semi-supervised learning},
   Author                   = {Guo, Jiang and Che, Wanxiang and Wang, Haifeng and Liu, Ting},
-  Booktitle                = {Proc. of EMNLP},
+  Booktitle                = EMNLP,
   Year                     = {2014}
 }
 
@@ -3760,7 +3767,7 @@ and Manning, D. Christopher},
 @Article{GoldbergSaSa14,
   Title                    = {{A Tabular Method for Dynamic Oracles in Transition-Based Parsing}},
   Author                   = {Goldberg, Yoav and Sartorio, Francesco and Satta, Giorgio},
-  Journal                  = {Proceedings of ACL},
+  Journal                  = ACL,
   Year                     = {2014},
   Pages                    = {119--130},
   Volume                   = {2},
@@ -3870,21 +3877,21 @@ and Manning, D. Christopher},
 @InProceedings{HermannBl14a,
   Title                    = {{Multilingual Models for Compositional Distributional Semantics}},
   Author                   = {Hermann, Karl Moritz and Blunsom, Phil},
-  Booktitle                = {Proc. of ACL},
+  Booktitle                = ACL,
   Year                     = {2014}
 }
 
 @InProceedings{HermannBl14b,
   Title                    = {{Multilingual Models for Compositional Distributional Semantics}},
   Author                   = {Hermann, Karl Moritz and Blunsom, Phil},
-  Booktitle                = {Proc. of ACL},
+  Booktitle                = ACL,
   Year                     = {2014}
 }
 
 @InProceedings{HermannBl14c,
   Title                    = {{Multilingual Models for Compositional Distributed Semantics}},
   Author                   = {Hermann, Karl Moritz and Blunsom, Phil},
-  Booktitle                = {Proc. of ACL},
+  Booktitle                = ACL,
   Year                     = {2014},
 
   Abstract                 = {We present a novel technique for learn- ing semantic representations, which ex- tends the distributional hypothesis to mul- tilingual data and joint-space embeddings. Our models leverage parallel data and learn to strongly align the embeddings of semantically equivalent sentences, while maintaining sufficient distance between those of dissimilar sentences. The mod- els do not rely on word alignments or any syntactic information and are success- fully applied to a number of diverse lan- guages. We extend our approach to learn semantic representations at the document level, too. We evaluate these models on two cross-lingual document classification tasks, outperforming the prior state of the art. Through qualitative analysis and the study of pivoting effects we demonstrate that our representations are semantically plausible and can capture semantic rela- tionships across languages without paral- lel data. 1},
@@ -4215,38 +4222,15 @@ Y. Artzi},
 @InProceedings{LevyGo14a,
   Title                    = {Linguistic Regularities in Sparse and Explicit Word Representations},
   Author                   = {Levy, Omer and Goldberg, Yoav},
-  Booktitle                = {Proc. of CoNLL},
+  Booktitle                = CoNLL,
   Year                     = {2014}
 }
 
 @InProceedings{LevyGo14b,
-  Title                    = {Linguistic Regularities in Sparse and Explicit Word Representations},
+  Title                    = {{Dependency-Based Word Embeddings}},
   Author                   = {Levy, Omer and Goldberg, Yoav},
-  Booktitle                = {Proc. of CoNLL},
+  Booktitle                = ACL,
   Year                     = {2014}
-}
-
-@InProceedings{LevyGo14c,
-  Title                    = {Dependency-Based Word Embeddings},
-  Author                   = {Levy, Omer and Goldberg, Yoav},
-  Booktitle                = {Proc. of ACL},
-  Year                     = {2014}
-}
-
-@InProceedings{LevyGo14d,
-  Title                    = {Dependencybased word embeddings},
-  Author                   = {Levy, O. and Goldberg, Y.},
-  Booktitle                = {ACL},
-  Year                     = {2014}
-}
-
-@InProceedings{LevyGo14e,
-  Title                    = {Dependencybased word embeddings},
-  Author                   = {Levy, Omer and Goldberg, Yoav},
-  Booktitle                = {Proceedings of the 52nd Annual Meeting of the Association for Computational Linguistics},
-  Year                     = {2014},
-  Pages                    = {302--308},
-  Volume                   = {2}
 }
 
 @InProceedings{LJHL14,
@@ -4363,7 +4347,7 @@ France, June 18-20, 2014. Proceedings},
 @InProceedings{MonroeGrMa14,
   Title                    = {Word Segmentation of Informal Arabic with Domain Adaptation},
   Author                   = {Monroe, Will and Green, Spence and Manning, Christopher D.},
-  Booktitle                = {Proc. of ACL},
+  Booktitle                = ACL,
   Year                     = {2014}
 }
 
@@ -4439,21 +4423,21 @@ France, June 18-20, 2014. Proceedings},
 @InProceedings{NSPM14,
   Title                    = {Efficient Non-parametric Estimation of Multiple Embeddings per Word in Vector Space},
   Author                   = {Neelakantan, Arvind and Shankar, Jeevan and Passos, Alexandre and McCallum, Andrew},
-  Booktitle                = {Proc. of EMNLP},
+  Booktitle                = EMNLP,
   Year                     = {2014}
 }
 
 @InProceedings{NSPM14a,
   Title                    = {Efficient Non-parametric Estimation of Multiple Embeddings per Word in Vector Space},
   Author                   = {Neelakantan, Arvind and Shankar, Jeevan and Passos, Alexandre and McCallum, Andrew},
-  Booktitle                = {Proc. of EMNLP},
+  Booktitle                = EMNLP,
   Year                     = {2014}
 }
 
 @InProceedings{OTDFD14,
   Title                    = {{Learning Scripts as Hidden Markov Models}},
   Author                   = {John Walker Orr and Prasad Tadepalli and Janardhan Rao Doppa and Xiaoli Fern and Thomas G. Dietterich},
-  Booktitle                = {Proceedings of the Twenty-Eighth {AAAI} Conference on Artificial Intelligence},
+  Booktitle                = {Proceedings of the Twenty-Eighth AAAI Conference on Artificial Intelligence},
   Year                     = {2014},
   Pages                    = {1565--1571}
 }
@@ -4536,7 +4520,7 @@ and McCallum, Andrew},
 @InProceedings{PenningtonSoMa14c,
   Title                    = {{GloVe: Global Vectors for Word Representation}},
   Author                   = {Pennington, Jeffrey and Socher, Richard and Manning, Christopher D},
-  Booktitle                = {Proc. of EMNLP},
+  Booktitle                = EMNLP,
   Year                     = {2014},
 
   Abstract                 = {Recent methods for learning vector space representations of words have succeeded in capturing fine-grained semantic and syntactic regularities using vector arith- metic, but the origin of these regularities has remained opaque. We analyze and make explicit the model properties needed for such regularities to emerge in word vectors. The result is a new global log- bilinear regression model that combines the advantages of the two major model families in the literature: global matrix factorization and local context window methods. Our model efficiently leverages statistical information by training only on the nonzero elements in a word-word co- occurrence matrix, rather than on the en- tire sparse matrix or on individual context windows in a large corpus. On a recent word analogy task our model obtains 75{\%} accuracy, an improvement of 11{\%} over Mikolov et al. (2013). It also outperforms related word vector models on similarity tasks and named entity recognition.}
@@ -4554,14 +4538,14 @@ and McCallum, Andrew},
 @InProceedings{PenningtonSoMa14e,
   Title                    = {GloVe: Global Vectors for Word Representation},
   Author                   = {Pennington, Jeffrey and Socher, Richard and Manning, Christopher D.},
-  Booktitle                = {Proc. of EMNLP},
+  Booktitle                = EMNLP,
   Year                     = {2014}
 }
 
 @InProceedings{PenningtonSoMa14f,
   Title                    = {GloVe: Global Vectors for Word Representation},
   Author                   = {Pennington, Jeffrey and Socher, Richard and Manning, Christopher D.},
-  Booktitle                = {Proc. of EMNLP},
+  Booktitle                = EMNLP,
   Year                     = {2014}
 }
 
@@ -4742,14 +4726,14 @@ and McCallum, Andrew},
 @InProceedings{SHTQ14,
   Title                    = {Graph-based Semi-Supervised Learning of Translation Models from Monolingual Data},
   Author                   = {Saluja, Avneesh and Hassan, Hany and Toutanova, Kristina and Quirk, Chris},
-  Booktitle                = {Proc. of ACL},
+  Booktitle                = ACL,
   Year                     = {2014}
 }
 
 @InProceedings{SHTQ14a,
   Title                    = {Graph-based Semi-Supervised Learning of Translation Models from Monolingual Data},
   Author                   = {Saluja, Avneesh and Hassan, Hany and Toutanova, Kristina and Quirk, Chris},
-  Booktitle                = {Proc. of ACL},
+  Booktitle                = ACL,
   Year                     = {2014}
 }
 
@@ -4773,31 +4757,6 @@ and McCallum, Andrew},
   Pages-omit               = {21--30},
   Publisher-omit           = {Association for Computational Linguistics},
   Url-omit                 = {http://aclweb.org/anthology/E14-3003}
-}
-
-@InProceedings{SongRo14,
-  Title                    = {On dataless hierarchical text classification},
-  Author                   = {Song, Y. and Roth, D.},
-  Booktitle                = {Proceedings of the Conference on Artificial Intelligence (AAAI)},
-  Year                     = {2014}
-}
-
-@InProceedings{SongRo14a,
-  Title                    = {On Dataless Hierarchical Text Classification},
-  Author                   = {Yangqiu Song and
- Dan Roth},
-  Booktitle                = {AAAI},
-  Year                     = {2014},
-  Pages                    = {1579--1585}
-}
-
-@InProceedings{SongRo14b,
-  Title                    = {On Dataless Hierarchical Text Classification },
-  Author                   = {Yangqiu Song and
- Dan Roth},
-  Booktitle                = {AAAI},
-  Year                     = {2014},
-  Pages                    = {1579--1585}
 }
 
 @InProceedings{SutskeverViLe14,
@@ -4831,7 +4790,7 @@ and McCallum, Andrew},
   Booktitle                = {Proceedings of AAAI Conference on Artificial Intelligence},
   Year                     = {2014},
 
-  Publisher-omit           = {AAAI}
+  Publisher-omit           = AAAI
 }
 
 @InProceedings{TandondeWe14b,
@@ -4840,7 +4799,7 @@ and McCallum, Andrew},
   Booktitle                = {Proceedings of AAAI Conference on Artificial Intelligence},
   Year                     = {2014},
 
-  Publisher-omit           = {AAAI}
+  Publisher-omit           = AAAI
 }
 
 @InProceedings{TandondeWe14c,
@@ -4848,7 +4807,7 @@ and McCallum, Andrew},
   Author                   = {N. Tandon and G. {de Melo} and G. Weikum},
   Booktitle                = {Proceedings of AAAI Conference on Artificial Intelligence},
   Year                     = {2014},
-  Publisher                = {AAAI}
+  Publisher                = AAAI
 }
 
 @Article{TrivediMcSh14,
@@ -4887,7 +4846,7 @@ and McCallum, Andrew},
   Author                   = {Josep Valls{-}Vargas and
  Jichen Zhu and
  Santiago Onta{\~{n}}{\'{o}}n},
-  Booktitle                = {Proceedings of the Tenth {AAAI} Conference on Artificial Intelligence
+  Booktitle                = {Proceedings of the Tenth AAAI Conference on Artificial Intelligence
  and Interactive Digital Entertainment, {AIIDE} 2014},
   Year                     = {2014},
   Pages                    = {188--194}
@@ -5136,14 +5095,14 @@ Weakly Supervised Learning},
 @InProceedings{BondFo13,
   Title                    = {Linking and Extending an Open Multilingual Wordnet},
   Author                   = {Bond, Francis and Foster, Ryan},
-  Booktitle                = {Proc. of ACL},
+  Booktitle                = ACL,
   Year                     = {2013}
 }
 
 @InProceedings{BondFo13a,
   Title                    = {Linking and Extending an Open Multilingual Wordnet},
   Author                   = {Bond, Francis and Foster, Ryan},
-  Booktitle                = {Proc. of ACL},
+  Booktitle                = ACL,
   Year                     = {2013}
 }
 
@@ -5257,14 +5216,14 @@ Weakly Supervised Learning},
 @InProceedings{ChangYiMe13,
   Title                    = {Multi-Relational Latent Semantic Analysis},
   Author                   = {Chang, Kai-Wei and Yih, Wen-tau and Meek, Christopher},
-  Booktitle                = {Proc. of EMNLP},
+  Booktitle                = EMNLP,
   Year                     = {2013}
 }
 
 @InProceedings{ChangYiMe13a,
   Title                    = {Multi-Relational Latent Semantic Analysis},
   Author                   = {Chang, Kai-Wei and Yih, Wen-tau and Meek, Christopher},
-  Booktitle                = {Proc. of EMNLP},
+  Booktitle                = EMNLP,
   Year                     = {2013}
 }
 
@@ -5347,7 +5306,7 @@ Weakly Supervised Learning},
 @InProceedings{DinuPhBa13,
   Title                    = {DISSECT - DIStributional SEmantics Composition Toolkit},
   Author                   = {Dinu, Georgiana and Pham, Nghia The and Baroni, Marco},
-  Booktitle                = {Proc. of ACL},
+  Booktitle                = ACL,
   Year                     = {2013}
 }
 
@@ -5363,15 +5322,6 @@ Weakly Supervised Learning},
   ISBN                     = {9781577356158},
   Keywords                 = {Technical Track},
   Mendeley-groups          = {Structured Prediction}
-}
-
-@Article{DRSZ13,
-  Title                    = {Recognizing textual entailment: Models and applications},
-  Author                   = {Dagan, Ido and Roth, Dan and Sammons, Mark and Zanzotto, Fabio Massimo},
-  Journal                  = {Synthesis Lectures on Human Language Technologies},
-  Year                     = {2013},
-
-  Publisher                = {Morgan \& Claypool Publishers}
 }
 
 @Book{DryerHa13,
@@ -5483,28 +5433,28 @@ and Klein, Dan},
   Title                    = {A simple, fast, and effective reparameterization of
  IBM Model 2},
   Author                   = {Dyer, Chris and Chahuneau, Victor and Smith, Noah A},
-  Booktitle                = {Proc. of NAACL},
+  Booktitle                = NAACL,
   Year                     = {2013}
 }
 
 @InProceedings{DyerChSm13a,
   Title                    = {A simple, fast, and effective reparameterization of IBM Model 2},
   Author                   = {Dyer, Chris and Chahuneau, Victor and Smith, Noah A},
-  Booktitle                = {Proc. of NAACL},
+  Booktitle                = NAACL,
   Year                     = {2013}
 }
 
 @InProceedings{DyerChSm13b,
   Title                    = {A Simple, Fast, and Effective Reparameterization of {IBM~Model~2}},
   Author                   = {Chris Dyer and Victor Chahuneau and Noah A. Smith},
-  Booktitle                = {Proc. of NAACL},
+  Booktitle                = NAACL,
   Year                     = {2013}
 }
 
 @InProceedings{DyerChSm13c,
   Title                    = {A Simple, Fast, and Effective Reparameterization of {IBM~Model~2}},
   Author                   = {Chris Dyer and Victor Chahuneau and Noah A. Smith},
-  Booktitle                = {Proc. of NAACL},
+  Booktitle                = NAACL,
   Year                     = {2013}
 }
 
@@ -5528,57 +5478,29 @@ and Klein, Dan},
 @InProceedings{FaruquiDy13,
   Title                    = {An Information Theoretic Approach to Bilingual Word Clustering},
   Author                   = {Faruqui, Manaal and Dyer, Chris},
-  Booktitle                = {Proc. of ACL},
+  Booktitle                = ACL,
   Year                     = {2013}
 }
 
 @InProceedings{FaruquiDy13a,
   Title                    = {An Information Theoretic Approach to Bilingual Word Clustering},
   Author                   = {Faruqui, Manaal and Dyer, Chris},
-  Booktitle                = {Proc. of ACL},
+  Booktitle                = ACL,
   Year                     = {2013}
 }
 
 @InProceedings{GanitkevitchVaCa13,
-  Title                    = {{PPDB}: The Paraphrase Database},
+  Title                    = {{PPDB: The Paraphrase Database}},
   Author                   = {Ganitkevitch, Juri and {Van Durme}, Benjamin and
  Callison-Burch, Chris},
-  Booktitle                = {Proc. of NAACL},
+  Booktitle                = NAACL,
   Year                     = {2013}
-}
-
-@InProceedings{GanitkevitchVaCa13a,
-  Title                    = {{PPDB}: The Paraphrase Database},
-  Author                   = {Ganitkevitch, Juri and {Van Durme}, Benjamin and
- Callison-Burch, Chris},
-  Booktitle                = {Proc. of NAACL},
-  Year                     = {2013}
-}
-
-@Article{GanitkevitchVaCa13b,
-  Title                    = {{PPDB : The Paraphrase Database}},
-  Author                   = {Ganitkevitch, Juri and {Van Durme}, Benjamin and Callison-Burch, Chris},
-  Journal                  = {Proceedings of NAACL-HLT 2013},
-  Year                     = {2013},
-  Number                   = {June},
-  Pages                    = {758----764},
-
-  Abstract                 = {We present the 1.0 release of our para- phrase database, PPDB. Its English portion, PPDB:Eng, contains over 220 million para- phrase pairs, consisting of 73 million phrasal and 8 million lexical paraphrases, as well as 140 million paraphrase patterns, which cap- ture many meaning-preserving syntactic trans- formations. The paraphrases are extracted from bilingual parallel corpora totaling over 100 million sentence pairs and over 2 billion English words. We also release PPDB:Spa, a collection of 196 million Spanish paraphrases. Each paraphrase pair in PPDB contains a set of associated scores, including paraphrase probabilities derived from the bitext data and a variety of monolingual distributional similar- ity scores computed from the Google n-grams and the Annotated Gigaword corpus. Our re- lease includes pruning tools that allowusers to determine their own precision/recall tradeoff.},
-  File                     = {:Users/yogarshi/Documents/Papers/Ganitkevitch, Van Durme, Callison-Burch{\_}2013.pdf:pdf},
-  ISBN                     = {9781937284473}
 }
 
 @InProceedings{GJLSSH13,
-  Title                    = {A Structured Distributional Semantic Model for Event Co-reference.},
-  Author                   = {Goyal, K. and Jauhar, S. K. and Li, H. and Sachan, M. and Srivastava, S. and Hovy, E.},
-  Booktitle                = {ACL},
-  Year                     = {2013}
-}
-
-@InProceedings{GJLSSH13a,
-  Title                    = {A Structured Distributional Semantic Model for Event Co-reference.},
+  Title                    = {A Structured Distributional Semantic Model for Event Co-reference},
   Author                   = {Goyal, Kartik and Jauhar, Sujay Kumar and Li, Huiying and Sachan, Mrinmaya and Srivastava, Shashank and Hovy, Eduard H},
-  Booktitle                = {ACL (2)},
+  Booktitle                = {ACL},
   Year                     = {2013},
   Pages                    = {467--473}
 }
@@ -5630,18 +5552,15 @@ and Klein, Dan},
 }
 
 @InProceedings{HHGDAH13,
-  Title                    = {Learning deep structured semantic models for web search using clickthrough
- data},
-  Author                   = {Po{-}Sen Huang and
- Xiaodong He and
- Jianfeng Gao and
- Li Deng and
- Alex Acero and
- Larry P. Heck},
-  Booktitle                = {Proceedings of the 22nd {ACM} International Conference on Information and Knowledge Management,
- {CIKM} 2013},
-  Year                     = {2013},
-  Pages                    = {2333--2338}
+  Title =	 {Learning deep structured semantic models for web
+                  search using clickthrough data},
+  Author =	 {Po{-}Sen Huang and Xiaodong He and Jianfeng Gao and
+                  Li Deng and Alex Acero and Larry P. Heck},
+  Booktitle =	 {Proceedings of the 22nd {ACM} International
+                  Conference on Information and Knowledge Management,
+                  {CIKM} 2013},
+  Year =	 {2013},
+  Pages =	 {2333--2338}
 }
 
 @InProceedings{HLLZZW13,
@@ -5839,14 +5758,14 @@ and Strube, Michael},
 @InProceedings{KalchbrennerBl13,
   Title                    = {Recurrent Continuous Translation Models},
   Author                   = {Kalchbrenner, Nal and Blunsom, Phil},
-  Booktitle                = {Proc. of EMNLP},
+  Booktitle                = EMNLP,
   Year                     = {2013}
 }
 
 @InProceedings{KalchbrennerBl13a,
   Title                    = {Recurrent Continuous Translation Models},
   Author                   = {Kalchbrenner, Nal and Blunsom, Phil},
-  Booktitle                = {Proc. of EMNLP},
+  Booktitle                = EMNLP,
   Year                     = {2013}
 }
 
@@ -5929,14 +5848,14 @@ and Klein, D.},
 @InProceedings{LazaridouVeBa13,
   Title                    = {Fish Transporters and Miracle Homes: How Compositional Distributional Semantics can Help {NP} Parsing},
   Author                   = {Lazaridou, Angeliki and Vecchi, Eva Maria and Baroni, Marco},
-  Booktitle                = {Proc. of EMNLP},
+  Booktitle                = EMNLP,
   Year                     = {2013}
 }
 
 @InProceedings{LazaridouVeBa13a,
   Title                    = {Fish Transporters and Miracle Homes: How Compositional Distributional Semantics can Help {NP} Parsing},
   Author                   = {Lazaridou, Angeliki and Vecchi, Eva Maria and Baroni, Marco},
-  Booktitle                = {Proc. of EMNLP},
+  Booktitle                = EMNLP,
   Year                     = {2013}
 }
 
@@ -6034,7 +5953,7 @@ and Klein, D.},
 @InProceedings{MartinsAlSm13,
   Title                    = {{Turning on the Turbo: Fast Third-Order Non-Projective Turbo Parsers}},
   Author                   = {Martins, Andre and Almeida, Miguel and Smith, Noah A.},
-  Booktitle                = {Proceedings of ACL},
+  Booktitle                = ACL,
   Year                     = {2013}
 }
 
@@ -6184,7 +6103,7 @@ and Klein, D.},
  and Petrov, Slav and Zhang, Hao and
  T{\"a}ckstr{\"o}m, Oscar and Bedini, Claudia and
  Bertomeu Castell{\'o}, N{\'u}ria and Lee, Jungmee},
-  Booktitle                = {Proc. of ACL},
+  Booktitle                = ACL,
   Year                     = {2013}
 }
 
@@ -6197,7 +6116,7 @@ and Klein, D.},
  and Petrov, Slav and Zhang, Hao and
  T{\"a}ckstr{\"o}m, Oscar and Bedini, Claudia and
  Bertomeu Castell{\'o}, N{\'u}ria and Lee, Jungmee},
-  Booktitle                = {Proc. of ACL},
+  Booktitle                = ACL,
   Year                     = {2013}
 }
 
@@ -6268,28 +6187,6 @@ and Klein, D.},
   Booktitle                = {NIPS},
   Year                     = {2013},
   Pages                    = {3111--3119}
-}
-
-@Article{NMMBG13,
-  Title                    = {{Semeval-2013 Task 8: Cross-lingual Textual Entailment for Content Synchronization}},
-  Author                   = {Negri, Matteo and Marchetti, Alessandro and Mehdad, Yashar and Bentivogli, Luisa and Giampiccolo, Danilo},
-  Year                     = {2013},
-
-  File                     = {:Users/yogarshi/Documents/Papers/clte{\_}sharedtask{\_}2012.pdf:pdf}
-}
-
-@Article{NMMBG13a,
-  Title                    = {{Semeval-2013 Task 8: Cross-lingual Textual Entailment for Content Synchronization}},
-  Author                   = {Negri, Matteo and Marchetti, Alessandro and Mehdad, Yashar and Bentivogli, Luisa and Giampiccolo, Danilo},
-  Journal                  = {SemEval},
-  Year                     = {2013},
-  Number                   = {SemEval},
-  Pages                    = {25--33},
-  Volume                   = {2},
-
-  File                     = {:Users/yogarshi/Documents/Papers/Negri et al.{\_}2013.pdf:pdf},
-  Mendeley-groups          = {Entailment/CLTE},
-  Url                      = {http://www.aclweb.org/anthology/S13-2005}
 }
 
 @Article{PaulFiSu13,
@@ -6473,7 +6370,7 @@ Andrew Y. Ng},
 @InProceedings{SPWCMNP13,
   Title                    = {Recursive Deep Models for Semantic Compositionality Over a Sentiment Treebank},
   Author                   = {Socher, Richard and Perelygin, Alex and Wu, Jean and Chuang, Jason and Manning, Christopher D. and Ng, Andrew Y. and Potts, Christopher},
-  Booktitle                = {Proc. of EMNLP},
+  Booktitle                = EMNLP,
   Year                     = {2013},
 
   Location-omit            = {Seattle, WA}
@@ -6482,7 +6379,7 @@ Andrew Y. Ng},
 @InProceedings{SPWCMNP13a,
   Title                    = {Recursive Deep Models for Semantic Compositionality Over a Sentiment Treebank},
   Author                   = {Socher, Richard and Perelygin, Alex and Wu, Jean and Chuang, Jason and Manning, Christopher D. and Ng, Andrew Y. and Potts, Christopher},
-  Booktitle                = {Proc. of EMNLP},
+  Booktitle                = EMNLP,
   Year                     = {2013},
 
   Location                 = {Seattle, WA}
@@ -6542,7 +6439,7 @@ Andrew Y. Ng},
   Title                    = {Cross-Lingual Semantic Similarity of Words as the
  Similarity of Their Semantic Word Responses},
   Author                   = {Vuli\'{c}, Ivan and Moens, Marie-Francine},
-  Booktitle                = {Proc. of NAACL},
+  Booktitle                = NAACL,
   Year                     = {2013}
 }
 
@@ -6550,21 +6447,21 @@ Andrew Y. Ng},
   Title                    = {Cross-Lingual Semantic Similarity of Words as the
  Similarity of Their Semantic Word Responses},
   Author                   = {Vuli\'{c}, Ivan and Moens, Marie-Francine},
-  Booktitle                = {Proc. of NAACL},
+  Booktitle                = NAACL,
   Year                     = {2013}
 }
 
 @InProceedings{VulicMo13b,
   Title                    = {A Study on Bootstrapping Bilingual Vector Spaces from Non-Parallel Data (and Nothing Else)},
   Author                   = {Vuli\'{c}, Ivan and Moens, Marie-Francine},
-  Booktitle                = {Proc. of EMNLP},
+  Booktitle                = EMNLP,
   Year                     = {2013}
 }
 
 @InProceedings{VulicMo13c,
   Title                    = {A Study on Bootstrapping Bilingual Vector Spaces from Non-Parallel Data (and Nothing Else)},
   Author                   = {Vuli\'{c}, Ivan and Moens, Marie-Francine},
-  Booktitle                = {Proc. of EMNLP},
+  Booktitle                = EMNLP,
   Year                     = {2013}
 }
 
@@ -6645,14 +6542,14 @@ Convex Optimization},
 @InProceedings{ZSCM13,
   Title                    = {Bilingual Word Embeddings for Phrase-Based Machine Translation},
   Author                   = {Zou, Will Y. and Socher, Richard and Cer, Daniel and Manning, Christopher D.},
-  Booktitle                = {Proc. of EMNLP},
+  Booktitle                = EMNLP,
   Year                     = {2013}
 }
 
 @InProceedings{ZSCM13a,
   Title                    = {Bilingual Word Embeddings for Phrase-Based Machine Translation},
   Author                   = {Zou, Will Y. and Socher, Richard and Cer, Daniel and Manning, Christopher D.},
-  Booktitle                = {Proc. of EMNLP},
+  Booktitle                = EMNLP,
   Year                     = {2013}
 }
 
@@ -6715,14 +6612,14 @@ Convex Optimization},
 @InProceedings{ZYMZM13,
   Title                    = {Combining Heterogeneous Models for Measuring Relational Similarity},
   Author                   = {Zhila, Alisa and Yih, Wen-tau and Meek, Christopher and Zweig, Geoffrey and Mikolov, Tomas},
-  Booktitle                = {Proc. of NAACL},
+  Booktitle                = NAACL,
   Year                     = {2013}
 }
 
 @InProceedings{ZYMZM13a,
   Title                    = {Combining Heterogeneous Models for Measuring Relational Similarity},
   Author                   = {Zhila, Alisa and Yih, Wen-tau and Meek, Christopher and Zweig, Geoffrey and Mikolov, Tomas},
-  Booktitle                = {Proc. of NAACL},
+  Booktitle                = NAACL,
   Year                     = {2013}
 }
 
@@ -6767,28 +6664,28 @@ Convex Optimization},
 @InProceedings{BBBT12,
   Title                    = {Distributional semantics in technicolor},
   Author                   = {Bruni, Elia and Boleda, Gemma and Baroni, Marco and Tran, Nam-Khanh},
-  Booktitle                = {Proc. of ACL},
+  Booktitle                = ACL,
   Year                     = {2012}
 }
 
 @InProceedings{BBBT12a,
   Title                    = {Distributional semantics in technicolor},
   Author                   = {Bruni, Elia and Boleda, Gemma and Baroni, Marco and Tran, Nam-Khanh},
-  Booktitle                = {Proc. of ACL},
+  Booktitle                = ACL,
   Year                     = {2012}
 }
 
 @InProceedings{BBDS12,
   Title                    = {Entailment above the word level in distributional semantics},
   Author                   = {Baroni, Marco and Bernardi, Raffaella and Do, Ngoc-Quynh and Shan, Chung-chieh},
-  Booktitle                = {Proc. of EACL},
+  Booktitle                = EACL,
   Year                     = {2012}
 }
 
 @InProceedings{BBDS12a,
   Title                    = {Entailment above the word level in distributional semantics},
   Author                   = {Baroni, Marco and Bernardi, Raffaella and Do, Ngoc-Quynh and Shan, Chung-chieh},
-  Booktitle                = {Proc. of EACL},
+  Booktitle                = EACL,
   Year                     = {2012}
 }
 
@@ -6958,14 +6855,14 @@ Convex Optimization},
 @InProceedings{DasSm12,
   Title                    = {Graph-Based Lexicon Expansion with Sparsity-Inducing Penalties},
   Author                   = {Das, Dipanjan and Smith, Noah A.},
-  Booktitle                = {Proc. of NAACL},
+  Booktitle                = NAACL,
   Year                     = {2012}
 }
 
 @InProceedings{DasSm12a,
   Title                    = {Graph-Based Lexicon Expansion with Sparsity-Inducing Penalties},
   Author                   = {Das, Dipanjan and Smith, Noah A.},
-  Booktitle                = {Proc. of NAACL},
+  Booktitle                = NAACL,
   Year                     = {2012}
 }
 
@@ -7076,14 +6973,14 @@ Kurt {De Grave}},
 @InProceedings{HSMN12,
   Title                    = {Improving word representations via global context and multiple word prototypes},
   Author                   = {Huang, Eric H and Socher, Richard and Manning, Christopher D and Ng, Andrew Y},
-  Booktitle                = {Proc. of ACL},
+  Booktitle                = ACL,
   Year                     = {2012}
 }
 
 @InProceedings{HSMN12a,
   Title                    = {Improving word representations via global context and multiple word prototypes},
   Author                   = {Huang, Eric H and Socher, Richard and Manning, Christopher D and Ng, Andrew Y},
-  Booktitle                = {Proc. of ACL},
+  Booktitle                = ACL,
   Year                     = {2012}
 }
 
@@ -7097,7 +6994,7 @@ Kurt {De Grave}},
 @InProceedings{HuangRi12,
   Title                    = {Modeling Textual Cohesion for Event Extraction.},
   Author                   = {Huang, R. and Riloff, E.},
-  Booktitle                = {AAAI},
+  Booktitle                = AAAI,
   Year                     = {2012}
 }
 
@@ -7167,14 +7064,14 @@ Kurt {De Grave}},
 @InProceedings{LeAlYv12,
   Title                    = {Continuous Space Translation Models with Neural Networks},
   Author                   = {Le, Hai-Son and Allauzen, Alexandre and Yvon, Fran\c{c}ois},
-  Booktitle                = {Proc. of NAACL},
+  Booktitle                = NAACL,
   Year                     = {2012}
 }
 
 @InProceedings{LeAlYv12a,
   Title                    = {Continuous Space Translation Models with Neural Networks},
   Author                   = {Le, Hai-Son and Allauzen, Alexandre and Yvon, Fran\c{c}ois},
-  Booktitle                = {Proc. of NAACL},
+  Booktitle                = NAACL,
   Year                     = {2012}
 }
 
@@ -7202,19 +7099,12 @@ Kurt {De Grave}},
 }
 
 @InProceedings{LingWe12,
-  Title                    = {Fine-Grained Entity Recognition},
+  Title                    = {{Fine-Grained Entity Recognition}},
   Author                   = {Ling, Xiao and Weld, Daniel S},
   Booktitle                = AAAI,
   Year                     = {2012},
 
   Url                      = {http://aiweb.cs.washington.edu/ai/pubs/ling-aaai12.pdf}
-}
-
-@InProceedings{LingWe12a,
-  Title                    = {Fine-grained entity recognition},
-  Author                   = {Ling, X. and Weld, D.S.},
-  Booktitle                = {Proceedings of the 26th Conference on Artificial Intelligence (AAAI)},
-  Year                     = {2012}
 }
 
 @InCollection{LiOwZh12,
@@ -7366,14 +7256,14 @@ Alexander J. Smola},
 @InProceedings{MnihTe12,
   Title                    = {A fast and simple algorithm for training neural probabilistic language models},
   Author                   = {Mnih, Andriy and Teh, Yee Whye},
-  Booktitle                = {Proc. of ICML},
+  Booktitle                = ICML,
   Year                     = {2012}
 }
 
 @InProceedings{MnihTe12a,
   Title                    = {A fast and simple algorithm for training neural probabilistic language models},
   Author                   = {Mnih, Andriy and Teh, Yee Whye},
-  Booktitle                = {Proc. of ICML},
+  Booktitle                = ICML,
   Year                     = {2012}
 }
 
@@ -7426,14 +7316,24 @@ Alexander J. Smola},
   Timestamp                = {2016.10.08}
 }
 
-@Article{NMMBG12,
-  Title                    = {{Semeval-2012 Task 8: Cross-lingual Textual Entailment for Content Synchronization}},
+@Article{NMMBG13,
+  Title                    = {{Semeval-2013 Task 8: Cross-lingual Textual Entailment for Content Synchronization}},
   Author                   = {Negri, Matteo and Marchetti, Alessandro and Mehdad, Yashar and Bentivogli, Luisa and Giampiccolo, Danilo},
-  Year                     = {2012},
-
-  File                     = {:Users/yogarshi/Documents/Papers/Negri et al.{\_}2012.pdf:pdf},
-  Mendeley-groups          = {Entailment/CLTE}
+  Journal = {Proceedings of the Seventh International Workshop on
+                  Semantic Evaluation (SemEval 2013)},
+  Year                     = {2013},
 }
+
+@Article{NMMBG12,
+  Title = {{Semeval-2012 Task 8: Cross-lingual Textual Entailment for
+                  Content Synchronization}},
+  Author = {Negri, Matteo and Marchetti, Alessandro and Mehdad, Yashar
+                  and Bentivogli, Luisa and Giampiccolo, Danilo},
+  Journal = {Proceedings of the Sixth International Workshop on
+                  Semantic Evaluation (SemEval 2012)},
+		    Year = {2012},
+
+		  }
 
 @Article{NWSMK12,
   Title                    = {{Joint Phrase Alignment and Extraction for Statistical Machine Translation}},
@@ -7518,15 +7418,6 @@ T. Ravindra Babu},
   Year                     = {2012},
   Organization             = {Association for Computational Linguistics},
   Pages                    = {777--789}
-}
-
-@InProceedings{RatinovRo12,
-  Title                    = {Learning-based Multi-Sieve Co-Reference Resolution with Knowledge},
-  Author                   = {L. Ratinov and D. Roth},
-  Booktitle                = {Proceedings of the Conference on Empirical Methods for Natural Language Processing (EMNLP)},
-  Year                     = {2012},
-
-  Url-omit                 = {http://cogcomp.cs.illinois.edu/papers/RatinovRo12.pdf}
 }
 
 @InProceedings{SHPU12,
@@ -7713,21 +7604,21 @@ and Eisner, Jason},
 @InProceedings{TaeckstroemMcUs12,
   Title                    = {Cross-lingual Word Clusters for Direct Transfer of Linguistic Structure},
   Author                   = {Oscar T\"{a}ckstr\"{o}m and Ryan T. McDonald and Jakob Uszkoreit},
-  Booktitle                = {NAACL},
+  Booktitle                = NAACL,
   Year                     = {2012}
 }
 
 @InProceedings{TaeckstroemMcUs12a,
   Title                    = {Cross-lingual Word Clusters for Direct Transfer of Linguistic Structure},
   Author                   = {T{\"a}ckstr{\"o}m, O. and McDonald, R. and Uszkoreit, J.},
-  Booktitle                = {NAACL},
+  Booktitle                = NAACL,
   Year                     = {2012}
 }
 
 @InProceedings{TaeckstroemMcUs12b,
   Title                    = {Cross-lingual Word Clusters for Direct Transfer of Linguistic Structure},
   Author                   = {T{\"a}ckstr{\"o}m, O. and McDonald, R. and Uszkoreit, J.},
-  Booktitle                = {NAACL},
+  Booktitle                = NAACL,
   Year                     = {2012}
 }
 
@@ -7785,28 +7676,28 @@ and Eisner, Jason},
 @InProceedings{YaoVaCa12,
   Title                    = {Expectations of word sense in parallel corpora},
   Author                   = {Yao, Xuchen and Van Durme, Benjamin and Callison-Burch, Chris},
-  Booktitle                = {Proc. of NAACL},
+  Booktitle                = NAACL,
   Year                     = {2012}
 }
 
 @InProceedings{YaoVaCa12a,
   Title                    = {Expectations of word sense in parallel corpora},
   Author                   = {Yao, Xuchen and Van Durme, Benjamin and Callison-Burch, Chris},
-  Booktitle                = {Proc. of NAACL},
+  Booktitle                = NAACL,
   Year                     = {2012}
 }
 
 @InProceedings{YihZwPl12,
   Title                    = {Polarity Inducing Latent Semantic Analysis},
   Author                   = {Yih, Wen-tau and Zweig, Geoffrey and Platt, John C.},
-  Booktitle                = {Proc. of EMNLP},
+  Booktitle                = EMNLP,
   Year                     = {2012}
 }
 
 @InProceedings{YihZwPl12a,
   Title                    = {Polarity Inducing Latent Semantic Analysis},
   Author                   = {Yih, Wen-tau and Zweig, Geoffrey and Platt, John C.},
-  Booktitle                = {Proc. of EMNLP},
+  Booktitle                = EMNLP,
   Year                     = {2012}
 }
 
@@ -7997,28 +7888,28 @@ Eamonn J. Keogh},
 @InProceedings{CohenDaSm11,
   Title                    = {Unsupervised structure prediction with non-parallel multilingual guidance},
   Author                   = {Cohen, Shay B. and Das, Dipanjan and Smith, Noah A.},
-  Booktitle                = {Proc. of EMNLP},
+  Booktitle                = EMNLP,
   Year                     = {2011}
 }
 
 @InProceedings{CohenDaSm11a,
   Title                    = {Unsupervised Structure Prediction with Non-Parallel Multilingual Guidance},
   Author                   = {Shay B. Cohen and Dipanjan Das and Noah A. Smith},
-  Booktitle                = {Proc. of EMNLP},
+  Booktitle                = EMNLP,
   Year                     = {2011}
 }
 
 @InProceedings{CohenDaSm11b,
   Title                    = {Unsupervised structure prediction with non-parallel multilingual guidance},
   Author                   = {Cohen, Shay B. and Das, Dipanjan and Smith, Noah A.},
-  Booktitle                = {Proc. of EMNLP},
+  Booktitle                = EMNLP,
   Year                     = {2011}
 }
 
 @InProceedings{CohenDaSm11c,
   Title                    = {Unsupervised Structure Prediction with Non-Parallel Multilingual Guidance},
   Author                   = {Shay B. Cohen and Dipanjan Das and Noah A. Smith},
-  Booktitle                = {Proc. of EMNLP},
+  Booktitle                = EMNLP,
   Year                     = {2011}
 }
 
@@ -8126,14 +8017,14 @@ Pavel P. Kuksa},
 @InProceedings{DasPe11b,
   Title                    = {Unsupervised Part-of-Speech Tagging with Bilingual Graph-Based Projections},
   Author                   = {Das, Dipanjan and Petrov, Slav},
-  Booktitle                = {Proc. of ACL},
+  Booktitle                = ACL,
   Year                     = {2011}
 }
 
 @InProceedings{DasPe11c,
   Title                    = {Unsupervised Part-of-Speech Tagging with Bilingual Graph-Based Projections},
   Author                   = {Das, Dipanjan and Petrov, Slav},
-  Booktitle                = {Proc. of ACL},
+  Booktitle                = ACL,
   Year                     = {2011}
 }
 
@@ -8172,14 +8063,14 @@ Pavel P. Kuksa},
 @InProceedings{DasSm11b,
   Title                    = {Semi-Supervised Frame-Semantic Parsing for Unknown Predicates},
   Author                   = {Das, Dipanjan and Smith, Noah A.},
-  Booktitle                = {Proc. of ACL},
+  Booktitle                = ACL,
   Year                     = {2011}
 }
 
 @InProceedings{DasSm11c,
   Title                    = {Semi-Supervised Frame-Semantic Parsing for Unknown Predicates},
   Author                   = {Das, Dipanjan and Smith, Noah A.},
-  Booktitle                = {Proc. of ACL},
+  Booktitle                = ACL,
   Year                     = {2011}
 }
 
@@ -8265,7 +8156,7 @@ Results
 @Article{GAGDM11,
   Title                    = {Entity Clustering Across Languages},
   Author                   = {Green, S. and Andrews, N. and Gormley, M.R. and Dredze, M. and Manning, C.D.},
-  Journal                  = {NAACL},
+  Journal                  = NAACL,
   Year                     = {2011},
 
   Pages-omit               = {591--599}
@@ -8274,7 +8165,7 @@ Results
 @Article{GAGDM11a,
   Title                    = {Entity Clustering Across Languages},
   Author                   = {Green, S. and Andrews, N. and Gormley, M.R. and Dredze, M. and Manning, C.D.},
-  Journal                  = {NAACL},
+  Journal                  = NAACL,
   Year                     = {2011},
   Pages                    = {591--599}
 }
@@ -8546,14 +8437,14 @@ and Kamp, H.},
 @InProceedings{LangLa11,
   Title                    = {Unsupervised Semantic Role Induction with Graph Partitioning},
   Author                   = {Lang, Joel and Lapata, Mirella},
-  Booktitle                = {Proc. of EMNLP},
+  Booktitle                = EMNLP,
   Year                     = {2011}
 }
 
 @InProceedings{LangLa11a,
   Title                    = {Unsupervised Semantic Role Induction with Graph Partitioning},
   Author                   = {Lang, Joel and Lapata, Mirella},
-  Booktitle                = {Proc. of EMNLP},
+  Booktitle                = EMNLP,
   Year                     = {2011}
 }
 
@@ -8701,7 +8592,7 @@ and Jurafsky, D.},
 @InProceedings{McDonaldPeHa11a,
   Title                    = {Multi-source transfer of delexicalized dependency parsers},
   Author                   = {McDonald, Ryan and Petrov, Slav and Hall, Keith},
-  Booktitle                = {Proc. of EMNLP},
+  Booktitle                = EMNLP,
   Year                     = {2011}
 }
 
@@ -8766,7 +8657,7 @@ and Jurafsky, D.},
   Mendeley-groups          = {Entailment/CLTE}
 }
 
-@InProceedings{Parker11,
+@Misc{Parker11,
   Title                    = {{Chinese Gigaword 5th Edition, LDC2011T13}},
   Author                   = {Robert Parker},
   Year                     = {2011},
@@ -8926,32 +8817,6 @@ and Ng, V.},
   Mendeley-groups          = {Structured Prediction}
 }
 
-@InProceedings{RRDA11,
-  Title                    = {Local and Global Algorithms for Disambiguation to Wikipedia},
-  Author                   = {Ratinov, Lev and Roth, Dan and Downey, Doug and Anderson, Mike},
-  Booktitle                = {Proceedings of the 49th Annual Meeting of the Association for Computational Linguistics: Human Language Technologies},
-  Year                     = {2011},
-
-  Address-omit             = {Portland, Oregon, USA},
-  Month-omit               = {June},
-  Pages-omit               = {1375--1384},
-  Publisher-omit           = {Association for Computational Linguistics},
-  Url-omit                 = {http://www.aclweb.org/anthology/P11-1138}
-}
-
-@InProceedings{RRDA11a,
-  Title                    = {Local and Global Algorithms for Disambiguation to Wikipedia},
-  Author                   = {Ratinov, Lev and Roth, Dan and Downey, Doug and Anderson, Mike},
-  Booktitle                = {Proceedings of the 49th Annual Meeting of the Association for Computational Linguistics: Human Language Technologies},
-  Year                     = {2011},
-
-  Address                  = {Portland, Oregon, USA},
-  Month                    = {June},
-  Pages                    = {1375--1384},
-  Publisher                = {Association for Computational Linguistics},
-
-  Url                      = {http://www.aclweb.org/anthology/P11-1138}
-}
 
 @InProceedings{SocherMaMa11,
   Title                    = {Spectral Chinese Restaurant Processes: Nonparametric Clustering Based on Similarities},
@@ -9187,14 +9052,14 @@ Mingrui Wu},
 @InProceedings{BaroniZa10,
   Title                    = {Nouns are vectors, adjectives are matrices: representing adjective-noun constructions in semantic space},
   Author                   = {Baroni, Marco and Zamparelli, Roberto},
-  Booktitle                = {Proc. of EMNLP},
+  Booktitle                = EMNLP,
   Year                     = {2010}
 }
 
 @InProceedings{BaroniZa10a,
   Title                    = {Nouns are vectors, adjectives are matrices: representing adjective-noun constructions in semantic space},
   Author                   = {Baroni, Marco and Zamparelli, Roberto},
-  Booktitle                = {Proc. of EMNLP},
+  Booktitle                = EMNLP,
   Year                     = {2010}
 }
 
@@ -9378,14 +9243,14 @@ Conference on Web Search and Data Mining},
 @InProceedings{DSCS10,
   Title                    = {Probabilistic frame-semantic parsing},
   Author                   = {Das, Dipanjan and Schneider, Nathan and Chen, Desai and Smith, Noah A.},
-  Booktitle                = {Proc. of NAACL},
+  Booktitle                = NAACL,
   Year                     = {2010}
 }
 
 @InProceedings{DSCS10a,
   Title                    = {Probabilistic frame-semantic parsing},
   Author                   = {Das, Dipanjan and Schneider, Nathan and Chen, Desai and Smith, Noah A.},
-  Booktitle                = {Proc. of NAACL},
+  Booktitle                = NAACL,
   Year                     = {2010}
 }
 
@@ -9882,14 +9747,14 @@ Amir Globerson},
 @InProceedings{PeirsmanPa10,
   Title                    = {Cross-lingual induction of selectional preferences with bilingual vector spaces},
   Author                   = {Peirsman, Yves and Pad\'{o}, Sebastian},
-  Booktitle                = {NAACL},
+  Booktitle                = NAACL,
   Year                     = {2010}
 }
 
 @InProceedings{PeirsmanPa10a,
   Title                    = {Cross-lingual induction of selectional preferences with bilingual vector spaces},
   Author                   = {Peirsman, Yves and Pad\'{o}, Sebastian},
-  Booktitle                = {NAACL},
+  Booktitle                = NAACL,
   Year                     = {2010}
 }
 
@@ -9979,28 +9844,10 @@ Amir Globerson},
 }
 
 @InProceedings{ReisingerMo10,
-  Title                    = {Multi-Prototype Vector-Space Models of Word Meaning},
-  Author                   = {Joseph Reisinger and Raymond J. Mooney},
-  Booktitle                = {Proc. of NAACL},
-  Year                     = {2010}
-}
-
-@InProceedings{ReisingerMo10a,
-  Title                    = {Multi-Prototype Vector-Space Models of Word Meaning},
-  Author                   = {Joseph Reisinger and Raymond J. Mooney},
-  Booktitle                = {Proc. of NAACL},
-  Year                     = {2010}
-}
-
-@InProceedings{ReisingerMo10b,
   Title                    = {{Multi-Prototype Vector-Space Models of Word Meaning}},
-  Author                   = {Reisinger, Joseph and Mooney, Raymond J},
-  Booktitle                = {Proceedings of NAACL 2010},
-  Year                     = {2010},
-
-  Address                  = {Los Angeles, CA},
-  Number                   = {June},
-  Pages                    = {109--117}
+  Author                   = {Joseph Reisinger and Raymond J. Mooney},
+  Booktitle                = NAACL,
+  Year                     = {2010}
 }
 
 @InProceedings{RiazGi10,
@@ -10138,14 +9985,14 @@ and Manning, C. D.},
 @InProceedings{SnyderBa10,
   Title                    = {Climbing the Tower of Babel: Unsupervised Multilingual Learning},
   Author                   = {Benjamin Snyder and Regina Barzilay},
-  Booktitle                = {Proc. of ICML},
+  Booktitle                = ICML,
   Year                     = {2010}
 }
 
 @InProceedings{SnyderBa10a,
   Title                    = {Climbing the Tower of Babel: Unsupervised Multilingual Learning},
   Author                   = {Benjamin Snyder and Regina Barzilay},
-  Booktitle                = {Proc. of ICML},
+  Booktitle                = ICML,
   Year                     = {2010}
 }
 
@@ -10172,28 +10019,28 @@ Science}
 @InProceedings{SubramanyaPePe10,
   Title                    = {Efficient Graph-based Semi-supervised Learning of Structured Tagging Models},
   Author                   = {Subramanya, Amarnag and Petrov, Slav and Pereira, Fernando},
-  Booktitle                = {Proc. of EMNLP},
+  Booktitle                = EMNLP,
   Year                     = {2010}
 }
 
 @InProceedings{SubramanyaPePe10a,
   Title                    = {Efficient Graph-based Semi-supervised Learning of Structured Tagging Models},
   Author                   = {Subramanya, Amarnag and Petrov, Slav and Pereira, Fernando},
-  Booktitle                = {Proc. of EMNLP},
+  Booktitle                = EMNLP,
   Year                     = {2010}
 }
 
 @InProceedings{TalukdarPe10,
   Title                    = {Experiments in Graph-based Semi-supervised Learning Methods for Class-instance Acquisition},
   Author                   = {Talukdar, Partha Pratim and Pereira, Fernando},
-  Booktitle                = {Proc. of ACL},
+  Booktitle                = ACL,
   Year                     = {2010}
 }
 
 @InProceedings{TalukdarPe10a,
   Title                    = {Experiments in Graph-based Semi-supervised Learning Methods for Class-instance Acquisition},
   Author                   = {Talukdar, Partha Pratim and Pereira, Fernando},
-  Booktitle                = {Proc. of ACL},
+  Booktitle                = ACL,
   Year                     = {2010}
 }
 
@@ -10232,14 +10079,14 @@ Science}
 @InProceedings{TurianRaBe10a,
   Title                    = {Word representations: a simple and general method for semi-supervised learning},
   Author                   = {Turian, Joseph and Ratinov, Lev and Bengio, Yoshua},
-  Booktitle                = {Proc. of ACL},
+  Booktitle                = ACL,
   Year                     = {2010}
 }
 
 @InProceedings{TurianRaBe10b,
   Title                    = {Word representations: a simple and general method for semi-supervised learning},
   Author                   = {Turian, Joseph and Ratinov, Lev and Bengio, Yoshua},
-  Booktitle                = {Proc. of ACL},
+  Booktitle                = ACL,
   Year                     = {2010}
 }
 
@@ -10415,14 +10262,14 @@ Chih-Jen Lin},
 @InProceedings{AAHKPS09,
   Title                    = {A study on similarity and relatedness using distributional and WordNet-based approaches},
   Author                   = {Agirre, Eneko and Alfonseca, Enrique and Hall, Keith and Kravalova, Jana and Pa\c{s}ca, Marius and Soroa, Aitor},
-  Booktitle                = {Proc. of NAACL},
+  Booktitle                = NAACL,
   Year                     = {2009}
 }
 
 @InProceedings{AAHKPS09a,
   Title                    = {A study on similarity and relatedness using distributional and WordNet-based approaches},
   Author                   = {Agirre, Eneko and Alfonseca, Enrique and Hall, Keith and Kravalova, Jana and Pa\c{s}ca, Marius and Soroa, Aitor},
-  Booktitle                = {Proc. of NAACL},
+  Booktitle                = NAACL,
   Year                     = {2009}
 }
 
@@ -11151,14 +10998,14 @@ and Klein, Dan},
 @InProceedings{HassanMi09,
   Title                    = {Cross-lingual Semantic Relatedness Using Encyclopedic Knowledge},
   Author                   = {Hassan, Samer and Mihalcea, Rada},
-  Booktitle                = {Proc. of EMNLP},
+  Booktitle                = EMNLP,
   Year                     = {2009}
 }
 
 @InProceedings{HassanMi09a,
   Title                    = {Cross-lingual Semantic Relatedness Using Encyclopedic Knowledge},
   Author                   = {Hassan, Samer and Mihalcea, Rada},
-  Booktitle                = {Proc. of EMNLP},
+  Booktitle                = EMNLP,
   Year                     = {2009}
 }
 
@@ -11266,8 +11113,7 @@ Conference (TAC)},
   Editor                   = {M. Paul Lewis},
   Year                     = {2009},
   Edition                  = {16th},
-
-  Publisher-omit           = {SIL International}
+  Publisher           = {SIL International}
 }
 
 @Book{Lewis09a,
@@ -11447,14 +11293,7 @@ Conference (TAC)},
 @InProceedings{MeloWe09,
   Title                    = {Towards a Universal Wordnet by Learning from Combined Evidence},
   Author                   = {Gerard de Melo and Gerhard Weikum},
-  Booktitle                = {Proc. of CIKM},
-  Year                     = {2009}
-}
-
-@InProceedings{MeloWe09a,
-  Title                    = {Towards a Universal Wordnet by Learning from Combined Evidence},
-  Author                   = {Gerard de Melo and Gerhard Weikum},
-  Booktitle                = {Proc. of CIKM},
+  Booktitle                = CIKM,
   Year                     = {2009}
 }
 
@@ -11495,28 +11334,28 @@ Answer Grading},
 @InProceedings{MWNSM09,
   Title                    = {Polylingual topic models},
   Author                   = {Mimno, David and Wallach, Hanna M. and Naradowsky, Jason and Smith, David A. and McCallum, Andrew},
-  Booktitle                = {Proc. of EMNLP},
+  Booktitle                = EMNLP,
   Year                     = {2009}
 }
 
 @InProceedings{MWNSM09a,
   Title                    = {Polylingual topic models},
   Author                   = {Mimno, David and Wallach, Hanna M. and Naradowsky, Jason and Smith, David A. and McCallum, Andrew},
-  Booktitle                = {Proc. of EMNLP},
+  Booktitle                = EMNLP,
   Year                     = {2009}
 }
 
 @InProceedings{MWNSM09b,
   Title                    = {Polylingual topic models},
   Author                   = {Mimno, David and Wallach, Hanna M. and Naradowsky, Jason and Smith, David A. and McCallum, Andrew},
-  Booktitle                = {Proc. of EMNLP},
+  Booktitle                = EMNLP,
   Year                     = {2009}
 }
 
 @InProceedings{MWNSM09c,
   Title                    = {Polylingual topic models},
   Author                   = {Mimno, David and Wallach, Hanna M. and Naradowsky, Jason and Smith, David A. and McCallum, Andrew},
-  Booktitle                = {Proc. of EMNLP},
+  Booktitle                = EMNLP,
   Year                     = {2009}
 }
 
@@ -11669,35 +11508,6 @@ Tom M. Mitchell},
   Publisher-omit           = {{ACM}}
 }
 
-@InBook{RatinovRo09,
-  Title                    = {Proceedings of the Thirteenth Conference on Computational Natural Language Learning (CoNLL-2009)},
-  Author                   = {Ratinov, Lev
-and Roth, Dan},
-  Chapter                  = {Design Challenges and Misconceptions in Named Entity Recognition},
-  Year                     = {2009},
-
-  Location-omit            = {Boulder, Colorado},
-  Pages-omit               = {147--155},
-  Publisher-omit           = {Association for Computational Linguistics},
-  Url-omit                 = {http://aclweb.org/anthology/W09-1119}
-}
-
-@InProceedings{RatinovRo09a,
-  Title                    = {Design Challenges and Misconceptions in Named Entity Recognition},
-  Author                   = {Ratinov, Lev and Roth, Dan},
-  Booktitle                = {CoNLL},
-  Year                     = {2009},
-  Pages                    = {147--155}
-}
-
-@InProceedings{RatinovRo09b,
-  Title                    = {Design Challenges and Misconceptions in Named Entity Recognition},
-  Author                   = {Ratinov, Lev and Roth, Dan},
-  Booktitle                = {CoNLL},
-  Year                     = {2009},
-  Pages                    = {147--155}
-}
-
 @Article{Riedel09,
   Title                    = {{Cutting Plane MAP Inference for Markov Logic}},
   Author                   = {Riedel, S.},
@@ -11802,28 +11612,28 @@ and Roth, Dan},
 @InProceedings{SNEB09,
   Title                    = {Adding more languages improves unsupervised multilingual part-of-speech tagging: a Bayesian non-parametric approach},
   Author                   = {Snyder, Benjamin and Naseem, Tahira and Eisenstein, Jacob and Barzilay, Regina},
-  Booktitle                = {Proc. of NAACL},
+  Booktitle                = NAACL,
   Year                     = {2009}
 }
 
 @InProceedings{SNEB09a,
   Title                    = {Adding more languages improves unsupervised multilingual part-of-speech tagging: a Bayesian non-parametric approach},
   Author                   = {Snyder, Benjamin and Naseem, Tahira and Eisenstein, Jacob and Barzilay, Regina},
-  Booktitle                = {Proc. of NAACL},
+  Booktitle                = NAACL,
   Year                     = {2009}
 }
 
 @InProceedings{SnyderNaBa09,
   Title                    = {Unsupervised multilingual grammar induction},
   Author                   = {Snyder, Benjamin and Naseem, Tahira and Barzilay, Regina},
-  Booktitle                = {Proc. of ACL},
+  Booktitle                = ACL,
   Year                     = {2009}
 }
 
 @InProceedings{SnyderNaBa09a,
   Title                    = {Unsupervised multilingual grammar induction},
   Author                   = {Snyder, Benjamin and Naseem, Tahira and Barzilay, Regina},
-  Booktitle                = {Proc. of ACL},
+  Booktitle                = ACL,
   Year                     = {2009}
 }
 
@@ -12322,7 +12132,7 @@ B. and Liu, T. and Li, S.},
 @InProceedings{CollobertWe08,
   Title                    = {A unified architecture for natural language processing: deep neural networks with multitask learning},
   Author                   = {Collobert, Ronan and Weston, Jason},
-  Booktitle                = {Proc. of ICML},
+  Booktitle                = ICML,
   Year                     = {2008}
 }
 
@@ -12347,7 +12157,7 @@ B. and Liu, T. and Li, S.},
 @InProceedings{CollobertWe08b,
   Title                    = {A unified architecture for natural language processing: deep neural networks with multitask learning},
   Author                   = {Collobert, Ronan and Weston, Jason},
-  Booktitle                = {Proc. of ICML},
+  Booktitle                = ICML,
   Year                     = {2008}
 }
 
@@ -12357,14 +12167,6 @@ B. and Liu, T. and Li, S.},
   Booktitle                = { Proceedings of the LREC'08 Workshop Towards a
 Shared Task for Multiword Expressions},
   Year                     = {2008}
-}
-
-@InProceedings{CRRS08,
-  Title                    = {Importance of Semantic Representation: Dataless Classification},
-  Author                   = {Chang, Ming-Wei and Ratinov, Lev and Roth, Dan and Srikumar, Vivek},
-  Booktitle                = {AAAI},
-  Year                     = {2008},
-  Pages                    = {830--835}
 }
 
 @Article{CulpMi08,
@@ -12704,14 +12506,14 @@ H.},
 @InProceedings{HLBK08,
   Title                    = {Learning Bilingual Lexicons from Monolingual Corpora},
   Author                   = {Aria Haghighi and Percy Liang and Taylor Berg-Kirkpatrick and Dan Klein},
-  Booktitle                = {Proc. of ACL},
+  Booktitle                = ACL,
   Year                     = {2008}
 }
 
 @InProceedings{HLBK08a,
   Title                    = {Learning Bilingual Lexicons from Monolingual Corpora},
   Author                   = {Aria Haghighi and Percy Liang and Taylor Berg-Kirkpatrick and Dan Klein},
-  Booktitle                = {Proc. of ACL},
+  Booktitle                = ACL,
   Year                     = {2008}
 }
 
@@ -12798,14 +12600,14 @@ S. Roweis},
 @InProceedings{KooCaCo08a,
   Title                    = {Simple Semi-supervised Dependency Parsing},
   Author                   = {Koo, Terry and Carreras, Xavier and Collins, Michael},
-  Booktitle                = {Proc. of ACL},
+  Booktitle                = ACL,
   Year                     = {2008}
 }
 
 @InProceedings{KooCaCo08b,
   Title                    = {Simple Semi-supervised Dependency Parsing},
   Author                   = {Koo, Terry and Carreras, Xavier and Collins, Michael},
-  Booktitle                = {Proc. of ACL},
+  Booktitle                = ACL,
   Year                     = {2008}
 }
 
@@ -13107,7 +12909,7 @@ language mathematical problems},
 Formulas},
   Author                   = {B. Milch and L. S. Zettlemoyer and K. Kersting and
 M. Haimes and L. Kaelbling},
-  Booktitle                = {AAAI},
+  Booktitle                = AAAI,
   Year                     = {2008},
 
   Pages-omit               = {1062-1068}
@@ -13140,9 +12942,9 @@ Logs},
 }
 
 @InProceedings{PDLMRJW08,
-  Title                    = {The Penn Discourse Treebank 2.0},
+  Title                    = {{The Penn Discourse Treebank 2.0}},
   Author                   = {Rashmi Prasad and Nikhil Dinesh and Alan Lee and Eleni Miltsakaki and Livio Robaldo and Aravind Joshi and Bonnie Webber},
-  Booktitle                = {Proceedings of the 6th International Conference on Language Resources and Evaluation (LREC 2008)},
+  Booktitle                = LREC,
   Year                     = {2008}
 }
 
@@ -13363,7 +13165,7 @@ transitivity-alternating verbs},
 @InProceedings{SinglaDo08,
   Title                    = {Lifted First-Order Belief Propagation},
   Author                   = {P. Singla and P. Domingos},
-  Booktitle                = {AAAI},
+  Booktitle                = AAAI,
   Year                     = {2008},
 
   Pages-omit               = {1094-1099}
@@ -13372,14 +13174,14 @@ transitivity-alternating verbs},
 @InProceedings{SNEB08,
   Title                    = {Unsupervised multilingual learning for POS tagging},
   Author                   = {Snyder, Benjamin and Naseem, Tahira and Eisenstein, Jacob and Barzilay, Regina},
-  Booktitle                = {Proc. of EMNLP},
+  Booktitle                = EMNLP,
   Year                     = {2008}
 }
 
 @InProceedings{SNEB08a,
   Title                    = {Unsupervised multilingual learning for POS tagging},
   Author                   = {Snyder, Benjamin and Naseem, Tahira and Eisenstein, Jacob and Barzilay, Regina},
-  Booktitle                = {Proc. of EMNLP},
+  Booktitle                = EMNLP,
   Year                     = {2008}
 }
 
@@ -13847,7 +13649,7 @@ Shnarch, Eyal},
 
   Address-omit             = {Vancouver},
   Month-omit               = {July},
-  Publisher-omit           = {AAAI}
+  Publisher-omit           = AAAI
 }
 
 @InProceedings{BDGSF07,
@@ -14948,7 +14750,7 @@ Resolution using Integer Programming},
   Title                    = {Joint Determination of Anaphoricity and Coreference
  Resolution using Integer Programming},
   Author                   = {Denis, Pascal and Baldridge, Jason},
-  Booktitle                = {NAACL},
+  Booktitle                = NAACL,
   Year                     = {2007},
 
   Owner                    = {penghaoruo},
@@ -15663,7 +15465,7 @@ syntactically similar verbs},
   Volume-omit              = {20}
 }
 
-@InProceedings{Graff07,
+@Misc{Graff07,
   Title                    = {Arabic Gigaword 3rd Edition, {LDC2003T40}},
   Author                   = {David Graff},
   Year                     = {2007},
@@ -17568,7 +17370,7 @@ modelling},
 @InProceedings{MnihHi07a,
   Title                    = {Three New Graphical Models for Statistical Language Modelling},
   Author                   = {Mnih, Andriy and Hinton, Geoffrey},
-  Booktitle                = {Proc. of ICML},
+  Booktitle                = ICML,
   Year                     = {2007}
 }
 
@@ -17583,7 +17385,7 @@ modelling},
 @InProceedings{MnihHi07c,
   Title                    = {Three New Graphical Models for Statistical Language Modelling},
   Author                   = {Mnih, Andriy and Hinton, Geoffrey},
-  Booktitle                = {Proc. of ICML},
+  Booktitle                = ICML,
   Year                     = {2007}
 }
 
@@ -17677,14 +17479,13 @@ Multi-Party Dialog},
   Url-omit                 = {http://www.aclweb.org/anthology/P/P07/P07-1103}
 }
 
-@InProceedings{MunteanuMa07,
-  Title                    = {{ISI Arabic-English Automatically Extracted Parallel
- Text LDC2007T08}},
-  Author                   = {Dragos Stefan Munteanu and Daniel Marcu},
-  Year                     = {2007},
-
-  Address                  = {University of Pennsylvania},
-  Publisher                = {LDC}
+@Misc{MunteanuMa07,
+  Title =	 {{ISI Arabic-English Automatically Extracted Parallel
+                  Text LDC2007T08}},
+  Author =	 {Dragos Stefan Munteanu and Daniel Marcu},
+  Year =	 {2007},
+  Address =	 {University of Pennsylvania},
+  Publisher =	 {LDC}
 }
 
 @InProceedings{MuresanRa07,
@@ -20399,7 +20200,7 @@ Challenge.},
 Wikipedia: Enhancing Text Categorization with
 Encyclopedic Knowledge},
   Author                   = {Evgeniy Gabrilovich and Shaul Markovitch},
-  Booktitle                = {AAAI},
+  Booktitle                = AAAI,
   Year                     = {2006},
 
   Pages-omit               = {1301--1306}
@@ -20410,7 +20211,7 @@ Encyclopedic Knowledge},
  Categorization with Encyclopedic Knowledge},
   Author                   = {Evgeniy Gabrilovich and
  Shaul Markovitch},
-  Booktitle                = {AAAI},
+  Booktitle                = AAAI,
   Year                     = {2006},
   Pages                    = {1301--1306}
 }
@@ -20540,7 +20341,7 @@ the Association for Computational Linguistics},
 @Article{HarabagiuHi06d,
   Title                    = {{Methods for Using Textual Entailment in Open-Domain Question Answering}},
   Author                   = {Harabagiu, S and Hickl, A},
-  Journal                  = {Proceedings of ACL},
+  Journal                  = ACL,
   Year                     = {2006},
   Number                   = {July},
   Pages                    = {905--912},
@@ -20733,7 +20534,7 @@ Background Knowledge and Its Applications to Knowledge Representation and Questi
 
   Address-omit             = {Stanford, CA},
   Month-omit               = {March},
-  Publisher-omit           = {AAAI}
+  Publisher-omit           = AAAI
 }
 
 @InProceedings{MGMCM06,
@@ -20749,7 +20550,7 @@ M.-C. and Cer, D. and Manning, C. D.},
   Title                    = {Corpus-based and Knowledge-based Measures of Text
 Semantic Similarity},
   Author                   = {R. Mihalcea and C. Corley and C. Strapparava},
-  Booktitle                = {AAAI},
+  Booktitle                = AAAI,
   Year                     = {2006},
 
   Address-omit             = {Boston, USA},
@@ -20773,7 +20574,7 @@ Acquisition},
 @Article{MunteanuMa06,
   Title                    = {{Extracting parallel sub-sentential fragments from non-parallel corpora}},
   Author                   = {Munteanu, Dragos Stefan and Marcu, Daniel},
-  Journal                  = {Proceedings of ACL},
+  Journal                  = ACL,
   Year                     = {2006},
   Number                   = {July},
   Pages                    = {81--88},
@@ -21155,7 +20956,7 @@ C. Zhai},
 
   Address-omit             = {Boston, MA},
   Pages-omit               = {1546--1551},
-  Publisher-omit           = {AAAI}
+  Publisher-omit           = AAAI
 }
 
 @InProceedings{VSSM06,
@@ -21293,14 +21094,14 @@ Entailment?},
 @InProceedings{BannardCa05,
   Title                    = {Paraphrasing with Bilingual Parallel Corpora},
   Author                   = {Colin Bannard and Chris Callison-Burch},
-  Booktitle                = {Proc. of ACL},
+  Booktitle                = ACL,
   Year                     = {2005}
 }
 
 @InProceedings{BannardCa05a,
   Title                    = {Paraphrasing with Bilingual Parallel Corpora},
   Author                   = {Colin Bannard and Chris Callison-Burch},
-  Booktitle                = {Proc. of ACL},
+  Booktitle                = ACL,
   Year                     = {2005}
 }
 
@@ -21638,7 +21439,7 @@ World Knowledge},
   Title                    = {The distributional inclusion hypotheses and lexical
  entailment},
   Author                   = {Geffet, Maayan and Dagan, Ido},
-  Booktitle                = {Proc. of ACL},
+  Booktitle                = ACL,
   Year                     = {2005},
   Organization             = {Association for Computational Linguistics},
   Pages                    = {107--114}
@@ -21647,7 +21448,7 @@ World Knowledge},
 @InProceedings{GeffetDa05a,
   Title                    = {{The Distributional Inclusion Hypotheses and Lexical Entailment}},
   Author                   = {Geffet, Maayan and Dagan, Ido},
-  Booktitle                = {Proc. of ACL},
+  Booktitle                = ACL,
   Year                     = {2005}
 }
 
@@ -22406,19 +22207,10 @@ alignment},
  Bakeoff 2005},
   Author                   = {Tseng, Huihsin and Chang, Pichuan and Andrew, Galen
  and Jurafsky, Daniel and Manning, Christopher},
-  Booktitle                = {Proc. of SIGHAN},
+  Booktitle                = SIGHAN,
   Year                     = {2005},
 
   Url-omit                 = {http://aclweb.org/anthology/I05-3027}
-}
-
-@InProceedings{TCAJM05a,
-  Title                    = {A Conditional Random Field Word Segmenter for Sighan
- Bakeoff 2005},
-  Author                   = {Tseng, Huihsin and Chang, Pichuan and Andrew, Galen
- and Jurafsky, Daniel and Manning, Christopher},
-  Booktitle                = {Proc. of SIGHAN},
-  Year                     = {2005}
 }
 
 @InProceedings{TCKG05,
@@ -23100,7 +22892,7 @@ J. H. Martin and D. Jurafsky},
   Title                    = {Robust Reading: Identification and Tracing of
  Ambiguous Names},
   Author                   = {Li, Xin and Morie, Paul and Roth, Dan},
-  Booktitle                = {NAACL},
+  Booktitle                = NAACL,
   Year                     = {2004},
 
   Owner                    = {penghaoruo},
@@ -23111,7 +22903,7 @@ J. H. Martin and D. Jurafsky},
   Title                    = {A Joint Source-Channel Model for Machine
 Transliteration},
   Author                   = {Li, H. and Zhang, M. and Su, J.},
-  Booktitle                = {Proceedings of ACL},
+  Booktitle                = ACL,
   Year                     = {2004},
 
   Address-omit             = {Barcelona, Spain},
@@ -23478,9 +23270,9 @@ language learning},
 }
 
 @InProceedings{SnowJuNg04,
-  Title                    = {Learning syntactic patterns for automatic hypernym
-discovery},
-  Author                   = {R. Snow and D. Jurafsky and A. Y. Ng},
+  Title                    = {{Learning Syntactic Patterns for Automatic Hypernym
+Discovery}},
+  Author                   = {Rion Snow and Dan Jurafsky and Andrew Y. Ng},
   Booktitle                = NIPS,
   Year                     = {2004},
 
@@ -25047,14 +24839,14 @@ V. Tablan},
 @InProceedings{Collins02,
   Title                    = {Discriminative training methods for hidden markov models: Theory and experiments with perceptron algorithms},
   Author                   = {Collins, Michael},
-  Booktitle                = {Proc. of ACL},
+  Booktitle                = ACL,
   Year                     = {2002}
 }
 
 @InProceedings{Collins02a,
   Title                    = {Discriminative training methods for hidden markov models: Theory and experiments with perceptron algorithms},
   Author                   = {Collins, Michael},
-  Booktitle                = {Proc. of ACL},
+  Booktitle                = ACL,
   Year                     = {2002}
 }
 
@@ -26894,12 +26686,13 @@ Statistical Language Analysis},
 }
 
 @InCollection{LevyBu01,
-  Title                    = {Learning lexical properties from word usage
- patterns: Which context words should be used?},
-  Author                   = {Levy, Joseph P and Bullinaria, John A},
-  Booktitle                = {Connectionist models of learning, development and
- evolution},
-  Year                     = {2001}
+  Title =	 {Learning lexical properties from word usage
+                  patterns: Which context words should be used?},
+  Author =	 {Levy, Joseph P and Bullinaria, John A},
+  Booktitle =	 {Connectionist models of learning, development and
+                  evolution},
+  Publisher =	 {Springer},
+  Year =	 {2001}
 }
 
 @InProceedings{LinPa01,
@@ -26995,7 +26788,7 @@ and Anne Verroust},
   Title                    = {Multipath Translation Lexicon Induction via Bridge Languages},
   Author                   = {Gideon S. Mann and
  David Yarowsky},
-  Booktitle                = {{NAACL}},
+  Booktitle                = NAACL,
   Year                     = {2001}
 }
 
@@ -27322,14 +27115,14 @@ interpretations of novel nouns and adjectives},
 @InProceedings{YarowskyNg01,
   Title                    = {Inducing multilingual POS taggers and NP bracketers via robust projection across aligned corpora},
   Author                   = {Yarowsky, David and Ngai, Grace},
-  Booktitle                = {Proc. of NAACL},
+  Booktitle                = NAACL,
   Year                     = {2001}
 }
 
 @InProceedings{YarowskyNg01a,
   Title                    = {Inducing multilingual POS taggers and NP bracketers via robust projection across aligned corpora},
   Author                   = {Yarowsky, David and Ngai, Grace},
-  Booktitle                = {Proc. of NAACL},
+  Booktitle                = NAACL,
   Year                     = {2001}
 }
 
@@ -28519,7 +28312,7 @@ Chunking},
   Year                     = {2000},
 
   Address-omit             = {Austin, TX},
-  Publisher-omit           = {AAAI}
+  Publisher-omit           = AAAI
 }
 
 @InProceedings{KramerFr00,
@@ -28951,7 +28744,7 @@ $k$-clustering},
   Title                    = {Semantics and Inference for Recursive Probability
 Models},
   Author                   = {Pfeffer, A. and Koller, D.},
-  Booktitle                = {{AAAI}/{IAAI}},
+  Booktitle                = {AAAI/{IAAI}},
   Year                     = {2000},
 
   Pages-omit               = {538-544},
@@ -29264,14 +29057,14 @@ robot arm motion planning},
 @InProceedings{Sumita00,
   Title                    = {Lexical transfer using a vector-space model},
   Author                   = {Sumita, Eiichiro},
-  Booktitle                = {Proc. of ACL},
+  Booktitle                = ACL,
   Year                     = {2000}
 }
 
 @InProceedings{Sumita00a,
   Title                    = {Lexical transfer using a vector-space model},
   Author                   = {Sumita, Eiichiro},
-  Booktitle                = {Proc. of ACL},
+  Booktitle                = ACL,
   Year                     = {2000}
 }
 
@@ -32326,14 +32119,14 @@ Learning Theory - ALT '99},
 @InProceedings{Och99,
   Title                    = {An efficient method for determining bilingual word classes},
   Author                   = {Och, Franz Josef},
-  Booktitle                = {Proc. of EACL},
+  Booktitle                = EACL,
   Year                     = {1999}
 }
 
 @InProceedings{Och99a,
   Title                    = {An efficient method for determining bilingual word classes},
   Author                   = {Och, Franz Josef},
-  Booktitle                = {Proc. of EACL},
+  Booktitle                = EACL,
   Year                     = {1999}
 }
 
@@ -33822,7 +33615,7 @@ Artificial Intelligence, {KI-98}},
 }
 
 @InProceedings{BakerFiLo98,
-  Title                    = {The Berkeley FrameNet Project},
+  Title                    = {{The Berkeley FrameNet Project}},
   Author                   = {Collin F. Baker and
  Charles J. Fillmore and
  John B. Lowe},
@@ -33830,71 +33623,6 @@ Artificial Intelligence, {KI-98}},
  and 17th International Conference on Computational Linguistics, {COLING-ACL} 1998},
   Year                     = {1998},
   Pages                    = {86--90}
-}
-
-@InProceedings{BakerFiLo98a,
-  Title                    = {The berkeley framenet project},
-  Author                   = {Baker, C. F. and Fillmore, C. J. and Lowe, J. B.},
-  Booktitle                = {COLING/ACL},
-  Year                     = {1998},
-  Pages                    = {86--90}
-}
-
-@InProceedings{BakerFiLo98b,
-  Title                    = {The Berkeley FrameNet Project},
-  Author                   = {Baker, Collin F. and Fillmore, Charles J. and Lowe, John B.},
-  Year                     = {1998},
-  Series                   = {ACL '98}
-}
-
-@InProceedings{BakerFiLo98c,
-  Title                    = {The {Berkeley} {FrameNet} Project},
-  Author                   = {Baker, Collin F. and Fillmore, Charles J. and Lowe,
- John B.},
-  Booktitle                = {ACL-COLING},
-  Year                     = {1998},
-
-  Owner                    = {penghaoruo},
-  Timestamp                = {2016.10.08}
-}
-
-@InProceedings{BakerFiLo98d,
-  Title                    = {The {Berkeley} {FrameNet} Project},
-  Author                   = {Baker, Collin F. and Fillmore, Charles J. and Lowe,
- John B.},
-  Booktitle                = {Proceedings of the 36th Annual Meeting of the
- ACL and 17th
- International Conference on Computational
- Linguistics - Volume 1},
-  Year                     = {1998},
-  Series                   = {ACL '98},
-
-  Acmid                    = {980860},
-  Address-omit             = {Stroudsburg, PA, USA},
-  Doi-omit                 = {10.3115/980845.980860},
-  Location-omit            = {Montreal, Quebec, Canada},
-  Numpages                 = {5},
-  Owner                    = {penghaoruo},
-  Pages-omit               = {86--90},
-  Publisher-omit           = {Association for Computational Linguistics},
-  Timestamp                = {2016.10.08},
-  Url-omit                 = {http://dx.doi.org/10.3115/980845.980860}
-}
-
-@InProceedings{BakerFiLo98e,
-  Title                    = {The {B}erkeley {F}rame{N}et project},
-  Author                   = {Collin F. Baker and Charles J. Fillmore and John B. Lowe},
-  Booktitle                = {Proceedings of the 17th International Conference on Computational Linguistics},
-  Year                     = {1998},
-
-  Pages-omit               = {86--90}
-}
-
-@InProceedings{BakerFiLo98f,
-  Title                    = {The Berkeley FrameNet Project},
-  Author                   = {Baker, Collin F. and Fillmore, Charles J. and Lowe, John B.},
-  Year                     = {1998},
-  Series                   = {ACL '98}
 }
 
 @TechReport{Bartak98,
@@ -34979,7 +34707,7 @@ J. Lee},
   Title                    = {Structured Representation of Complex Stochastic
 Systems},
   Author                   = {N. Friedman and Koller, D. and Pfeffer, A.},
-  Booktitle                = {{AAAI}/{IAAI}},
+  Booktitle                = {AAAI/{IAAI}},
   Year                     = {1998},
 
   Pages-omit               = {157-164},
@@ -35621,8 +35349,8 @@ imperfect value functions},
 }
 
 @Article{KnightGr98,
-  Title                    = {Machine Transliteration},
-  Author                   = {Knight, K. and Graehl, J.},
+  Title                    = {{Machine Transliteration}},
+  Author                   = {Knight, Kevin and Graehl, Jonathan},
   Journal                  = {Computational Linguistics},
   Year                     = {1998},
 
@@ -35830,47 +35558,31 @@ Computational Linguistics},
 
 @InProceedings{Lin98,
   Title                    = {Dependency-based Evaluation of MINIPAR},
-  Author                   = {D. Lin},
+  Author                   = {Dekang Lin},
   Booktitle                = {In Workshop on the Evaluation of Parsing Systems
 Granada Spain},
   Year                     = {1998}
 }
 
 @InProceedings{Lin98a,
-  Title                    = {Automatic Retrieval and Clustering of Similar Words},
-  Author                   = {D. Lin},
-  Booktitle                = ACL,
-  Year                     = {1998},
-
-  Pages-omit               = {768-774}
-}
-
-@InProceedings{Lin98b,
-  Title                    = {Automatic retrieval and clustering of similar words},
-  Author                   = {Lin, Dekang},
-  Booktitle                = {Proc. of ACL},
-  Year                     = {1998}
-}
-
-@InProceedings{Lin98c,
-  Title                    = {Automatic {R}etrieval and {C}lustering of similar
-words},
+  Title                    = {{Automatic Retrieval and Clustering of Similar
+Words}},
   Author                   = {Dekang Lin},
-  Booktitle                = {COLING-ACL},
+  Booktitle                = {Proc. of COLING-ACL},
   Year                     = {1998},
 
   Pages-omit               = {768--774}
 }
 
-@InProceedings{Lin98d,
-  Title                    = {An information-theoretic definition of similarity},
-  Author                   = {D. Lin},
+@InProceedings{Lin98b,
+  Title                    = {{An Information-theoretic Definition of Similarity}},
+  Author                   = {Dekang Lin},
   Booktitle                = ICML,
   Year                     = {1998}
 }
 
 @InProceedings{LiquiereSa98,
-  Title                    = {Srtuctural machine learning with {G}alois lattice
+  Title                    = {Structural machine learning with {G}alois lattice
 and graphs},
   Author                   = {Michel Liquiere and Jean Sallantin},
   Booktitle                = {Proc. 15th International Conf. on Machine Learning},
@@ -39383,7 +39095,7 @@ neural networks},
   Title                    = {P-{CLASSIC}: A Tractable Probablistic Description
 Logic},
   Author                   = {Koller, D. and Alon Y. Levy and Pfeffer, A.},
-  Booktitle                = {{AAAI}/{IAAI}},
+  Booktitle                = {AAAI/{IAAI}},
   Year                     = {1997},
 
   Pages-omit               = {390-397},
@@ -46995,17 +46707,9 @@ Learning},
 }
 
 @InProceedings{Lang95b,
-  Title                    = {Newsweeder: Learning to filter netnews},
+  Title                    = {{Newsweeder: Learning to Filter Netnews}},
   Author                   = {Ken Lang},
-  Booktitle                = {ICML},
-  Year                     = {1995},
-  Pages                    = {331--339}
-}
-
-@InProceedings{Lang95c,
-  Title                    = {Newsweeder: Learning to filter netnews},
-  Author                   = {Ken Lang},
-  Booktitle                = {ICML},
+  Booktitle                = ICML,
   Year                     = {1995},
   Pages                    = {331--339}
 }
@@ -59317,11 +59021,10 @@ Modelfor Neural Net and Other Learning Applications},
 }
 
 @InProceedings{Hearst92,
-  Title                    = {Automatic acquisition of hyponyms from large text
-corpora},
-  Author                   = {Hearst, M. A. },
-  Booktitle                = {Proceedings of the 14th conference on Computational
-linguistics},
+  Title                    = {{Automatic Acquisition of Hyponyms from Large Text
+Corpora}},
+  Author                   = {Hearst, Marti A.},
+  Booktitle                = CoNLL,
   Year                     = {1992},
 
   Address-omit             = {Morristown, NJ, USA},
@@ -70871,7 +70574,7 @@ Genetic Algorithms},
 }
 
 @Article{GSBG88,
-  Title                    = {A Review of Machine Learning at {AAAI}-87},
+  Title                    = {A Review of Machine Learning at AAAI-87},
   Author                   = {R. Greiner and B. Silver and S. Becker and
 M. Gr{\"u}ninger},
   Journal                  = {Machine Learning},
@@ -74034,7 +73737,7 @@ Descriptions},
   Author                   = {P. Laird},
   Booktitle                = {Proc. of AAAI-86},
   Year                     = {1986},
-  Organization             = {AAAI},
+  Organization             = AAAI,
 
   Annote                   = {Earlier version is Yale Comp Sci TR-376 from 1985},
   Pages-omit               = {472--476}
@@ -81964,19 +81667,6 @@ School of Aviation Medicine, Randolph Field, TX},
   Pages-omit               = {153--157},
   Publisher-omit           = {Springer},
   Volume-omit              = {12}
-}
-
-@Article{McNemar47a,
-  Title                    = {Note on the sampling error of the difference between
- correlated proportions or percentages},
-  Author                   = {McNemar, Quinn},
-  Journal                  = {Psychometrika},
-  Year                     = {1947},
-  Number                   = {2},
-  Pages                    = {153--157},
-  Volume                   = {12},
-
-  Publisher                = {Springer}
 }
 
 @Article{Cox46,


### PR DESCRIPTION
1. Need to replace {Proc. of XYZ} to XYZ, so that macros can take over.
2. Need to correct J. Smith to John Smith
3. Protect title {My Paper} to {{My Paper}} for correct casing
4. Remove duplicates of the same paper ShwartzSaSc17 and ShwartzSaSc17a which are the same paper. 
5. Remove anything that has Dan Roth or a CogComp member as an author, that should belong to ccg.bib anyways. 